### PR TITLE
Claude/restore mycobrain page kb odq

### DIFF
--- a/app/devices/alarm/page.tsx
+++ b/app/devices/alarm/page.tsx
@@ -1,50 +1,15 @@
-import Link from "next/link"
-import { Metadata } from "next"
+import { AlarmDetails } from "@/components/devices/alarm-details"
+import type { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "ALARM | Devices",
-  description: "ALARM device profile for incident signaling and response.",
+  title: "ALARM | Incident Signaling & Response | Mycosoft",
+  description: "ALARM device profile for incident signaling, escalation routing, and mission-critical response.",
 }
 
 export default function AlarmPage() {
   return (
-    <main className="min-h-dvh bg-background">
-      <section className="container mx-auto px-4 py-10 md:py-14">
-        <Link
-          href="/devices"
-          className="inline-flex min-h-[44px] items-center gap-2 text-sm font-medium text-primary"
-        >
-          Back to Devices
-        </Link>
-        <p className="mt-4 text-xs sm:text-sm text-muted-foreground uppercase tracking-wide">ALARM</p>
-        <h1 className="mt-2 text-3xl sm:text-4xl md:text-5xl font-semibold">ALARM</h1>
-        <p className="mt-4 text-base sm:text-lg text-muted-foreground">
-          ALARM provides rapid incident signaling and escalation for mission-critical events.
-        </p>
-      </section>
-
-      <section className="container mx-auto px-4 pb-12">
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Rapid notification</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Immediate alerting for high-priority environmental or device anomalies.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Escalation routing</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Connects alerts to MAS agent workflows and response teams.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Operational context</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Ties incidents to mission data, telemetry, and response notes.
-            </p>
-          </div>
-        </div>
-      </section>
-    </main>
+    <div className="min-h-screen flex flex-col">
+      <AlarmDetails />
+    </div>
   )
 }

--- a/app/devices/hyphae-1/page.tsx
+++ b/app/devices/hyphae-1/page.tsx
@@ -1,52 +1,15 @@
-import Link from "next/link"
-import { Metadata } from "next"
+import { Hyphae1Details } from "@/components/devices/hyphae1-details"
+import type { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "Hyphae 1 | Devices",
-  description: "Hyphae 1 device profile for fungal network interfacing.",
+  title: "Hyphae 1 | Fungal Network Interface | Mycosoft",
+  description: "Hyphae 1 device profile for fungal network interfacing. FCI integration with precision sensing and research telemetry.",
 }
 
 export default function HyphaeOnePage() {
   return (
-    <main className="min-h-dvh bg-background">
-      <section className="container mx-auto px-4 py-10 md:py-14">
-        <Link
-          href="/devices"
-          className="inline-flex min-h-[44px] items-center gap-2 text-sm font-medium text-primary"
-        >
-          Back to Devices
-        </Link>
-        <p className="mt-4 text-xs sm:text-sm text-muted-foreground uppercase tracking-wide">
-          Hyphae 1
-        </p>
-        <h1 className="mt-2 text-3xl sm:text-4xl md:text-5xl font-semibold">Hyphae 1</h1>
-        <p className="mt-4 text-base sm:text-lg text-muted-foreground">
-          Hyphae 1 enables direct interfacing with fungal networks for bio-compute experimentation.
-        </p>
-      </section>
-
-      <section className="container mx-auto px-4 pb-12">
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">FCI integration</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Optimized for signal capture and Fungal Computer Interface workflows.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Precision sensing</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              High-resolution monitoring for low-noise biological signals.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Research telemetry</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Streams to NatureOS and MAS for experiments and analysis.
-            </p>
-          </div>
-        </div>
-      </section>
-    </main>
+    <div className="min-h-screen flex flex-col">
+      <Hyphae1Details />
+    </div>
   )
 }

--- a/app/devices/mushroom-1/page.tsx
+++ b/app/devices/mushroom-1/page.tsx
@@ -1,53 +1,15 @@
-import Link from "next/link"
-import { Metadata } from "next"
+import { Mushroom1Details } from "@/components/devices/mushroom1-details"
+import type { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "Mushroom 1 | Devices",
-  description: "Mushroom 1 device profile for fungal sensing and intelligence.",
+  title: "Mushroom 1 | Fungal Sensing Platform | Mycosoft",
+  description: "Mushroom 1 flagship sensing platform bridging fungal networks with real-time telemetry and intelligence workflows.",
 }
 
 export default function MushroomOnePage() {
   return (
-    <main className="min-h-dvh bg-background">
-      <section className="container mx-auto px-4 py-10 md:py-14">
-        <Link
-          href="/devices"
-          className="inline-flex min-h-[44px] items-center gap-2 text-sm font-medium text-primary"
-        >
-          Back to Devices
-        </Link>
-        <p className="mt-4 text-xs sm:text-sm text-muted-foreground uppercase tracking-wide">
-          Mushroom 1
-        </p>
-        <h1 className="mt-2 text-3xl sm:text-4xl md:text-5xl font-semibold">Mushroom 1</h1>
-        <p className="mt-4 text-base sm:text-lg text-muted-foreground">
-          Mushroom 1 is a flagship sensing platform that bridges fungal networks with real-time
-          telemetry and intelligence workflows.
-        </p>
-      </section>
-
-      <section className="container mx-auto px-4 pb-12">
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Sensor suite</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Multimodal sensing for environmental, biological, and electrical signals.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Edge intelligence</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              On-device inference and adaptive signal processing for rapid decisions.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Telemetry pipeline</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Streams to MAS and NatureOS for fleet monitoring and alerts.
-            </p>
-          </div>
-        </div>
-      </section>
-    </main>
+    <div className="min-h-screen flex flex-col">
+      <Mushroom1Details />
+    </div>
   )
 }

--- a/app/devices/myconode/page.tsx
+++ b/app/devices/myconode/page.tsx
@@ -1,52 +1,15 @@
-import Link from "next/link"
-import { Metadata } from "next"
+import { MycoNodeDetails } from "@/components/devices/myconode-details"
+import type { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "MycoNode | Devices",
-  description: "MycoNode device profile for distributed sensing and compute.",
+  title: "MycoNode | Distributed Sensing & Compute | Mycosoft",
+  description: "MycoNode device profile for distributed sensing and compute. Modular architecture with edge compute and secure telemetry.",
 }
 
 export default function MycoNodePage() {
   return (
-    <main className="min-h-dvh bg-background">
-      <section className="container mx-auto px-4 py-10 md:py-14">
-        <Link
-          href="/devices"
-          className="inline-flex min-h-[44px] items-center gap-2 text-sm font-medium text-primary"
-        >
-          Back to Devices
-        </Link>
-        <p className="mt-4 text-xs sm:text-sm text-muted-foreground uppercase tracking-wide">
-          MycoNode
-        </p>
-        <h1 className="mt-2 text-3xl sm:text-4xl md:text-5xl font-semibold">MycoNode</h1>
-        <p className="mt-4 text-base sm:text-lg text-muted-foreground">
-          MycoNode delivers modular sensing and compute for scalable field deployments.
-        </p>
-      </section>
-
-      <section className="container mx-auto px-4 pb-12">
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Modular architecture</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Configurable payloads for mission-specific sensing and analytics.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Edge compute</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Local inference and compression for low-latency operations.
-            </p>
-          </div>
-          <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">Secure telemetry</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Authenticated streaming into MAS and NatureOS device services.
-            </p>
-          </div>
-        </div>
-      </section>
-    </main>
+    <div className="min-h-screen flex flex-col">
+      <MycoNodeDetails />
+    </div>
   )
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor device detail pages to use shared detail components and update their metadata for improved consistency and branding.

Enhancements:
- Replace inline layouts on Mushroom 1, Hyphae 1, MycoNode, and ALARM device pages with shared detail components.
- Update page metadata titles and descriptions for device pages to align with Mycosoft branding and richer device descriptions.