### PR TITLE
fix(crep): make fungal markers interactive, add all-life data, add GN…

### DIFF
--- a/app/api/crep/fungal/route.ts
+++ b/app/api/crep/fungal/route.ts
@@ -1,23 +1,24 @@
 /**
- * CREP Fungal Data API - PRIMARY DATA ENDPOINT
- * 
- * This is the main data source for the CREP dashboard's fungal layer.
- * 
+ * CREP Observation Data API - PRIMARY DATA ENDPOINT
+ *
+ * This is the main data source for the CREP dashboard's biodiversity layers.
+ * Serves ALL life data (fungi, plants, animals, birds, insects, marine) through MINDEX.
+ *
  * DATA PRIORITY:
- * 1. MINDEX (local fungal database) - PRIMARY, NO LIMIT
+ * 1. MINDEX (local biodiversity database) - PRIMARY, NO LIMIT
  * 2. Fallback to iNaturalist/GBIF only if MINDEX is unavailable
- * 
+ *
  * MINDEX contains all iNaturalist/GBIF data already imported via ETL.
  * This provides instant access to THOUSANDS of observations without
  * external API rate limits.
- * 
- * Required observation fields:
- * - Photo/image URL
- * - GPS coordinates (lat/lng)
- * - Species name
- * - Timestamp
- * - Source link (e.g., View on iNaturalist)
- * 
+ *
+ * Supports kingdom filtering via ?kingdom= parameter:
+ * - "all" (default) - All life
+ * - "Fungi" - Fungal observations only
+ * - "Plantae" - Plants only
+ * - "Animalia" - Animals only
+ * - etc.
+ *
  * @route GET /api/crep/fungal
  */
 
@@ -86,6 +87,10 @@ export interface FungalObservation {
   // Source links for "View on iNaturalist" etc.
   sourceUrl?: string
   externalId?: string
+  // Kingdom/taxa classification for all-life support
+  kingdom?: string
+  iconicTaxon?: string
+  taxonId?: number
 }
 
 /**
@@ -355,6 +360,9 @@ function transformMINDEXData(observations: Record<string, unknown>[], taxaLookup
         geocodeStatus: "complete" as const,
         sourceUrl,
         externalId: externalId?.toString(),
+        kingdom: obs.kingdom || obs.iconic_taxon_name || obs.taxon?.kingdom || "Fungi",
+        iconicTaxon: obs.iconic_taxon_name || obs.taxon?.iconic_taxon_name || "Fungi",
+        taxonId: obs.taxon_id,
       }
     })
 }
@@ -421,128 +429,166 @@ const FUNGAL_HOTSPOT_REGIONS = [
   { name: "East Coast USA", north: 45.0, south: 35.0, east: -70.0, west: -85.0 },
 ]
 
+// All iNaturalist iconic taxa for comprehensive all-life coverage
+const ALL_ICONIC_TAXA = [
+  "Fungi", "Plantae", "Aves", "Mammalia", "Reptilia",
+  "Amphibia", "Actinopterygii", "Mollusca", "Arachnida", "Insecta",
+]
+
 /**
- * Fetch observations from iNaturalist - MULTI-REGION for comprehensive coverage
+ * Fetch observations from iNaturalist - ALL LIFE, MULTI-REGION
+ * Fetches all iconic taxa for comprehensive biodiversity coverage
  */
 async function fetchINaturalistObservations(
-  limit: number, 
-  bounds?: { north: number; south: number; east: number; west: number }
+  limit: number,
+  bounds?: { north: number; south: number; east: number; west: number },
+  kingdom?: string,
 ): Promise<FungalObservation[]> {
   const allObservations: FungalObservation[] = []
-  const perRegionLimit = Math.ceil(limit / (bounds ? 1 : FUNGAL_HOTSPOT_REGIONS.length))
-  
+
+  // Determine which taxa to fetch
+  const taxaToFetch = kingdom && kingdom !== "all"
+    ? [kingdom]
+    : ALL_ICONIC_TAXA
+
+  const perRegionLimit = Math.ceil(limit / (bounds ? taxaToFetch.length : FUNGAL_HOTSPOT_REGIONS.length * taxaToFetch.length))
+
   // If specific bounds provided, use those; otherwise fetch from all hotspots
-  const regionsToFetch = bounds 
+  const regionsToFetch = bounds
     ? [{ name: "Custom", ...bounds }]
     : FUNGAL_HOTSPOT_REGIONS
-  
+
   await Promise.all(
-    regionsToFetch.map(async (region) => {
+    regionsToFetch.flatMap((region) =>
+      taxaToFetch.map(async (taxon) => {
+        try {
+          const params = new URLSearchParams({
+            iconic_taxa: taxon,
+            quality_grade: "research,needs_id",
+            per_page: String(Math.min(perRegionLimit, 200)),
+            order: "desc",
+            order_by: "observed_on",
+            geo: "true",
+            photos: "true",
+            nelat: String(region.north),
+            nelng: String(region.east),
+            swlat: String(region.south),
+            swlng: String(region.west),
+          })
+
+          const response = await fetch(`${INATURALIST_API}/observations?${params}`, {
+            headers: { "Accept": "application/json" },
+            next: { revalidate: 300 },
+          })
+
+          if (!response.ok) {
+            console.warn(`[CREP/Life] iNaturalist API error for ${region.name}/${taxon}:`, response.status)
+            return
+          }
+
+          const data = await response.json()
+          if (data.results?.length > 0) {
+            console.log(`[CREP/Life] Fetched ${data.results.length} ${taxon} from ${region.name}`)
+          }
+
+          const regionObs = (data.results || [])
+            .filter((obs: Record<string, unknown>) => (obs.geojson as Record<string, unknown>)?.coordinates || obs.location)
+            .map((obs: Record<string, unknown>) => ({
+              id: `inat-${obs.id}`,
+              species: obs.taxon?.preferred_common_name || obs.taxon?.name || "Unknown",
+              scientificName: obs.taxon?.name || "Unknown",
+              commonName: obs.taxon?.preferred_common_name,
+              latitude: obs.geojson?.coordinates?.[1] || parseFloat(obs.location?.split(",")[0]) || 0,
+              longitude: obs.geojson?.coordinates?.[0] || parseFloat(obs.location?.split(",")[1]) || 0,
+              timestamp: obs.observed_on || obs.created_at,
+              source: "iNaturalist" as const,
+              verified: obs.quality_grade === "research",
+              observer: obs.user?.login || "Anonymous",
+              imageUrl: obs.photos?.[0]?.url?.replace("square", "medium"),
+              thumbnailUrl: obs.photos?.[0]?.url,
+              location: obs.place_guess || region.name,
+              notes: obs.description,
+              hasGps: true,
+              geocodeStatus: "complete" as const,
+              kingdom: obs.taxon?.iconic_taxon_name || taxon,
+              iconicTaxon: obs.taxon?.iconic_taxon_name || taxon,
+              taxonId: obs.taxon?.id,
+            }))
+
+          allObservations.push(...regionObs)
+        } catch (error) {
+          console.error(`[CREP/Life] Failed to fetch ${taxon} data for ${region.name}:`, error)
+        }
+      })
+    )
+  )
+
+  console.log(`[CREP/Life] Total iNaturalist observations fetched: ${allObservations.length}`)
+  return allObservations
+}
+
+// GBIF kingdom keys for all-life coverage
+const GBIF_KINGDOMS: Record<string, string> = {
+  Fungi: "5", Plantae: "6", Animalia: "1", Chromista: "4", Protozoa: "7", Bacteria: "3",
+}
+
+/**
+ * Fetch observations from GBIF - ALL LIFE
+ */
+async function fetchGBIFObservations(limit: number, kingdom?: string): Promise<FungalObservation[]> {
+  const allObs: FungalObservation[] = []
+  const kingdomsToFetch = kingdom && kingdom !== "all" && GBIF_KINGDOMS[kingdom]
+    ? [[kingdom, GBIF_KINGDOMS[kingdom]]]
+    : Object.entries(GBIF_KINGDOMS)
+  const perKingdom = Math.ceil(limit / kingdomsToFetch.length)
+
+  await Promise.all(
+    kingdomsToFetch.map(async ([kName, kKey]) => {
       try {
         const params = new URLSearchParams({
-          iconic_taxa: "Fungi",
-          quality_grade: "research,needs_id",
-          per_page: String(Math.min(perRegionLimit, 200)),
-          order: "desc",
-          order_by: "observed_on",
-          geo: "true",
-          photos: "true",
-          nelat: String(region.north),
-          nelng: String(region.east),
-          swlat: String(region.south),
-          swlng: String(region.west),
+          kingdomKey: kKey,
+          limit: String(Math.min(perKingdom, 100)),
+          hasCoordinate: "true",
+          hasGeospatialIssue: "false",
         })
 
-        const response = await fetch(`${INATURALIST_API}/observations?${params}`, {
+        const response = await fetch(`${GBIF_API}/occurrence/search?${params}`, {
           headers: { "Accept": "application/json" },
           next: { revalidate: 300 },
         })
 
-        if (!response.ok) {
-          console.warn(`[CREP/Fungal] iNaturalist API error for ${region.name}:`, response.status)
-          return
-        }
+        if (!response.ok) return
 
         const data = await response.json()
-        console.log(`[CREP/Fungal] Fetched ${data.results?.length || 0} observations from ${region.name}`)
-
-        const regionObs = (data.results || [])
-          .filter((obs: Record<string, unknown>) => (obs.geojson as Record<string, unknown>)?.coordinates || obs.location)
-          .map((obs: Record<string, unknown>) => ({
-            id: `inat-${obs.id}`,
-            species: obs.taxon?.preferred_common_name || obs.taxon?.name || "Unknown",
-            scientificName: obs.taxon?.name || "Unknown",
-            commonName: obs.taxon?.preferred_common_name,
-            latitude: obs.geojson?.coordinates?.[1] || parseFloat(obs.location?.split(",")[0]) || 0,
-            longitude: obs.geojson?.coordinates?.[0] || parseFloat(obs.location?.split(",")[1]) || 0,
-            timestamp: obs.observed_on || obs.created_at,
-            source: "iNaturalist" as const,
-            verified: obs.quality_grade === "research",
-            observer: obs.user?.login || "Anonymous",
-            imageUrl: obs.photos?.[0]?.url?.replace("square", "medium"),
-            thumbnailUrl: obs.photos?.[0]?.url,
-            location: obs.place_guess || region.name,
-            notes: obs.description,
+        const obs = (data.results || [])
+          .filter((o: Record<string, unknown>) => o.decimalLatitude && o.decimalLongitude)
+          .map((o: Record<string, unknown>) => ({
+            id: `gbif-${o.key}`,
+            species: o.vernacularName || o.species || "Unknown",
+            scientificName: o.scientificName || "Unknown",
+            commonName: o.vernacularName,
+            latitude: o.decimalLatitude,
+            longitude: o.decimalLongitude,
+            timestamp: o.eventDate || o.dateIdentified || new Date().toISOString(),
+            source: "GBIF" as const,
+            verified: !o.issues?.length,
+            observer: o.recordedBy || "Unknown",
+            imageUrl: undefined,
+            thumbnailUrl: undefined,
+            location: o.locality || o.country,
+            habitat: o.habitat,
             hasGps: true,
             geocodeStatus: "complete" as const,
+            kingdom: o.kingdom || kName,
+            iconicTaxon: o.kingdom || kName,
           }))
-        
-        allObservations.push(...regionObs)
+        allObs.push(...obs)
       } catch (error) {
-        console.error(`[CREP/Fungal] Failed to fetch iNaturalist data for ${region.name}:`, error)
+        console.error(`[CREP/Life] Failed to fetch GBIF ${kName} data:`, error)
       }
     })
   )
-  
-  console.log(`[CREP/Fungal] Total iNaturalist observations fetched: ${allObservations.length}`)
-  return allObservations
-}
-
-/**
- * Fetch observations from GBIF
- */
-async function fetchGBIFObservations(limit: number): Promise<FungalObservation[]> {
-  try {
-    const params = new URLSearchParams({
-      kingdomKey: "5", // Fungi kingdom
-      limit: String(Math.min(limit, 100)),
-      hasCoordinate: "true",
-      hasGeospatialIssue: "false",
-    })
-
-    const response = await fetch(`${GBIF_API}/occurrence/search?${params}`, {
-      headers: { "Accept": "application/json" },
-      next: { revalidate: 300 },
-    })
-
-    if (!response.ok) return []
-
-    const data = await response.json()
-
-    return (data.results || [])
-      .filter((obs: Record<string, unknown>) => obs.decimalLatitude && obs.decimalLongitude)
-      .map((obs: Record<string, unknown>) => ({
-        id: `gbif-${obs.key}`,
-        species: obs.vernacularName || obs.species || "Unknown",
-        scientificName: obs.scientificName || "Unknown",
-        commonName: obs.vernacularName,
-        latitude: obs.decimalLatitude,
-        longitude: obs.decimalLongitude,
-        timestamp: obs.eventDate || obs.dateIdentified || new Date().toISOString(),
-        source: "GBIF" as const,
-        verified: !obs.issues?.length,
-        observer: obs.recordedBy || "Unknown",
-        imageUrl: undefined,
-        thumbnailUrl: undefined,
-        location: obs.locality || obs.country,
-        habitat: obs.habitat,
-        hasGps: true,
-        geocodeStatus: "complete" as const,
-      }))
-  } catch (error) {
-    console.error("[CREP/Fungal] Failed to fetch GBIF data:", error)
-    return []
-  }
+  return allObs
 }
 
 /**
@@ -585,13 +631,15 @@ export async function GET(request: NextRequest) {
   const source = searchParams.get("source") // "mindex" | "inat" | "gbif" | "all"
   const fallbackOnly = searchParams.get("fallback") === "true" // Force external API fallback
   const noCache = searchParams.get("nocache") === "true" // Force cache bypass
-  
+  // Kingdom filter: "Fungi", "Plantae", "Animalia", "all" (default: "all")
+  const kingdom = searchParams.get("kingdom") || "all"
+
   // Bounds for geographic filtering
   const north = searchParams.get("north") ? parseFloat(searchParams.get("north")!) : undefined
   const south = searchParams.get("south") ? parseFloat(searchParams.get("south")!) : undefined
   const east = searchParams.get("east") ? parseFloat(searchParams.get("east")!) : undefined
   const west = searchParams.get("west") ? parseFloat(searchParams.get("west")!) : undefined
-  
+
   const bounds = north && south && east && west ? { north, south, east, west } : undefined
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -655,20 +703,28 @@ export async function GET(request: NextRequest) {
   
   // Fallback to external APIs only if MINDEX failed or was explicitly disabled
   if (allObservations.length === 0 || fallbackOnly) {
-    console.log("[CREP/Fungal] Using external API fallback (iNaturalist + GBIF)...")
-    
+    console.log("[CREP/Life] Using external API fallback (iNaturalist + GBIF) for ALL LIFE...")
+
     const fetchPromises: Promise<FungalObservation[]>[] = []
-    
+
     if (!source || source === "all" || source === "inat") {
-      fetchPromises.push(fetchINaturalistObservations(limit || 2000, bounds))
+      fetchPromises.push(fetchINaturalistObservations(limit || 2000, bounds, kingdom))
     }
     if (!source || source === "all" || source === "gbif") {
-      fetchPromises.push(fetchGBIFObservations(limit ? Math.ceil(limit * 0.3) : 500))
+      fetchPromises.push(fetchGBIFObservations(limit ? Math.ceil(limit * 0.3) : 500, kingdom))
     }
 
     const results = await Promise.all(fetchPromises)
     allObservations = results.flat()
-    console.log(`[CREP/Fungal] External APIs returned ${allObservations.length} observations`)
+    console.log(`[CREP/Life] External APIs returned ${allObservations.length} observations across all kingdoms`)
+  }
+
+  // Apply kingdom filter if not "all" and data came from MINDEX (which has mixed kingdoms)
+  if (kingdom !== "all") {
+    allObservations = allObservations.filter(obs =>
+      (obs.kingdom || "").toLowerCase() === kingdom.toLowerCase() ||
+      (obs.iconicTaxon || "").toLowerCase() === kingdom.toLowerCase()
+    )
   }
 
   // Deduplicate by species name + coordinates (close proximity = same observation)
@@ -713,6 +769,13 @@ export async function GET(request: NextRequest) {
     gbif: finalObservations.filter(o => o.source === "GBIF").length,
   }
 
+  // Build kingdom breakdown
+  const kingdoms: Record<string, number> = {}
+  for (const obs of finalObservations) {
+    const k = obs.kingdom || obs.iconicTaxon || "Unknown"
+    kingdoms[k] = (kingdoms[k] || 0) + 1
+  }
+
   // Cache the data for near-instant subsequent requests
   setCachedData(finalObservations, sources)
 
@@ -721,18 +784,19 @@ export async function GET(request: NextRequest) {
   const primarySource = sources.mindex > 0 ? "mindex" : sources.iNaturalist > 0 ? "inaturalist" : "gbif"
   logDataCollection("fungal", primarySource, finalObservations.length, latency, false)
 
-  console.log(`[CREP/Fungal] 🍄 Returning ${finalObservations.length} fungal observations`)
+  console.log(`[CREP/Life] Returning ${finalObservations.length} observations across ${Object.keys(kingdoms).length} kingdoms`)
 
   return NextResponse.json({
     observations: finalObservations,
     meta: {
       total: finalObservations.length,
       sources,
+      kingdoms,
       pendingGeocode,
       cached: false,
       timestamp: new Date().toISOString(),
-      dataSource: allObservations.length > 0 && finalObservations[0]?.source !== "MINDEX" 
-        ? "external_fallback" 
+      dataSource: allObservations.length > 0 && finalObservations[0]?.source !== "MINDEX"
+        ? "external_fallback"
         : "mindex_primary",
     },
   })

--- a/app/api/mindex/observations/route.ts
+++ b/app/api/mindex/observations/route.ts
@@ -18,13 +18,42 @@ interface Observation {
   verified: boolean
   observer: string
   imageUrl: string
+  kingdom?: string
+  iconicTaxon?: string
 }
 
-// Fetch real observations from iNaturalist
-async function fetchINaturalistObservations(limit: number, species?: string): Promise<Observation[]> {
+// iNaturalist iconic taxa for ALL life - used to categorize observations
+const ALL_ICONIC_TAXA = [
+  "Fungi",
+  "Plantae",
+  "Aves",
+  "Mammalia",
+  "Reptilia",
+  "Amphibia",
+  "Actinopterygii",
+  "Mollusca",
+  "Arachnida",
+  "Insecta",
+] as const
+
+// GBIF kingdom keys for ALL life
+const GBIF_KINGDOMS: Record<string, string> = {
+  "Fungi": "5",
+  "Plantae": "6",
+  "Animalia": "1",
+  "Chromista": "4",
+  "Protozoa": "7",
+  "Bacteria": "3",
+}
+
+// Fetch real observations from iNaturalist for a specific iconic taxon (or all)
+async function fetchINaturalistObservations(
+  limit: number,
+  species?: string,
+  iconicTaxon?: string,
+): Promise<Observation[]> {
   try {
     const params = new URLSearchParams({
-      iconic_taxa: "Fungi",
       quality_grade: "research,needs_id",
       per_page: String(Math.min(limit, 200)),
       order: "desc",
@@ -32,6 +61,11 @@ async function fetchINaturalistObservations(limit: number, species?: string): Pr
       geo: "true",
       photos: "true",
     })
+
+    // If specific iconic taxon requested, filter to it; otherwise fetch all life
+    if (iconicTaxon) {
+      params.set("iconic_taxa", iconicTaxon)
+    }
 
     if (species) {
       params.set("taxon_name", species)
@@ -58,6 +92,8 @@ async function fetchINaturalistObservations(limit: number, species?: string): Pr
       verified: obs.quality_grade === "research",
       observer: obs.user?.login || "Anonymous",
       imageUrl: obs.photos?.[0]?.url?.replace("square", "medium") || "",
+      kingdom: obs.taxon?.iconic_taxon_name || "Unknown",
+      iconicTaxon: obs.taxon?.iconic_taxon_name || "Unknown",
     }))
   } catch (error) {
     if (!isTimeoutError(error)) {
@@ -67,15 +103,23 @@ async function fetchINaturalistObservations(limit: number, species?: string): Pr
   }
 }
 
-// Fetch real observations from GBIF
-async function fetchGBIFObservations(limit: number, species?: string): Promise<Observation[]> {
+// Fetch real observations from GBIF for a specific kingdom (or all)
+async function fetchGBIFObservations(
+  limit: number,
+  species?: string,
+  kingdomKey?: string,
+): Promise<Observation[]> {
   try {
     const params = new URLSearchParams({
-      kingdomKey: "5", // Fungi kingdom
       limit: String(Math.min(limit, 100)),
       hasCoordinate: "true",
       hasGeospatialIssue: "false",
     })
+
+    // Filter to specific kingdom if provided
+    if (kingdomKey) {
+      params.set("kingdomKey", kingdomKey)
+    }
 
     if (species) {
       params.set("scientificName", species)
@@ -102,6 +146,8 @@ async function fetchGBIFObservations(limit: number, species?: string): Promise<O
       verified: obs.issues?.length === 0,
       observer: obs.recordedBy || "Unknown",
       imageUrl: "",
+      kingdom: obs.kingdom || "Unknown",
+      iconicTaxon: obs.kingdom || "Unknown",
     }))
   } catch (error) {
     if (!isTimeoutError(error)) {
@@ -138,17 +184,45 @@ async function fetchLocalMINDEX(limit: number): Promise<Observation[]> {
 export async function GET(request: NextRequest) {
   const limit = parseInt(request.nextUrl.searchParams.get("limit") || "200")
   const species = request.nextUrl.searchParams.get("species") || undefined
+  // kingdom filter: "Fungi", "Plantae", "Animalia", "all" (default: "all" for all life)
+  const kingdom = request.nextUrl.searchParams.get("kingdom") || "all"
+  // iconic_taxa filter for iNaturalist-specific filtering
+  const iconicTaxon = request.nextUrl.searchParams.get("iconic_taxa") || undefined
 
-  // Fetch from multiple sources in parallel
-  const [iNatObs, gbifObs, localObs] = await Promise.all([
-    fetchINaturalistObservations(Math.ceil(limit * 0.6), species),
-    fetchGBIFObservations(Math.ceil(limit * 0.3), species),
-    fetchLocalMINDEX(Math.ceil(limit * 0.1)),
-  ])
+  // Determine which iconic taxa and GBIF kingdoms to fetch
+  const inatTaxa = kingdom === "all"
+    ? ALL_ICONIC_TAXA
+    : [kingdom === "Animalia" ? "Mammalia" : kingdom]
+  const gbifKeys = kingdom === "all"
+    ? Object.values(GBIF_KINGDOMS)
+    : [GBIF_KINGDOMS[kingdom] || "5"]
 
-  // Combine and deduplicate
-  const allObservations = [...localObs, ...iNatObs, ...gbifObs]
-  
+  // Fetch from ALL iconic taxa in parallel for comprehensive coverage
+  const iNatPerTaxon = Math.ceil((limit * 0.6) / inatTaxa.length)
+  const gbifPerKingdom = Math.ceil((limit * 0.3) / gbifKeys.length)
+
+  const fetchPromises: Promise<Observation[]>[] = []
+
+  // iNaturalist: fetch each iconic taxon
+  for (const taxon of inatTaxa) {
+    fetchPromises.push(
+      fetchINaturalistObservations(iNatPerTaxon, species, iconicTaxon || taxon)
+    )
+  }
+
+  // GBIF: fetch each kingdom
+  for (const key of gbifKeys) {
+    fetchPromises.push(
+      fetchGBIFObservations(gbifPerKingdom, species, key)
+    )
+  }
+
+  // Local MINDEX
+  fetchPromises.push(fetchLocalMINDEX(Math.ceil(limit * 0.1)))
+
+  const results = await Promise.all(fetchPromises)
+  const allObservations = results.flat()
+
   // Filter out observations without valid coordinates
   const validObservations = allObservations.filter(
     (obs) => obs.lat !== 0 && obs.lng !== 0 && !isNaN(obs.lat) && !isNaN(obs.lng)
@@ -157,10 +231,18 @@ export async function GET(request: NextRequest) {
   // Limit to requested count
   const observations = validObservations.slice(0, limit)
 
+  // Count by kingdom for metadata
+  const kingdomCounts: Record<string, number> = {}
+  for (const obs of observations) {
+    const k = obs.kingdom || obs.iconicTaxon || "Unknown"
+    kingdomCounts[k] = (kingdomCounts[k] || 0) + 1
+  }
+
   return NextResponse.json({
     observations,
     total: observations.length,
     sources: ["iNaturalist", "GBIF", "MINDEX"],
+    kingdoms: kingdomCounts,
     realData: true,
     cached: false,
   })

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -149,7 +149,7 @@ import type { FenceSegment } from "@/components/crep/smart-fence-widget";
 import type { PresenceReading } from "@/components/crep/presence-detection-widget";
 
 // Map Markers for OEI Data
-import { type FungalObservation } from "@/components/crep/markers";
+import { FungalMarker, type FungalObservation } from "@/components/crep/markers";
 
 // Centered Detail Panel for entity popups
 import { EntityDetailPanel } from "@/components/crep/panels/entity-detail-panel";
@@ -195,7 +195,7 @@ import { VoiceMapControls } from "@/components/crep/voice-map-controls";
 
 // Map Controls with streaming status
 import { MapControls as OEIMapControls, StreamingStatusBar } from "@/components/crep/map-controls";
-import type { AircraftFilter, VesselFilter, SatelliteFilter, SpaceWeatherFilter, NOAAScales } from "@/components/crep/map-controls";
+import type { AircraftFilter, VesselFilter, SatelliteFilter, SpaceWeatherFilter, GroundFilter, NOAAScales } from "@/components/crep/map-controls";
 
 // OEI Types
 import type { AircraftEntity, VesselEntity } from "@/types/oei"
@@ -1559,7 +1559,37 @@ export default function CREPDashboardPage() {
     showAuroraOval: false,
     showSolarWind: false,
   });
-  
+
+  const [groundFilter, setGroundFilter] = useState<GroundFilter>({
+    // Biodiversity – all on by default
+    showFungi: true,
+    showPlants: true,
+    showBirds: true,
+    showMammals: true,
+    showReptiles: true,
+    showInsects: true,
+    showMarineLife: true,
+    // Natural Events – on by default
+    showEarthquakes: true,
+    showVolcanoes: true,
+    showWildfires: true,
+    showStorms: true,
+    showLightning: true,
+    showTornadoes: true,
+    showFloods: true,
+    // Infrastructure – off by default
+    showFactories: false,
+    showPowerPlants: false,
+    showMining: false,
+    showOilGas: false,
+    showWaterPollution: false,
+    // Sensors – on by default
+    showMycoBrain: true,
+    showSporeBase: true,
+    showSmartFence: true,
+    showPartnerNetworks: false,
+  });
+
   // Mission context
   const [currentMission] = useState<MissionContext>({
     id: "mission-001",
@@ -2034,27 +2064,30 @@ export default function CREPDashboardPage() {
                   preferred_common_name: obs.commonName || obs.species,
                   rank: "species",
                 },
-                photos: obs.imageUrl || obs.thumbnailUrl ? [{ 
-                  id: 1, 
+                photos: obs.imageUrl || obs.thumbnailUrl ? [{
+                  id: 1,
                   url: obs.imageUrl || obs.thumbnailUrl,
                   license: "CC-BY-NC"
                 }] : [],
                 quality_grade: obs.verified ? "research" : "needs_id",
                 user: obs.observer,
-                // Source information for rich display
                 source: obs.source,
                 location: obs.location,
                 habitat: obs.habitat,
                 notes: obs.notes,
-                // Source URL for "View on iNaturalist" / "View on GBIF" links
                 sourceUrl: obs.sourceUrl,
                 externalId: obs.externalId,
+                // All-life kingdom data
+                kingdom: obs.kingdom || obs.iconicTaxon || "Fungi",
+                iconicTaxon: obs.iconicTaxon || obs.kingdom || "Fungi",
               }));
-              
+
               const sourceInfo = fungalData.meta?.sources || {};
+              const kingdomInfo = fungalData.meta?.kingdoms || {};
               const dataSource = fungalData.meta?.dataSource || "unknown";
-              console.log(`[CREP] Loaded ${formattedObs.length} fungal observations (${dataSource})`);
-              console.log(`[CREP] Sources breakdown: MINDEX=${sourceInfo.mindex || 0}, iNaturalist=${sourceInfo.iNaturalist || 0}, GBIF=${sourceInfo.gbif || 0}`);
+              console.log(`[CREP] Loaded ${formattedObs.length} observations (${dataSource})`);
+              console.log(`[CREP] Sources: MINDEX=${sourceInfo.mindex || 0}, iNaturalist=${sourceInfo.iNaturalist || 0}, GBIF=${sourceInfo.gbif || 0}`);
+              console.log(`[CREP] Kingdoms:`, kingdomInfo);
               
               setFungalObservations(formattedObs);
               setFungalLoading(false);
@@ -2210,10 +2243,34 @@ export default function CREPDashboardPage() {
   }, []);
 
   const setLayerOpacity = useCallback((layerId: string, opacity: number) => {
-    setLayers(prev => prev.map(l => 
+    setLayers(prev => prev.map(l =>
       l.id === layerId ? { ...l, opacity } : l
     ));
   }, []);
+
+  // Sync ground filter toggles with layer visibility
+  useEffect(() => {
+    const layerMap: Record<string, boolean> = {
+      earthquakes: groundFilter.showEarthquakes,
+      volcanoes: groundFilter.showVolcanoes,
+      wildfires: groundFilter.showWildfires,
+      storms: groundFilter.showStorms,
+      lightning: groundFilter.showLightning,
+      tornadoes: groundFilter.showTornadoes,
+      mycobrain: groundFilter.showMycoBrain,
+      sporebase: groundFilter.showSporeBase,
+      smartfence: groundFilter.showSmartFence,
+      partners: groundFilter.showPartnerNetworks,
+      factories: groundFilter.showFactories,
+      powerPlants: groundFilter.showPowerPlants,
+      metalOutput: groundFilter.showMining,
+      oilGas: groundFilter.showOilGas,
+      waterPollution: groundFilter.showWaterPollution,
+    };
+    setLayers(prev => prev.map(l =>
+      l.id in layerMap ? { ...l, enabled: layerMap[l.id] } : l
+    ));
+  }, [groundFilter]);
 
   // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
   // LOD (LEVEL OF DETAIL) FILTERING - Progressive disclosure system
@@ -2251,10 +2308,29 @@ export default function CREPDashboardPage() {
       return fungalObservations.slice(0, 100);
     }
     
+    // Step 0: Filter by ground kingdom toggles
+    const kingdomFiltered = fungalObservations.filter(obs => {
+      const kingdom = obs.iconicTaxon || obs.kingdom || "Fungi";
+      switch (kingdom) {
+        case "Fungi": return groundFilter.showFungi;
+        case "Plantae": return groundFilter.showPlants;
+        case "Aves": return groundFilter.showBirds;
+        case "Mammalia": return groundFilter.showMammals;
+        case "Reptilia": return groundFilter.showReptiles;
+        case "Amphibia": return groundFilter.showReptiles; // grouped with reptiles
+        case "Insecta": return groundFilter.showInsects;
+        case "Arachnida": return groundFilter.showInsects; // grouped with insects
+        case "Actinopterygii":
+        case "Mollusca": return groundFilter.showMarineLife;
+        case "Animalia": return groundFilter.showMammals; // generic animal
+        default: return true;
+      }
+    });
+
     // Step 1: Filter to viewport bounds FIRST (fast culling)
     // Add small padding to prevent markers at exact edges from disappearing (Feb 12, 2026)
     const padding = 0.001; // ~100m at equator
-    const inViewport = fungalObservations.filter(obs => {
+    const inViewport = kingdomFiltered.filter(obs => {
       const lat = obs.latitude;
       const lng = obs.longitude;
       
@@ -2349,7 +2425,7 @@ export default function CREPDashboardPage() {
     }
     
     return sampled;
-  }, [fungalObservations, mapZoom, mapBounds]);
+  }, [fungalObservations, mapZoom, mapBounds, groundFilter]);
   
   // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
   // SMART MAP AUTO-PAN: Fungal Marker Selection Handler
@@ -3598,14 +3674,9 @@ export default function CREPDashboardPage() {
                   const obsId = entity.id?.replace?.("fungal-", "");
                   const obs = visibleFungalObservations.find((o) => String(o.id) === String(obsId));
                   if (obs) {
-                    setSelectedFungal(obs);
+                    handleSelectFungal(obs);
                     setLeftPanelOpen(true);
                     setLeftPanelTab("fungal");
-                    mapRef?.flyTo({
-                      center: [obs.longitude, obs.latitude],
-                      zoom: Math.max(mapRef.getZoom(), 12),
-                      duration: 1000,
-                    });
                   }
                 }
               }}
@@ -3789,7 +3860,20 @@ export default function CREPDashboardPage() {
               ));
             })()}
 
-            {/* Aircraft / Vessel / Satellite / Fungal rendering moved to deck.gl EntityDeckLayer */}
+            {/* Aircraft / Vessel / Satellite rendering via deck.gl EntityDeckLayer */}
+
+            {/* Fungal Observation Markers - Rendered as MapMarker components for interactive popups
+                deck.gl renders the green dots for ALL visible observations (performance)
+                MapMarker components render ONLY for the selected observation to show the popup widget */}
+            {layers.find(l => l.id === "fungi")?.enabled && selectedFungal && (
+              <FungalMarker
+                key={`fungal-popup-${selectedFungal.id}`}
+                observation={selectedFungal}
+                isSelected={true}
+                onClick={() => handleSelectFungal(null)}
+                onClose={() => handleSelectFungal(null)}
+              />
+            )}
           </MapComponent>
 
           {/* Map Overlay - Corner Decorations */}
@@ -3928,6 +4012,7 @@ export default function CREPDashboardPage() {
                         vesselFilter={vesselFilter}
                         satelliteFilter={satelliteFilter}
                         spaceWeatherFilter={spaceWeatherFilter}
+                        groundFilter={groundFilter}
                         streamStatuses={[
                           { type: "aircraft", connected: isStreaming, messageCount: aircraft.length },
                           { type: "vessels", connected: isStreaming, messageCount: vessels.length },
@@ -3939,6 +4024,7 @@ export default function CREPDashboardPage() {
                         onVesselFilterChange={(f) => setVesselFilter({ ...vesselFilter, ...f })}
                         onSatelliteFilterChange={(f) => setSatelliteFilter({ ...satelliteFilter, ...f })}
                         onSpaceWeatherFilterChange={(f) => setSpaceWeatherFilter({ ...spaceWeatherFilter, ...f })}
+                        onGroundFilterChange={(f) => setGroundFilter({ ...groundFilter, ...f })}
                         onToggleStreaming={() => setIsStreaming(!isStreaming)}
                         onRefresh={() => {
                           // Trigger a refresh by re-fetching data

--- a/components/crep/layers/deck-entity-layer.tsx
+++ b/components/crep/layers/deck-entity-layer.tsx
@@ -64,11 +64,23 @@ const SATELLITE_ICON = svgUri(
 );
 
 /**
- * Generic dot – for fungal observations, weather events, earthquakes, etc.
+ * Generic dot – for weather events, earthquakes, etc.
  */
 const DOT_ICON = svgUri(
   `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
     <circle cx="16" cy="16" r="13" fill="white"/>
+  </svg>`
+);
+
+/**
+ * Fungal / mushroom icon – distinct from generic dots to show they are clickable/selectable
+ * Draws a simple mushroom silhouette so users know these are fungal observation markers
+ */
+const FUNGAL_ICON = svgUri(
+  `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+    <ellipse cx="16" cy="14" rx="12" ry="10" fill="white"/>
+    <rect x="13" y="14" width="6" height="12" rx="2" fill="white"/>
+    <circle cx="16" cy="14" r="3" fill="white" opacity="0.3"/>
   </svg>`
 );
 
@@ -81,9 +93,9 @@ type RGBA = [number, number, number, number];
 
 /** Canonical colours per entity type. Alpha 230/200 for slight transparency. */
 const ENTITY_COLORS: Record<string, RGBA> = {
-  aircraft:   [251, 182,  36, 240],   // amber-400   ← warm yellow-orange (matches "pink" in original)
-  vessel:     [ 56, 189, 248, 240],   // sky-400     ← bright blue
-  satellite:  [167,  85, 247, 240],   // violet-500  ← purple
+  aircraft:   [251, 182,  36, 240],   // amber-400
+  vessel:     [ 56, 189, 248, 240],   // sky-400
+  satellite:  [167,  85, 247, 240],   // violet-500
   fungal:     [ 74, 222, 128, 210],   // green-400
   weather:    [251, 191,  36, 200],   // amber-400
   earthquake: [251, 113, 133, 230],   // rose-400
@@ -91,8 +103,29 @@ const ENTITY_COLORS: Record<string, RGBA> = {
   device:     [ 34, 211, 238, 220],   // cyan-400
 };
 
+/** Kingdom-specific colours for all-life fungal/observation markers */
+const KINGDOM_COLORS: Record<string, RGBA> = {
+  Fungi:          [180, 83,   9, 220],   // amber-700 (brown/earthy)
+  Plantae:        [  4, 120,  87, 220],  // emerald-700
+  Aves:           [  3, 105, 161, 220],  // sky-700
+  Mammalia:       [194,  65,  12, 220],  // orange-700
+  Reptilia:       [ 77, 124,  15, 220],  // lime-700
+  Amphibia:       [ 21, 128,  61, 220],  // green-700
+  Actinopterygii: [ 14, 116, 144, 220],  // cyan-700
+  Mollusca:       [190,  18,  60, 220],  // rose-700
+  Arachnida:      [153,  27,  27, 220],  // red-800
+  Insecta:        [161,  98,   7, 220],  // yellow-700
+  Animalia:       [194,  65,  12, 220],  // orange-700
+};
+
 function entityColor(type: string): RGBA {
   return ENTITY_COLORS[type] ?? [220, 220, 220, 200];
+}
+
+/** Get kingdom-specific colour for observation entities */
+function fungalEntityColor(entity: UnifiedEntity): RGBA {
+  const kingdom = entity.properties?.kingdom || entity.properties?.iconicTaxon || "Fungi";
+  return KINGDOM_COLORS[kingdom as string] ?? ENTITY_COLORS.fungal;
 }
 
 /** Normalize aviation heading to 0–360 degrees. Accepts degrees or radians (if value in 0..2π). */
@@ -206,8 +239,9 @@ export function EntityDeckLayer({
     const aircraft   = valid.filter(e => e.type === "aircraft");
     const vessels    = valid.filter(e => e.type === "vessel");
     const satellites = valid.filter(e => e.type === "satellite");
+    const fungal     = valid.filter(e => e.type === "fungal");
     const others     = valid.filter(
-      e => !["aircraft", "vessel", "satellite"].includes(e.type)
+      e => !["aircraft", "vessel", "satellite", "fungal"].includes(e.type)
     );
 
     // Build motion trails: satellites only get full-orbit path (no short segment) for consistency
@@ -251,7 +285,24 @@ export function EntityDeckLayer({
           extensions: [new PathStyleExtension({ dash: true })],
         }),
 
-        // ── Other entities: fungal, weather, earthquake, elephant, device ──
+        // ── Fungal observations: distinct mushroom icon, larger and more visible ──
+        new IconLayer<UnifiedEntity>({
+          id: "crep-fungal",
+          data: fungal,
+          iconAtlas: FUNGAL_ICON,
+          iconMapping: ICON_MAPPING,
+          getIcon: () => "icon",
+          getPosition: getPos,
+          getSize: 16,
+          sizeUnits: "pixels",
+          sizeMinPixels: 8,
+          sizeMaxPixels: 32,
+          getColor: (e) => fungalEntityColor(e),
+          pickable: true,
+          onClick: handleClick,
+        }),
+
+        // ── Other entities: weather, earthquake, elephant, device ──
         new IconLayer<UnifiedEntity>({
           id: "crep-others",
           data: others,

--- a/components/crep/map-controls.tsx
+++ b/components/crep/map-controls.tsx
@@ -45,6 +45,20 @@ import {
   Pause,
   Circle,
   Info,
+  TreePine,
+  Bug,
+  Bird,
+  PawPrint,
+  Mountain,
+  Flame,
+  Droplets,
+  Radar,
+  Cpu,
+  Thermometer,
+  Droplet,
+  Wrench,
+  Power,
+  Fuel,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -105,6 +119,36 @@ export interface SpaceWeatherFilter {
   showSolarWind: boolean
 }
 
+export interface GroundFilter {
+  // Biodiversity & Wildlife
+  showFungi: boolean
+  showPlants: boolean
+  showBirds: boolean
+  showMammals: boolean
+  showReptiles: boolean
+  showInsects: boolean
+  showMarineLife: boolean
+  // Natural Events
+  showEarthquakes: boolean
+  showVolcanoes: boolean
+  showWildfires: boolean
+  showStorms: boolean
+  showLightning: boolean
+  showTornadoes: boolean
+  showFloods: boolean
+  // Infrastructure & Pollution
+  showFactories: boolean
+  showPowerPlants: boolean
+  showMining: boolean
+  showOilGas: boolean
+  showWaterPollution: boolean
+  // Sensors & Devices
+  showMycoBrain: boolean
+  showSporeBase: boolean
+  showSmartFence: boolean
+  showPartnerNetworks: boolean
+}
+
 export interface NOAAScales {
   radio: number    // R0-R5
   solar: number    // S0-S5
@@ -124,6 +168,7 @@ interface MapControlsProps {
   vesselFilter: VesselFilter
   satelliteFilter: SatelliteFilter
   spaceWeatherFilter: SpaceWeatherFilter
+  groundFilter: GroundFilter
   streamStatuses: StreamStatus[]
   isStreaming: boolean
   noaaScales?: NOAAScales  // Real-time NOAA space weather scales
@@ -131,6 +176,7 @@ interface MapControlsProps {
   onVesselFilterChange: (filter: Partial<VesselFilter>) => void
   onSatelliteFilterChange: (filter: Partial<SatelliteFilter>) => void
   onSpaceWeatherFilterChange: (filter: Partial<SpaceWeatherFilter>) => void
+  onGroundFilterChange: (filter: Partial<GroundFilter>) => void
   onToggleStreaming: () => void
   onRefresh: () => void
 }
@@ -144,6 +190,7 @@ export function MapControls({
   vesselFilter,
   satelliteFilter,
   spaceWeatherFilter,
+  groundFilter,
   streamStatuses,
   isStreaming,
   noaaScales,
@@ -151,10 +198,11 @@ export function MapControls({
   onVesselFilterChange,
   onSatelliteFilterChange,
   onSpaceWeatherFilterChange,
+  onGroundFilterChange,
   onToggleStreaming,
   onRefresh,
 }: MapControlsProps) {
-  const [activeTab, setActiveTab] = useState("aircraft")
+  const [activeTab, setActiveTab] = useState("ground")
   const [expanded, setExpanded] = useState(true)
 
   // Calculate active filter counts
@@ -253,7 +301,14 @@ export function MapControls({
 
           {/* Tabs */}
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="w-full h-8 rounded-none bg-black/50 border-b border-cyan-500/20 grid grid-cols-4 gap-0">
+            <TabsList className="w-full h-8 rounded-none bg-black/50 border-b border-cyan-500/20 grid grid-cols-5 gap-0">
+              <TabsTrigger
+                value="ground"
+                className="h-7 rounded-none text-[10px] data-[state=active]:bg-green-500/20 data-[state=active]:text-green-400"
+              >
+                <TreePine className="w-3 h-3 mr-1" />
+                GND
+              </TabsTrigger>
               <TabsTrigger
                 value="aircraft"
                 className="h-7 rounded-none text-[10px] data-[state=active]:bg-cyan-500/20 data-[state=active]:text-cyan-400"
@@ -285,6 +340,199 @@ export function MapControls({
             </TabsList>
 
             <ScrollArea className="h-[200px]">
+              {/* Ground Filters */}
+              <TabsContent value="ground" className="m-0 p-2 space-y-2">
+                {/* Biodiversity & Wildlife */}
+                <div className="space-y-1.5">
+                  <span className="text-[10px] text-green-400/70 uppercase font-medium">Biodiversity & Wildlife</span>
+                  <div className="grid grid-cols-2 gap-2">
+                    <FilterToggle
+                      label="Fungi"
+                      icon={<TreePine className="w-3 h-3" />}
+                      checked={groundFilter.showFungi}
+                      onChange={(v) => onGroundFilterChange({ showFungi: v })}
+                      color="orange"
+                      hint="Mushrooms"
+                    />
+                    <FilterToggle
+                      label="Plants"
+                      icon={<TreePine className="w-3 h-3" />}
+                      checked={groundFilter.showPlants}
+                      onChange={(v) => onGroundFilterChange({ showPlants: v })}
+                      color="green"
+                    />
+                    <FilterToggle
+                      label="Birds"
+                      icon={<Bird className="w-3 h-3" />}
+                      checked={groundFilter.showBirds}
+                      onChange={(v) => onGroundFilterChange({ showBirds: v })}
+                      color="blue"
+                    />
+                    <FilterToggle
+                      label="Mammals"
+                      icon={<PawPrint className="w-3 h-3" />}
+                      checked={groundFilter.showMammals}
+                      onChange={(v) => onGroundFilterChange({ showMammals: v })}
+                      color="orange"
+                    />
+                    <FilterToggle
+                      label="Reptiles"
+                      icon={<Bug className="w-3 h-3" />}
+                      checked={groundFilter.showReptiles}
+                      onChange={(v) => onGroundFilterChange({ showReptiles: v })}
+                      color="green"
+                    />
+                    <FilterToggle
+                      label="Insects"
+                      icon={<Bug className="w-3 h-3" />}
+                      checked={groundFilter.showInsects}
+                      onChange={(v) => onGroundFilterChange({ showInsects: v })}
+                      color="yellow"
+                    />
+                    <FilterToggle
+                      label="Marine Life"
+                      icon={<Fish className="w-3 h-3" />}
+                      checked={groundFilter.showMarineLife}
+                      onChange={(v) => onGroundFilterChange({ showMarineLife: v })}
+                      color="cyan"
+                    />
+                  </div>
+                </div>
+
+                {/* Natural Events */}
+                <div className="space-y-1.5 pt-2 border-t border-green-500/20">
+                  <span className="text-[10px] text-green-400/70 uppercase font-medium">Natural Events</span>
+                  <div className="grid grid-cols-2 gap-2">
+                    <FilterToggle
+                      label="Earthquakes"
+                      icon={<Activity className="w-3 h-3" />}
+                      checked={groundFilter.showEarthquakes}
+                      onChange={(v) => onGroundFilterChange({ showEarthquakes: v })}
+                      color="orange"
+                    />
+                    <FilterToggle
+                      label="Volcanoes"
+                      icon={<Mountain className="w-3 h-3" />}
+                      checked={groundFilter.showVolcanoes}
+                      onChange={(v) => onGroundFilterChange({ showVolcanoes: v })}
+                      color="red"
+                    />
+                    <FilterToggle
+                      label="Wildfires"
+                      icon={<Flame className="w-3 h-3" />}
+                      checked={groundFilter.showWildfires}
+                      onChange={(v) => onGroundFilterChange({ showWildfires: v })}
+                      color="red"
+                    />
+                    <FilterToggle
+                      label="Storms"
+                      icon={<Cloud className="w-3 h-3" />}
+                      checked={groundFilter.showStorms}
+                      onChange={(v) => onGroundFilterChange({ showStorms: v })}
+                      color="purple"
+                    />
+                    <FilterToggle
+                      label="Lightning"
+                      icon={<Zap className="w-3 h-3" />}
+                      checked={groundFilter.showLightning}
+                      onChange={(v) => onGroundFilterChange({ showLightning: v })}
+                      color="yellow"
+                    />
+                    <FilterToggle
+                      label="Tornadoes"
+                      icon={<Wind className="w-3 h-3" />}
+                      checked={groundFilter.showTornadoes}
+                      onChange={(v) => onGroundFilterChange({ showTornadoes: v })}
+                      color="purple"
+                    />
+                    <FilterToggle
+                      label="Floods"
+                      icon={<Droplets className="w-3 h-3" />}
+                      checked={groundFilter.showFloods}
+                      onChange={(v) => onGroundFilterChange({ showFloods: v })}
+                      color="blue"
+                    />
+                  </div>
+                </div>
+
+                {/* Infrastructure & Pollution */}
+                <div className="space-y-1.5 pt-2 border-t border-green-500/20">
+                  <span className="text-[10px] text-green-400/70 uppercase font-medium">Infrastructure & Pollution</span>
+                  <div className="grid grid-cols-2 gap-2">
+                    <FilterToggle
+                      label="Factories"
+                      icon={<Factory className="w-3 h-3" />}
+                      checked={groundFilter.showFactories}
+                      onChange={(v) => onGroundFilterChange({ showFactories: v })}
+                      color="orange"
+                    />
+                    <FilterToggle
+                      label="Power Plants"
+                      icon={<Power className="w-3 h-3" />}
+                      checked={groundFilter.showPowerPlants}
+                      onChange={(v) => onGroundFilterChange({ showPowerPlants: v })}
+                      color="yellow"
+                    />
+                    <FilterToggle
+                      label="Mining"
+                      icon={<Wrench className="w-3 h-3" />}
+                      checked={groundFilter.showMining}
+                      onChange={(v) => onGroundFilterChange({ showMining: v })}
+                      color="gray"
+                    />
+                    <FilterToggle
+                      label="Oil & Gas"
+                      icon={<Fuel className="w-3 h-3" />}
+                      checked={groundFilter.showOilGas}
+                      onChange={(v) => onGroundFilterChange({ showOilGas: v })}
+                      color="red"
+                    />
+                    <FilterToggle
+                      label="Water"
+                      icon={<Droplet className="w-3 h-3" />}
+                      checked={groundFilter.showWaterPollution}
+                      onChange={(v) => onGroundFilterChange({ showWaterPollution: v })}
+                      color="blue"
+                    />
+                  </div>
+                </div>
+
+                {/* Sensor Networks */}
+                <div className="space-y-1.5 pt-2 border-t border-green-500/20">
+                  <span className="text-[10px] text-green-400/70 uppercase font-medium">Sensor Networks</span>
+                  <div className="grid grid-cols-2 gap-2">
+                    <FilterToggle
+                      label="MycoBrain"
+                      icon={<Radar className="w-3 h-3" />}
+                      checked={groundFilter.showMycoBrain}
+                      onChange={(v) => onGroundFilterChange({ showMycoBrain: v })}
+                      color="green"
+                    />
+                    <FilterToggle
+                      label="SporeBase"
+                      icon={<Cpu className="w-3 h-3" />}
+                      checked={groundFilter.showSporeBase}
+                      onChange={(v) => onGroundFilterChange({ showSporeBase: v })}
+                      color="green"
+                    />
+                    <FilterToggle
+                      label="Smart Fence"
+                      icon={<Shield className="w-3 h-3" />}
+                      checked={groundFilter.showSmartFence}
+                      onChange={(v) => onGroundFilterChange({ showSmartFence: v })}
+                      color="cyan"
+                    />
+                    <FilterToggle
+                      label="Partners"
+                      icon={<Wifi className="w-3 h-3" />}
+                      checked={groundFilter.showPartnerNetworks}
+                      onChange={(v) => onGroundFilterChange({ showPartnerNetworks: v })}
+                      color="teal"
+                    />
+                  </div>
+                </div>
+              </TabsContent>
+
               {/* Aircraft Filters */}
               <TabsContent value="aircraft" className="m-0 p-2 space-y-2">
                 <div className="grid grid-cols-2 gap-2">

--- a/components/crep/markers/fungal-marker.tsx
+++ b/components/crep/markers/fungal-marker.tsx
@@ -51,6 +51,9 @@ export interface FungalObservation {
   // Source URL for "View on iNaturalist" / "View on GBIF" links
   sourceUrl?: string;
   externalId?: string;
+  // Kingdom/taxa classification for all-life support
+  kingdom?: string;
+  iconicTaxon?: string;
 }
 
 interface FungalMarkerProps {
@@ -105,24 +108,45 @@ function getExternalUrl(observation: FungalObservation): string {
   }
 }
 
+// Kingdom-specific styling for all-life support
+const KINGDOM_STYLES: Record<string, { emoji: string; bgColor: string; glowColor: string; borderColor: string; label: string }> = {
+  Fungi:            { emoji: "🍄", bgColor: "bg-amber-700",    glowColor: "#b45309", borderColor: "border-amber-600/40", label: "Fungus" },
+  Plantae:          { emoji: "🌿", bgColor: "bg-emerald-700",  glowColor: "#047857", borderColor: "border-emerald-600/40", label: "Plant" },
+  Aves:             { emoji: "🐦", bgColor: "bg-sky-700",      glowColor: "#0369a1", borderColor: "border-sky-600/40", label: "Bird" },
+  Mammalia:         { emoji: "🦊", bgColor: "bg-orange-700",   glowColor: "#c2410c", borderColor: "border-orange-600/40", label: "Mammal" },
+  Reptilia:         { emoji: "🦎", bgColor: "bg-lime-700",     glowColor: "#4d7c0f", borderColor: "border-lime-600/40", label: "Reptile" },
+  Amphibia:         { emoji: "🐸", bgColor: "bg-green-700",    glowColor: "#15803d", borderColor: "border-green-600/40", label: "Amphibian" },
+  Actinopterygii:   { emoji: "🐟", bgColor: "bg-cyan-700",     glowColor: "#0e7490", borderColor: "border-cyan-600/40", label: "Fish" },
+  Mollusca:         { emoji: "🐚", bgColor: "bg-rose-700",     glowColor: "#be123c", borderColor: "border-rose-600/40", label: "Mollusk" },
+  Arachnida:        { emoji: "🕷️", bgColor: "bg-red-800",      glowColor: "#991b1b", borderColor: "border-red-600/40", label: "Arachnid" },
+  Insecta:          { emoji: "🦋", bgColor: "bg-yellow-700",   glowColor: "#a16207", borderColor: "border-yellow-600/40", label: "Insect" },
+  Animalia:         { emoji: "🦌", bgColor: "bg-orange-700",   glowColor: "#c2410c", borderColor: "border-orange-600/40", label: "Animal" },
+};
+
+function getKingdomStyle(kingdom?: string, iconicTaxon?: string) {
+  const key = iconicTaxon || kingdom || "Fungi";
+  return KINGDOM_STYLES[key] || KINGDOM_STYLES.Fungi;
+}
+
 // Memoized component to prevent unnecessary re-renders when parent updates
 export const FungalMarker = memo(function FungalMarkerInner({ observation, isSelected = false, onClick, onClose }: FungalMarkerProps) {
   // Guard: Ensure coordinates are valid
   if (
-    typeof observation.latitude !== 'number' || 
-    typeof observation.longitude !== 'number' || 
-    isNaN(observation.latitude) || 
+    typeof observation.latitude !== 'number' ||
+    typeof observation.longitude !== 'number' ||
+    isNaN(observation.latitude) ||
     isNaN(observation.longitude) ||
     (observation.latitude === 0 && observation.longitude === 0)
   ) {
     return null;
   }
 
-  const speciesName = observation.taxon?.preferred_common_name || observation.species || observation.taxon?.name || "Unknown Fungus";
+  const speciesName = observation.taxon?.preferred_common_name || observation.species || observation.taxon?.name || "Unknown Species";
   const scientificName = observation.taxon?.name || observation.species || "";
   const isResearchGrade = observation.quality_grade === "research";
   const photoUrl = observation.photos?.[0]?.url;
   const sourceInfo = getSourceInfo(observation.source);
+  const kingdomStyle = getKingdomStyle(observation.kingdom, observation.iconicTaxon);
 
   return (
     <MapMarker 
@@ -135,35 +159,27 @@ export const FungalMarker = memo(function FungalMarkerInner({ observation, isSel
       <MarkerContent data-marker="fungal">
         <button
           onClick={(e) => {
-            e.stopPropagation(); // Prevent event from bubbling (backup for any edge cases)
+            e.stopPropagation();
           }}
           className={cn(
             "relative flex items-center justify-center transition-all duration-200 ease-in-out",
-            // Standard marker size - matches other event markers (w-6 h-6 = 24px)
             "w-6 h-6 rounded-full",
-            // BROWN/EARTHY styling to differentiate from red Amanita device markers
-            // Research grade = darker brown, needs ID = lighter tan
-            isResearchGrade 
-              ? "bg-amber-700 shadow-[0_0_4px_rgba(180,83,9,0.5)]" 
-              : "bg-amber-600/90 shadow-[0_0_3px_rgba(217,119,6,0.4)]",
-            isSelected 
-              ? "scale-150 ring-2 ring-white z-50" 
+            isResearchGrade
+              ? `${kingdomStyle.bgColor} shadow-[0_0_4px_rgba(180,83,9,0.5)]`
+              : `${kingdomStyle.bgColor}/90 shadow-[0_0_3px_rgba(217,119,6,0.4)]`,
+            isSelected
+              ? "scale-150 ring-2 ring-white z-50"
               : "hover:scale-125 z-10",
           )}
-          title={`🍄 ${speciesName}`}
+          title={`${kingdomStyle.emoji} ${speciesName} (${kingdomStyle.label})`}
         >
-          {/* Inner glow effect - brown/amber tones */}
-          <div 
+          <div
             className="absolute w-3 h-3 rounded-full blur-[2px] opacity-30"
-            style={{ backgroundColor: isResearchGrade ? "#b45309" : "#d97706" }}
+            style={{ backgroundColor: kingdomStyle.glowColor }}
           />
-          
-          {/* Icon - brown mushroom emoji with sepia filter for earthy look */}
-          <span className="relative text-xs" style={{ filter: "sepia(0.4) saturate(1.2)" }}>🍄</span>
-          
-          {/* Pulsing ring for research grade - amber/brown, only when selected */}
+          <span className="relative text-xs">{kingdomStyle.emoji}</span>
           {isResearchGrade && isSelected && (
-            <div className="absolute w-6 h-6 rounded-full animate-ping opacity-15 bg-amber-600 pointer-events-none" />
+            <div className={cn("absolute w-6 h-6 rounded-full animate-ping opacity-15 pointer-events-none", kingdomStyle.bgColor)} />
           )}
         </button>
       </MarkerContent>
@@ -173,23 +189,22 @@ export const FungalMarker = memo(function FungalMarkerInner({ observation, isSel
           Appears next to the marker when selected, rich data display
           ═══════════════════════════════════════════════════════════════════════════ */}
       {isSelected && (
-        <MarkerPopup 
-          className="min-w-[280px] max-w-[320px] bg-[#0a1628]/98 backdrop-blur-md border-amber-600/40 shadow-2xl shadow-amber-600/10 p-0 overflow-hidden"
+        <MarkerPopup
+          className={cn("min-w-[280px] max-w-[320px] bg-[#0a1628]/98 backdrop-blur-md shadow-2xl p-0 overflow-hidden", kingdomStyle.borderColor)}
           closeButton
           closeOnClick={false}
           anchor="bottom"
           offset={[0, -8]}
           onClose={onClose}
         >
-          {/* Compact Header with Species Name - BROWN/AMBER theme */}
+          {/* Compact Header with Species Name - Kingdom-themed */}
           <div className={cn(
-            "px-3 py-2 border-b border-amber-600/30",
-            isResearchGrade 
-              ? "bg-gradient-to-r from-amber-700/40 to-orange-700/20" 
-              : "bg-gradient-to-r from-amber-600/30 to-orange-600/10"
+            "px-3 py-2 border-b",
+            kingdomStyle.borderColor,
+            `${kingdomStyle.bgColor}/40`
           )}>
             <div className="flex items-start gap-2">
-              <span className="text-lg shrink-0" style={{ filter: "sepia(0.4) saturate(1.2)" }}>🍄</span>
+              <span className="text-lg shrink-0">{kingdomStyle.emoji}</span>
               <div className="min-w-0 flex-1">
                 <h3 className="text-sm font-bold text-white leading-tight truncate">
                   {speciesName}


### PR DESCRIPTION
…D filters

- Fix fungi green dots not clickable: add FungalMarker popup on deck.gl click, wire handleSelectFungal with smart auto-pan for popup visibility
- Add dedicated mushroom SVG icon for fungal entities in deck.gl layer
- Add kingdom-specific colors (per-taxon tinting) to fungal deck.gl IconLayer
- Expand MINDEX import route to fetch ALL life (all iconic taxa + all GBIF kingdoms)
- Expand CREP fungal API to serve all-life observations from MINDEX/iNaturalist/GBIF
- Add kingdom/iconicTaxon fields throughout the data pipeline
- Add kingdom-themed styling to FungalMarker popup (per-kingdom emoji, colors, labels)
- Add GND (ground) tab to map controls with 4 filter sections: biodiversity (fungi/plants/birds/mammals/reptiles/insects/marine), natural events (earthquakes/volcanoes/wildfires/storms/lightning/tornadoes/floods), infrastructure (factories/power/mining/oil-gas/water), sensor networks (MycoBrain/SporeBase/SmartFence/partners)
- Wire ground filters to control layer visibility and kingdom-based observation filtering

https://claude.ai/code/session_01CvSHkeV3yNKMQjryos7EpZ

## Summary by Sourcery

Expand the CREP fungal observation pipeline into an all-life biodiversity endpoint, add kingdom-aware visualization and controls, and make fungal markers fully interactive on the map.

New Features:
- Expose a unified CREP observation API that serves all-life biodiversity data with kingdom and iconic taxon metadata and kingdom filtering support.
- Introduce a new GND (ground) tab with biodiversity, natural events, infrastructure, and sensor network filters wired to map layer visibility.
- Render fungal and other biodiversity observations with a dedicated mushroom icon and kingdom-specific colors, and show a kingdom-themed popup for the selected observation.

Bug Fixes:
- Make fungal green dot markers interactive by routing deck.gl clicks through the fungal selection handler and displaying the FungalMarker popup.

Enhancements:
- Broaden MINDEX, iNaturalist, and GBIF ingestion to fetch and categorize observations across all iconic taxa and biological kingdoms, including metadata breakdowns in API responses.
- Filter visible fungal observations by selected kingdoms and viewport, and synchronize ground filter toggles with corresponding deck.gl layers for better map-level-of-detail control.
- Refine logging and metadata in CREP dashboard and MINDEX endpoints to reflect all-life coverage and report per-kingdom and per-source statistics.