### PR TITLE
Claude/restore mycobrain page kb odq

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "@types/google.maps": "^3.58.1",
     "@types/jest": "^30.0.0",
     "@types/leaflet": "^1.9.21",
-    "@types/mapbox__point-geometry": "^1.0.87",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
## Summary by Sourcery

Remove an unused Mapbox point geometry type dependency from the project configuration.

Build:
- Remove the @types/mapbox__point-geometry package from package.json dependencies.

Chores:
- Regenerate TypeScript build metadata to reflect the updated dependency set.