### PR TITLE
fix: unblock sandbox deployment — profile GPU services and rebuild on…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -204,7 +204,7 @@ jobs:
           script: |
             cd /opt/mycosoft-staging
             docker compose pull
-            docker compose up -d --remove-orphans
+            docker compose up -d --build --remove-orphans
             docker compose exec -T website npm run db:migrate --if-present
             echo "Deployed ${{ github.sha }} to staging at $(date)"
 
@@ -333,8 +333,8 @@ jobs:
             "Pull new images"
 
           run_on_vm \
-            "cd /opt/mycosoft && docker compose up -d --remove-orphans" \
-            "Rolling update containers"
+            "cd /opt/mycosoft && docker compose up -d --build --remove-orphans" \
+            "Rebuild and update containers"
 
           run_on_vm \
             "cd /opt/mycosoft && docker compose exec -T website npm run db:migrate --if-present" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -304,6 +304,7 @@ services:
   # ==========================================================================
 
   moshi-server:
+    profiles: ["gpu"]
     build:
       context: ../MAS/mycosoft-mas/services/personaplex-local
       dockerfile: Dockerfile.personaplex
@@ -336,6 +337,7 @@ services:
       - "com.mycosoft.requires=gpu"
 
   personaplex-bridge:
+    profiles: ["gpu"]
     build:
       context: ../MAS/mycosoft-mas/services/personaplex-local
       dockerfile: Dockerfile.personaplex


### PR DESCRIPTION
… deploy

Two issues prevented the sandbox from deploying new code:

1. GPU services (moshi-server, personaplex-bridge) reference a build context outside the repo (../MAS/...) that doesn't exist on the sandbox VM, causing `docker compose up` to fail entirely. Fixed by adding profiles: ["gpu"] so they're opt-in only.

2. The deploy step ran `docker compose up -d` without --build, and since no services have `image:` directives, `docker compose pull` was a no-op. Containers kept running stale cached images. Fixed by adding --build flag to rebuild from freshly pulled code.

https://claude.ai/code/session_017kwJmCFF6GETvRLmpHH22v

## Summary by Sourcery

Ensure sandbox and staging deployments rebuild containers from latest code and make GPU-dependent services optional via Docker profiles.

Build:
- Update CI/CD workflows to run `docker compose up` with `--build` to rebuild containers during staging and production deployments.

Deployment:
- Mark GPU-dependent Docker services with a `gpu` profile so they are only started when explicitly requested.