### PR TITLE
Claude/fix crep dashboard f26f3

### DIFF
--- a/app/api/crep/health/route.ts
+++ b/app/api/crep/health/route.ts
@@ -1,36 +1,35 @@
 /**
- * CREP Health API – Feb 11, 2026
+ * CREP Health API
  *
  * Health check for CREP dashboard dependencies:
- * - MINDEX (fungal observations, primary data)
  * - MAS (entity stream WebSocket, global events)
+ * - MINDEX (fungal observations, primary data)
  *
- * Used by Fungi Compute control panel and CREP status widgets.
- * NO MOCK DATA – returns real connectivity status.
+ * Uses centralized API_URLS config — no hard-coded development IPs.
  */
 
 import { NextResponse } from "next/server"
+import { API_URLS } from "@/lib/config/api-urls"
 
 export const dynamic = "force-dynamic"
 
-const MAS_API_URL = process.env.MAS_API_URL || "http://192.168.0.188:8001"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://192.168.0.189:8000"
+interface ServiceHealth {
+  name: string
+  status: "online" | "offline" | "degraded"
+  latency_ms?: number
+  details?: string
+  url?: string
+}
 
 export async function GET() {
-  const services: {
-    name: string
-    status: "online" | "offline" | "degraded"
-    latency_ms?: number
-    details?: string
-  }[] = []
-
+  const services: ServiceHealth[] = []
   let status: "healthy" | "degraded" | "unhealthy" = "unhealthy"
 
   try {
     // 1. MAS health (entity stream, global events)
     const masStart = Date.now()
     try {
-      const masRes = await fetch(`${MAS_API_URL}/health`, {
+      const masRes = await fetch(`${API_URLS.MAS}/health`, {
         cache: "no-store",
         signal: AbortSignal.timeout(5000),
       })
@@ -40,6 +39,7 @@ export async function GET() {
         status: masRes.ok ? "online" : "degraded",
         latency_ms: masLatency,
         details: masRes.ok ? "Orchestrator reachable" : `HTTP ${masRes.status}`,
+        url: API_URLS.MAS,
       })
     } catch (e) {
       services.push({
@@ -47,13 +47,14 @@ export async function GET() {
         status: "offline",
         latency_ms: Date.now() - masStart,
         details: e instanceof Error ? e.message : "Connection failed",
+        url: API_URLS.MAS,
       })
     }
 
     // 2. MINDEX health (fungal observations)
     const mindexStart = Date.now()
     try {
-      const mindexRes = await fetch(`${MINDEX_API_URL}/health`, {
+      const mindexRes = await fetch(`${API_URLS.MINDEX}/health`, {
         cache: "no-store",
         signal: AbortSignal.timeout(5000),
       })
@@ -63,6 +64,7 @@ export async function GET() {
         status: mindexRes.ok ? "online" : "degraded",
         latency_ms: mindexLatency,
         details: mindexRes.ok ? "API reachable" : `HTTP ${mindexRes.status}`,
+        url: API_URLS.MINDEX,
       })
     } catch (e) {
       services.push({
@@ -70,6 +72,7 @@ export async function GET() {
         status: "offline",
         latency_ms: Date.now() - mindexStart,
         details: e instanceof Error ? e.message : "Connection failed",
+        url: API_URLS.MINDEX,
       })
     }
 
@@ -81,7 +84,7 @@ export async function GET() {
       status,
       services,
       timestamp: new Date().toISOString(),
-      crep_version: "2.0",
+      crep_version: "3.0",
     })
   } catch (error) {
     return NextResponse.json(

--- a/app/api/search/crep/route.ts
+++ b/app/api/search/crep/route.ts
@@ -1,0 +1,402 @@
+/**
+ * CREP Search API Route
+ *
+ * Provides bidirectional search integration between the CREP dashboard
+ * and the unified search system.
+ *
+ * Search → CREP:
+ * - Query CREP entities by keyword, location, type
+ * - Returns entities formatted for search result rendering
+ * - Supports the CrepWidget in search results
+ *
+ * CREP → Search:
+ * - Entity data enriched with MINDEX/MYCA context
+ * - Fungal observations with species details
+ * - Global events with impact analysis
+ * - Device sensor readings with environmental correlations
+ *
+ * GET /api/search/crep?q=query&type=aircraft&bounds=north,south,east,west&limit=50
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { API_URLS } from "@/lib/config/api-urls"
+
+export const dynamic = "force-dynamic"
+
+interface CREPSearchResult {
+  id: string
+  type: "aircraft" | "vessel" | "satellite" | "fungal" | "event" | "device"
+  title: string
+  description: string
+  latitude: number
+  longitude: number
+  altitude?: number
+  timestamp: string
+  source: string
+  properties: Record<string, unknown>
+  /** Search relevance score */
+  relevance: number
+  /** Can be opened on CREP map */
+  crepMapUrl: string
+}
+
+interface CREPSearchResponse {
+  results: CREPSearchResult[]
+  total: number
+  query: string
+  filters: Record<string, string>
+  timestamp: string
+  sources: string[]
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const query = searchParams.get("q") || ""
+  const type = searchParams.get("type") // aircraft, vessel, satellite, fungal, event, device
+  const limit = Math.min(parseInt(searchParams.get("limit") || "50"), 200)
+  const offset = parseInt(searchParams.get("offset") || "0")
+
+  // Bounds-based filtering
+  const north = parseFloat(searchParams.get("north") || "90")
+  const south = parseFloat(searchParams.get("south") || "-90")
+  const east = parseFloat(searchParams.get("east") || "180")
+  const west = parseFloat(searchParams.get("west") || "-180")
+
+  const results: CREPSearchResult[] = []
+  const sources: string[] = []
+  const startTime = Date.now()
+
+  try {
+    // Parallel fetch from relevant CREP data sources
+    const fetchPromises: Promise<void>[] = []
+
+    // Fungal observations (always included - primary data)
+    if (!type || type === "fungal") {
+      fetchPromises.push(
+        fetchFungalForSearch(query, { north, south, east, west }, limit).then((items) => {
+          results.push(...items)
+          if (items.length > 0) sources.push("MINDEX")
+        })
+      )
+    }
+
+    // Aircraft
+    if (!type || type === "aircraft") {
+      fetchPromises.push(
+        fetchAircraftForSearch(query, limit).then((items) => {
+          results.push(...items)
+          if (items.length > 0) sources.push("FlightRadar24")
+        })
+      )
+    }
+
+    // Global events
+    if (!type || type === "event") {
+      fetchPromises.push(
+        fetchEventsForSearch(query, limit).then((items) => {
+          results.push(...items)
+          if (items.length > 0) sources.push("USGS/NASA")
+        })
+      )
+    }
+
+    // Vessels
+    if (!type || type === "vessel") {
+      fetchPromises.push(
+        fetchVesselsForSearch(query, limit).then((items) => {
+          results.push(...items)
+          if (items.length > 0) sources.push("AISstream")
+        })
+      )
+    }
+
+    // Devices
+    if (!type || type === "device") {
+      fetchPromises.push(
+        fetchDevicesForSearch(query, limit).then((items) => {
+          results.push(...items)
+          if (items.length > 0) sources.push("MycoBrain")
+        })
+      )
+    }
+
+    await Promise.allSettled(fetchPromises)
+
+    // Sort by relevance (query match score)
+    results.sort((a, b) => b.relevance - a.relevance)
+
+    // Apply pagination
+    const paginatedResults = results.slice(offset, offset + limit)
+
+    return NextResponse.json({
+      results: paginatedResults,
+      total: results.length,
+      query,
+      filters: { type: type || "all", limit: String(limit), offset: String(offset) },
+      timestamp: new Date().toISOString(),
+      sources,
+      latency_ms: Date.now() - startTime,
+    } satisfies CREPSearchResponse & { latency_ms: number })
+  } catch (error) {
+    console.error("[CREP Search] Error:", error)
+    return NextResponse.json(
+      {
+        results: [],
+        total: 0,
+        query,
+        filters: {},
+        timestamp: new Date().toISOString(),
+        sources: [],
+        error: error instanceof Error ? error.message : "Search failed",
+      },
+      { status: 500 }
+    )
+  }
+}
+
+// ============================================================================
+// Data Fetchers
+// ============================================================================
+
+async function fetchFungalForSearch(
+  query: string,
+  bounds: { north: number; south: number; east: number; west: number },
+  limit: number
+): Promise<CREPSearchResult[]> {
+  try {
+    const url = new URL(`${API_URLS.LOCAL_BASE}/api/crep/fungal`)
+    if (query) url.searchParams.set("q", query)
+    url.searchParams.set("limit", String(limit))
+    url.searchParams.set("north", String(bounds.north))
+    url.searchParams.set("south", String(bounds.south))
+    url.searchParams.set("east", String(bounds.east))
+    url.searchParams.set("west", String(bounds.west))
+
+    const response = await fetch(url.toString(), { signal: AbortSignal.timeout(10000) })
+    if (!response.ok) return []
+
+    const data = await response.json()
+    const observations = data.observations || data.results || []
+
+    return observations.map((obs: Record<string, unknown>) => {
+      const species = String(obs.species || obs.species_name || "Unknown species")
+      const relevance = query
+        ? species.toLowerCase().includes(query.toLowerCase()) ? 0.9 : 0.5
+        : 0.7
+
+      return {
+        id: String(obs.id),
+        type: "fungal" as const,
+        title: String(obs.common_name || obs.commonName || species),
+        description: `${species} observed ${obs.location ? `at ${obs.location}` : ""} on ${obs.observed_on || obs.observedOn || "unknown date"}`,
+        latitude: Number(obs.latitude || obs.lat || 0),
+        longitude: Number(obs.longitude || obs.lng || 0),
+        timestamp: String(obs.observed_on || obs.observedOn || new Date().toISOString()),
+        source: String(obs.source || "MINDEX"),
+        properties: {
+          scientificName: obs.scientific_name || obs.scientificName,
+          commonName: obs.common_name || obs.commonName,
+          imageUrl: obs.image_url || obs.imageUrl,
+          thumbnailUrl: obs.thumbnail_url || obs.thumbnailUrl,
+          sourceUrl: obs.source_url || obs.sourceUrl,
+          isToxic: obs.is_toxic || obs.isToxic,
+          qualityGrade: obs.quality_grade || obs.qualityGrade,
+          observer: obs.observer,
+        },
+        relevance,
+        crepMapUrl: `/dashboard/crep?lat=${obs.latitude || obs.lat}&lng=${obs.longitude || obs.lng}&zoom=12&highlight=${obs.id}`,
+      }
+    })
+  } catch (error) {
+    console.warn("[CREP Search] Fungal fetch error:", error)
+    return []
+  }
+}
+
+async function fetchAircraftForSearch(
+  query: string,
+  limit: number
+): Promise<CREPSearchResult[]> {
+  try {
+    const response = await fetch(`${API_URLS.LOCAL_BASE}/api/oei/flightradar24`, {
+      signal: AbortSignal.timeout(10000),
+    })
+    if (!response.ok) return []
+
+    const data = await response.json()
+    const aircraft = data.aircraft || []
+
+    return aircraft
+      .filter((a: Record<string, unknown>) => {
+        if (!query) return true
+        const searchable = `${a.callsign || ""} ${a.origin || ""} ${a.destination || ""} ${a.type || ""}`.toLowerCase()
+        return searchable.includes(query.toLowerCase())
+      })
+      .slice(0, limit)
+      .map((a: Record<string, unknown>) => ({
+        id: String(a.id || a.icao24),
+        type: "aircraft" as const,
+        title: String(a.callsign || a.flightNumber || a.id),
+        description: `${a.type || "Aircraft"} ${a.origin && a.destination ? `from ${a.origin} to ${a.destination}` : ""} at ${a.altitude || 0}ft`,
+        latitude: Number(a.lat || a.latitude || 0),
+        longitude: Number(a.lng || a.longitude || 0),
+        altitude: Number(a.altitude || 0),
+        timestamp: String(a.lastSeen || new Date().toISOString()),
+        source: "FlightRadar24",
+        properties: {
+          callsign: a.callsign,
+          aircraftType: a.type || a.aircraftType,
+          origin: a.origin,
+          destination: a.destination,
+          speed: a.speed || a.velocity,
+          heading: a.heading,
+        },
+        relevance: query
+          ? String(a.callsign || "").toLowerCase().includes(query.toLowerCase()) ? 0.95 : 0.6
+          : 0.5,
+        crepMapUrl: `/dashboard/crep?lat=${a.lat || a.latitude}&lng=${a.lng || a.longitude}&zoom=8&highlight=${a.id}`,
+      }))
+  } catch (error) {
+    console.warn("[CREP Search] Aircraft fetch error:", error)
+    return []
+  }
+}
+
+async function fetchEventsForSearch(
+  query: string,
+  limit: number
+): Promise<CREPSearchResult[]> {
+  try {
+    const response = await fetch(`${API_URLS.LOCAL_BASE}/api/natureos/global-events`, {
+      signal: AbortSignal.timeout(10000),
+    })
+    if (!response.ok) return []
+
+    const data = await response.json()
+    const events = data.events || []
+
+    return events
+      .filter((e: Record<string, unknown>) => {
+        if (!query) return true
+        const searchable = `${e.title || ""} ${e.type || ""} ${e.description || ""}`.toLowerCase()
+        return searchable.includes(query.toLowerCase())
+      })
+      .slice(0, limit)
+      .map((e: Record<string, unknown>) => ({
+        id: String(e.id),
+        type: "event" as const,
+        title: String(e.title || e.type || "Unknown event"),
+        description: String(e.description || `${e.type} event - severity: ${e.severity || "unknown"}`),
+        latitude: Number(e.lat || e.latitude || 0),
+        longitude: Number(e.lng || e.longitude || 0),
+        timestamp: String(e.timestamp || new Date().toISOString()),
+        source: String(e.source || "USGS/NASA"),
+        properties: {
+          severity: e.severity,
+          eventType: e.type,
+          magnitude: e.magnitude,
+          sourceUrl: e.sourceUrl || e.link,
+        },
+        relevance: query
+          ? String(e.title || "").toLowerCase().includes(query.toLowerCase()) ? 0.9 : 0.6
+          : 0.6,
+        crepMapUrl: `/dashboard/crep?lat=${e.lat || e.latitude}&lng=${e.lng || e.longitude}&zoom=8&highlight=${e.id}`,
+      }))
+  } catch (error) {
+    console.warn("[CREP Search] Events fetch error:", error)
+    return []
+  }
+}
+
+async function fetchVesselsForSearch(
+  query: string,
+  limit: number
+): Promise<CREPSearchResult[]> {
+  try {
+    const response = await fetch(`${API_URLS.LOCAL_BASE}/api/oei/aisstream`, {
+      signal: AbortSignal.timeout(10000),
+    })
+    if (!response.ok) return []
+
+    const data = await response.json()
+    const vessels = data.vessels || []
+
+    return vessels
+      .filter((v: Record<string, unknown>) => {
+        if (!query) return true
+        const searchable = `${v.name || ""} ${v.mmsi || ""} ${v.destination || ""}`.toLowerCase()
+        return searchable.includes(query.toLowerCase())
+      })
+      .slice(0, limit)
+      .map((v: Record<string, unknown>) => ({
+        id: String(v.id || v.mmsi),
+        type: "vessel" as const,
+        title: String(v.name || v.mmsi || "Unknown vessel"),
+        description: `${v.type || "Vessel"} ${v.destination ? `bound for ${v.destination}` : ""} at ${v.speed || v.sog || 0}kts`,
+        latitude: Number(v.lat || v.latitude || 0),
+        longitude: Number(v.lng || v.longitude || 0),
+        timestamp: String(v.lastSeen || new Date().toISOString()),
+        source: "AISstream",
+        properties: {
+          mmsi: v.mmsi,
+          shipType: v.type || v.shipType,
+          destination: v.destination,
+          flag: v.flag,
+          speed: v.speed || v.sog,
+        },
+        relevance: query
+          ? String(v.name || "").toLowerCase().includes(query.toLowerCase()) ? 0.9 : 0.5
+          : 0.4,
+        crepMapUrl: `/dashboard/crep?lat=${v.lat || v.latitude}&lng=${v.lng || v.longitude}&zoom=8&highlight=${v.id}`,
+      }))
+  } catch (error) {
+    console.warn("[CREP Search] Vessels fetch error:", error)
+    return []
+  }
+}
+
+async function fetchDevicesForSearch(
+  query: string,
+  limit: number
+): Promise<CREPSearchResult[]> {
+  try {
+    const response = await fetch(`${API_URLS.LOCAL_BASE}/api/mycobrain/devices`, {
+      signal: AbortSignal.timeout(10000),
+    })
+    if (!response.ok) return []
+
+    const data = await response.json()
+    const devices = data.devices || []
+
+    return devices
+      .filter((d: Record<string, unknown>) => {
+        if (!query) return true
+        const searchable = `${d.name || ""} ${d.type || ""} ${d.status || ""}`.toLowerCase()
+        return searchable.includes(query.toLowerCase())
+      })
+      .slice(0, limit)
+      .map((d: Record<string, unknown>) => ({
+        id: String(d.id),
+        type: "device" as const,
+        title: String(d.name || d.id),
+        description: `${d.type || "MycoBrain"} device - ${d.status || "unknown"}`,
+        latitude: Number(d.lat || d.latitude || 0),
+        longitude: Number(d.lng || d.longitude || 0),
+        timestamp: String(d.lastSeen || d.lastUpdate || new Date().toISOString()),
+        source: "MycoBrain",
+        properties: {
+          deviceType: d.type,
+          status: d.status,
+          firmware: d.firmware,
+          sensorData: d.sensorData,
+        },
+        relevance: query
+          ? String(d.name || "").toLowerCase().includes(query.toLowerCase()) ? 0.85 : 0.5
+          : 0.5,
+        crepMapUrl: `/dashboard/crep?lat=${d.lat || d.latitude}&lng=${d.lng || d.longitude}&zoom=14&highlight=${d.id}`,
+      }))
+  } catch (error) {
+    console.warn("[CREP Search] Devices fetch error:", error)
+    return []
+  }
+}

--- a/app/api/stream/crep/route.ts
+++ b/app/api/stream/crep/route.ts
@@ -1,162 +1,172 @@
 /**
- * CREP/OEI Dashboard Stream API - February 12, 2026
- * 
+ * CREP/OEI Dashboard Stream API
+ *
  * Server-Sent Events (SSE) proxy to MAS WebSocket for CREP dashboard.
  * Converts WebSocket stream from MAS to SSE for browser consumption.
- * 
- * Real-time data from:
- * - Aviation tracking (aircraft positions)
- * - Maritime tracking (vessel positions)
- * - Satellite tracking
- * - Weather updates
- * 
- * NO MOCK DATA - Proxies Redis pub/sub via MAS WebSocket
+ *
+ * Uses centralized API_URLS config — no hard-coded development IPs.
  */
 
-import { NextRequest } from 'next/server';
+import { NextRequest } from "next/server"
+import { API_URLS } from "@/lib/config/api-urls"
 
-const MAS_API_URL = process.env.MAS_API_URL || 'http://192.168.0.188:8001';
-const MAS_WS_URL = MAS_API_URL.replace('http://', 'ws://').replace('https://', 'wss://');
+const MAS_API_URL = API_URLS.MAS
+const MAS_WS_URL = MAS_API_URL.replace("http://", "ws://").replace("https://", "wss://")
 
-export const runtime = 'nodejs';
-export const dynamic = 'force-dynamic';
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
 
 /**
  * GET /api/stream/crep
- * 
+ *
  * Server-Sent Events endpoint for CREP/OEI dashboard live data.
  * Connects to MAS WebSocket and converts to SSE for browser.
- * 
+ *
  * Query params:
  * - category: Optional filter (aircraft, vessel, satellite, weather)
  */
 export async function GET(request: NextRequest) {
-  const encoder = new TextEncoder();
-  const { searchParams } = new URL(request.url);
-  const category = searchParams.get('category');
+  const encoder = new TextEncoder()
+  const { searchParams } = new URL(request.url)
+  const category = searchParams.get("category")
 
   const customReadable = new ReadableStream({
     async start(controller) {
-      let ws: WebSocket | null = null;
-      let heartbeatInterval: NodeJS.Timeout | null = null;
+      let heartbeatInterval: NodeJS.Timeout | null = null
 
       try {
         // Connect to MAS WebSocket
-        let wsUrl = `${MAS_WS_URL}/api/crep/stream`;
+        let wsUrl = `${MAS_WS_URL}/api/crep/stream`
         if (category) {
-          wsUrl += `?category=${encodeURIComponent(category)}`;
+          wsUrl += `?category=${encodeURIComponent(category)}`
         }
-        
+
         // Use Node.js WebSocket (ws package)
-        const WebSocket = (await import('ws')).default;
-        const wsInstance = new WebSocket(wsUrl) as any;
-        ws = wsInstance;
+        const WebSocketModule = await import("ws")
+        const WS = WebSocketModule.default
+        const wsInstance = new WS(wsUrl)
 
         // Send initial connection message
         controller.enqueue(
-          encoder.encode(`event: connected\ndata: ${JSON.stringify({
-            message: 'CREP stream connected',
-            category: category || 'all',
-            timestamp: new Date().toISOString()
-          })}\n\n`)
-        );
+          encoder.encode(
+            `event: connected\ndata: ${JSON.stringify({
+              message: "CREP stream connected",
+              category: category || "all",
+              masUrl: MAS_API_URL,
+              timestamp: new Date().toISOString(),
+            })}\n\n`
+          )
+        )
 
         // WebSocket open handler
-        wsInstance.on('open', () => {
-          console.log('[CREP Stream] WebSocket connected', category ? `(filter: ${category})` : '');
+        wsInstance.on("open", () => {
+          console.log(
+            "[CREP Stream] WebSocket connected to MAS",
+            category ? `(filter: ${category})` : ""
+          )
 
           // Start heartbeat
           heartbeatInterval = setInterval(() => {
-            if (wsInstance && wsInstance.readyState === WebSocket.OPEN) {
-              wsInstance.send(JSON.stringify({ type: 'ping' }));
+            if (wsInstance.readyState === WS.OPEN) {
+              wsInstance.send(JSON.stringify({ type: "ping" }))
             }
-          }, 30000); // 30 seconds
-        });
+          }, 30000)
+        })
 
         // WebSocket message handler
-        wsInstance.on('message', (data: Buffer) => {
+        wsInstance.on("message", (data: Buffer) => {
           try {
-            const message = JSON.parse(data.toString());
-            
+            const message = JSON.parse(data.toString())
+
             // Forward to SSE client
-            const eventType = message.type || 'message';
-            const eventData = JSON.stringify(message);
-            
-            controller.enqueue(
-              encoder.encode(`event: ${eventType}\ndata: ${eventData}\n\n`)
-            );
+            const eventType = message.type || "message"
+            const eventData = JSON.stringify(message)
+
+            controller.enqueue(encoder.encode(`event: ${eventType}\ndata: ${eventData}\n\n`))
           } catch (error) {
-            console.error('[CREP Stream] Message parse error:', error);
+            console.error("[CREP Stream] Message parse error:", error)
           }
-        });
+        })
 
         // WebSocket error handler
-        wsInstance.on('error', (error: any) => {
-          console.error('[CREP Stream] WebSocket error:', error);
-          
+        wsInstance.on("error", (error: Error) => {
+          console.error("[CREP Stream] WebSocket error:", error.message)
+
           controller.enqueue(
-            encoder.encode(`event: error\ndata: ${JSON.stringify({
-              error: 'WebSocket error',
-              message: error.message || 'Unknown error',
-              timestamp: new Date().toISOString()
-            })}\n\n`)
-          );
-        });
+            encoder.encode(
+              `event: error\ndata: ${JSON.stringify({
+                error: "WebSocket error",
+                message: error.message || "Unknown error",
+                timestamp: new Date().toISOString(),
+              })}\n\n`
+            )
+          )
+        })
 
         // WebSocket close handler
-        wsInstance.on('close', () => {
-          console.log('[CREP Stream] WebSocket closed');
-          
+        wsInstance.on("close", (code: number, reason: Buffer) => {
+          console.log(`[CREP Stream] WebSocket closed (code: ${code}, reason: ${reason.toString() || "none"})`)
+
           if (heartbeatInterval) {
-            clearInterval(heartbeatInterval);
+            clearInterval(heartbeatInterval)
           }
-          
+
           controller.enqueue(
-            encoder.encode(`event: disconnected\ndata: ${JSON.stringify({
-              message: 'CREP stream disconnected',
-              timestamp: new Date().toISOString()
-            })}\n\n`)
-          );
-          
-          controller.close();
-        });
+            encoder.encode(
+              `event: disconnected\ndata: ${JSON.stringify({
+                message: "CREP stream disconnected",
+                code,
+                timestamp: new Date().toISOString(),
+              })}\n\n`
+            )
+          )
+
+          controller.close()
+        })
 
         // Handle client disconnect
-        request.signal.addEventListener('abort', () => {
-          console.log('[CREP Stream] Client disconnected');
-          
+        request.signal.addEventListener("abort", () => {
+          console.log("[CREP Stream] Client disconnected")
+
           if (heartbeatInterval) {
-            clearInterval(heartbeatInterval);
+            clearInterval(heartbeatInterval)
           }
-          
-          if (wsInstance && wsInstance.readyState === WebSocket.OPEN) {
-            wsInstance.close();
+
+          if (wsInstance.readyState === WS.OPEN) {
+            wsInstance.close()
           }
-          
-          controller.close();
-        });
+
+          try {
+            controller.close()
+          } catch {
+            // Stream may already be closed
+          }
+        })
       } catch (error) {
-        console.error('[CREP Stream] Setup error:', error);
-        
+        console.error("[CREP Stream] Setup error:", error)
+
         controller.enqueue(
-          encoder.encode(`event: error\ndata: ${JSON.stringify({
-            error: 'Connection setup failed',
-            message: error instanceof Error ? error.message : 'Unknown error',
-            timestamp: new Date().toISOString()
-          })}\n\n`)
-        );
-        
-        controller.close();
+          encoder.encode(
+            `event: error\ndata: ${JSON.stringify({
+              error: "Connection setup failed",
+              message: error instanceof Error ? error.message : "Unknown error",
+              masUrl: MAS_API_URL,
+              timestamp: new Date().toISOString(),
+            })}\n\n`
+          )
+        )
+
+        controller.close()
       }
-    }
-  });
+    },
+  })
 
   return new Response(customReadable, {
     headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache, no-transform',
-      'Connection': 'keep-alive',
-      'X-Accel-Buffering': 'no', // Disable nginx buffering
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
     },
-  });
+  })
 }

--- a/app/dashboard/crep/CREPDashboardLoader.tsx
+++ b/app/dashboard/crep/CREPDashboardLoader.tsx
@@ -12,6 +12,8 @@ import nextDynamic from "next/dynamic"
 import { RefreshCw, Map, Monitor, Tablet } from "lucide-react"
 import Link from "next/link"
 import { MYCAProvider } from "@/contexts/myca-context"
+import { CREPProvider } from "@/contexts/crep-context"
+import { CREPErrorBoundary } from "@/components/crep/crep-error-boundary"
 
 const CREPDashboardClient = nextDynamic(
   () => import("./CREPDashboardClient"),
@@ -74,7 +76,11 @@ export default function CREPDashboardLoader() {
       {/* Tablet+: full WebGL dashboard */}
       <div className="hidden md:block">
         <MYCAProvider>
-          <CREPDashboardClient />
+          <CREPProvider>
+            <CREPErrorBoundary componentName="CREP Dashboard">
+              <CREPDashboardClient />
+            </CREPErrorBoundary>
+          </CREPProvider>
         </MYCAProvider>
       </div>
     </>

--- a/components/crep/crep-error-boundary.tsx
+++ b/components/crep/crep-error-boundary.tsx
@@ -1,0 +1,159 @@
+/**
+ * CREP Error Boundary
+ *
+ * Catches rendering errors in any CREP component and provides
+ * graceful degradation instead of crashing the entire dashboard.
+ *
+ * Features:
+ * - Component-level error isolation
+ * - Retry mechanism
+ * - Error reporting to console
+ * - Fallback UI that matches CREP dark tactical theme
+ */
+
+"use client"
+
+import React from "react"
+import { AlertTriangle, RotateCcw, Bug } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface CREPErrorBoundaryProps {
+  children: React.ReactNode
+  /** Name of the component for error reporting */
+  componentName?: string
+  /** Compact mode for widgets/panels */
+  compact?: boolean
+  /** Custom fallback UI */
+  fallback?: React.ReactNode
+  /** Called when an error occurs */
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void
+}
+
+interface CREPErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+  errorInfo: React.ErrorInfo | null
+  retryCount: number
+}
+
+export class CREPErrorBoundary extends React.Component<
+  CREPErrorBoundaryProps,
+  CREPErrorBoundaryState
+> {
+  constructor(props: CREPErrorBoundaryProps) {
+    super(props)
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      retryCount: 0,
+    }
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<CREPErrorBoundaryState> {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    const componentName = this.props.componentName || "Unknown CREP Component"
+
+    console.error(
+      `[CREP Error Boundary] Error in ${componentName}:`,
+      error,
+      errorInfo.componentStack
+    )
+
+    this.setState({ errorInfo })
+    this.props.onError?.(error, errorInfo)
+  }
+
+  handleRetry = (): void => {
+    this.setState((prev) => ({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      retryCount: prev.retryCount + 1,
+    }))
+  }
+
+  render(): React.ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children
+    }
+
+    if (this.props.fallback) {
+      return this.props.fallback
+    }
+
+    const { compact, componentName } = this.props
+    const { error, retryCount } = this.state
+    const maxRetries = 3
+
+    if (compact) {
+      return (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20">
+          <AlertTriangle className="w-3.5 h-3.5 text-red-400 shrink-0" />
+          <span className="text-[10px] text-red-300 truncate">
+            {componentName || "Component"} error
+          </span>
+          {retryCount < maxRetries && (
+            <button
+              onClick={this.handleRetry}
+              className="ml-auto text-[9px] text-red-400 hover:text-red-300 underline shrink-0"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      )
+    }
+
+    return (
+      <div className="flex flex-col items-center justify-center p-6 rounded-xl bg-[#0a0f1e]/80 border border-red-500/20 space-y-3">
+        <div className="p-3 rounded-full bg-red-500/10">
+          <Bug className="w-6 h-6 text-red-400" />
+        </div>
+        <div className="text-center space-y-1">
+          <p className="text-sm font-medium text-red-300">
+            {componentName || "Component"} Error
+          </p>
+          <p className="text-xs text-gray-500 max-w-[300px]">
+            {error?.message || "An unexpected error occurred"}
+          </p>
+        </div>
+        {retryCount < maxRetries ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={this.handleRetry}
+            className="text-xs border-red-500/30 text-red-300 hover:bg-red-500/10"
+          >
+            <RotateCcw className="w-3.5 h-3.5 mr-1.5" />
+            Retry ({maxRetries - retryCount} left)
+          </Button>
+        ) : (
+          <p className="text-[10px] text-gray-600">
+            Max retries reached. Reload the page to try again.
+          </p>
+        )}
+      </div>
+    )
+  }
+}
+
+/**
+ * Convenience wrapper for wrapping individual CREP components
+ */
+export function withCREPErrorBoundary<P extends object>(
+  WrappedComponent: React.ComponentType<P>,
+  componentName: string,
+  compact = false
+): React.FC<P> {
+  const Wrapped: React.FC<P> = (props) => (
+    <CREPErrorBoundary componentName={componentName} compact={compact}>
+      <WrappedComponent {...props} />
+    </CREPErrorBoundary>
+  )
+  Wrapped.displayName = `withCREPErrorBoundary(${componentName})`
+  return Wrapped
+}

--- a/components/crep/voice-map-controls.tsx
+++ b/components/crep/voice-map-controls.tsx
@@ -64,24 +64,16 @@ export function VoiceMapControls({
   const inputRef = useRef<HTMLInputElement>(null)
   
   // PersonaPlex context (from app-level provider)
+  // Type-safe access with fallback defaults when PersonaPlex is not available
   const personaplex = usePersonaPlexContext()
-  const {
-    isListening,
-    lastTranscript,
-    startListening,
-    stopListening,
-    isConnected: voiceConnected,
-    connectionState,
-    isSpeaking
-  } = (personaplex as any) || {
-    isListening: false,
-    lastTranscript: "",
-    startListening: () => {},
-    stopListening: () => {},
-    isConnected: false,
-    connectionState: "disconnected",
-    isSpeaking: false,
-  }
+  const ppCtx = personaplex as Record<string, unknown> | null
+  const isListening = (ppCtx?.isListening as boolean) ?? false
+  const lastTranscript = (ppCtx?.lastTranscript as string) ?? ""
+  const startListening = (ppCtx?.startListening as () => void) ?? (() => {})
+  const stopListening = (ppCtx?.stopListening as () => void) ?? (() => {})
+  const voiceConnected = (ppCtx?.isConnected as boolean) ?? false
+  const connectionState = (ppCtx?.connectionState as string) ?? "disconnected"
+  const isSpeaking = (ppCtx?.isSpeaking as boolean) ?? false
   
   // Adapter functions to convert old API to new MapCommandHandlers format
   const handleZoom = useCallback((direction: "in" | "out") => {

--- a/components/search/fluid/FluidSearchCanvas.tsx
+++ b/components/search/fluid/FluidSearchCanvas.tsx
@@ -548,9 +548,9 @@ export function FluidSearchCanvas({
     { revalidateOnFocus: false, dedupingInterval: 30000 }
   )
   
-  // CREP fungal observations data fetcher
+  // CREP data fetcher - uses both fungal endpoint and new CREP search API
   const { data: crepData } = useSWR(
-    debouncedQuery && debouncedQuery.length >= 2 ? `/api/crep/fungal?species=${encodeURIComponent(debouncedQuery)}&limit=20` : null,
+    debouncedQuery && debouncedQuery.length >= 2 ? `/api/search/crep?q=${encodeURIComponent(debouncedQuery)}&limit=20` : null,
     async (url) => { const res = await fetch(url); return res.json() },
     { revalidateOnFocus: false, dedupingInterval: 15000 }
   )
@@ -570,7 +570,27 @@ export function FluidSearchCanvas({
   const newsResults = newsData?.results || []
   const newsError = newsData?.error
   const newsQueryUsed = newsData?.queryUsed as string | undefined
-  const crepResults = useMemo(() => crepData?.observations || [], [crepData])
+  const crepResults = useMemo(() => {
+    // Support both old format (observations) and new CREP search format (results)
+    const results = crepData?.results || crepData?.observations || []
+    return results.map((r: Record<string, unknown>) => ({
+      id: r.id,
+      species: r.title || r.species,
+      scientificName: r.properties?.scientificName || r.scientificName || r.title,
+      commonName: r.properties?.commonName || r.commonName,
+      latitude: r.latitude || r.lat || 0,
+      longitude: r.longitude || r.lng || 0,
+      timestamp: r.timestamp || r.observed_on,
+      source: r.source || "CREP",
+      verified: r.properties?.qualityGrade === "research",
+      imageUrl: r.properties?.imageUrl || r.imageUrl || r.image_url,
+      thumbnailUrl: r.properties?.thumbnailUrl || r.thumbnailUrl || r.thumbnail_url,
+      location: r.description || r.location,
+      sourceUrl: r.properties?.sourceUrl || r.sourceUrl || r.crepMapUrl,
+      isToxic: r.properties?.isToxic || r.isToxic,
+      type: r.type || "fungal",
+    }))
+  }, [crepData])
   const earth2Data = earth2RawData?.available ? earth2RawData : null
   
   // Map observations from location and CREP data

--- a/components/search/fluid/widgets/CrepWidget.tsx
+++ b/components/search/fluid/widgets/CrepWidget.tsx
@@ -34,7 +34,7 @@ export interface CrepObservation {
   latitude: number
   longitude: number
   timestamp: string
-  source: "MINDEX" | "iNaturalist" | "GBIF"
+  source: "MINDEX" | "iNaturalist" | "GBIF" | "FlightRadar24" | "AISstream" | "MycoBrain" | "USGS/NASA" | "CREP" | string
   verified: boolean
   observer?: string
   imageUrl?: string
@@ -42,6 +42,8 @@ export interface CrepObservation {
   location?: string
   sourceUrl?: string
   isToxic?: boolean
+  /** Entity type for CREP search results (aircraft, vessel, event, device, fungal) */
+  type?: string
 }
 
 interface CrepWidgetProps {
@@ -126,13 +128,24 @@ export function CrepWidget({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Radar className="h-4 w-4 text-cyan-400" />
-          <span className="text-sm font-medium">{data.length} observations</span>
+          <span className="text-sm font-medium">{data.length} results</span>
           {recentCount > 0 && (
             <span className="text-xs px-2 py-0.5 rounded-full bg-cyan-500/20 text-cyan-300">
               {recentCount} recent
             </span>
           )}
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-cyan-400 hover:text-cyan-300 hover:bg-cyan-500/10"
+          asChild
+        >
+          <a href="/dashboard/crep" target="_blank" rel="noopener noreferrer">
+            Open CREP Map
+            <ExternalLink className="h-3 w-3 ml-1" />
+          </a>
+        </Button>
       </div>
 
       {/* Source filters */}

--- a/contexts/crep-context.tsx
+++ b/contexts/crep-context.tsx
@@ -1,0 +1,604 @@
+/**
+ * CREP Dashboard Context
+ *
+ * Top-level context provider for the CREP dashboard. Replaces 30+ useState
+ * hooks and 15+ prop-drilled handlers with structured context.
+ *
+ * Sub-contexts:
+ * - CREPEntityContext: entity data (aircraft, vessels, satellites, etc.)
+ * - CREPMapContext: map operations (flyTo, zoom, pan, view state)
+ * - CREPLayerContext: layer visibility and filtering
+ * - CREPMissionContext: mission state and objectives
+ *
+ * MYCA and MINDEX integration is handled through the existing MYCAProvider
+ * and dedicated bridge hooks.
+ */
+
+"use client"
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react"
+import type { UnifiedEntity } from "@/lib/crep/entities/unified-entity-schema"
+import { EntityStreamClient, type ConnectionState } from "@/lib/crep/streaming/entity-websocket-client"
+
+// ============================================================================
+// Entity Context
+// ============================================================================
+
+export interface CREPEntityState {
+  aircraft: UnifiedEntity[]
+  vessels: UnifiedEntity[]
+  satellites: UnifiedEntity[]
+  fungalObservations: UnifiedEntity[]
+  globalEvents: UnifiedEntity[]
+  devices: UnifiedEntity[]
+  /** All entities in a flat list for deck.gl rendering */
+  allEntities: UnifiedEntity[]
+  /** Currently selected entity */
+  selectedEntity: UnifiedEntity | null
+  /** Loading state per entity type */
+  loading: Record<string, boolean>
+  /** Error state per entity type */
+  errors: Record<string, string | null>
+  /** Last data refresh timestamp */
+  lastRefresh: Record<string, number>
+}
+
+type EntityAction =
+  | { type: "SET_ENTITIES"; entityType: string; entities: UnifiedEntity[] }
+  | { type: "ADD_ENTITY"; entity: UnifiedEntity }
+  | { type: "UPDATE_ENTITY"; entity: UnifiedEntity }
+  | { type: "SELECT_ENTITY"; entity: UnifiedEntity | null }
+  | { type: "SET_LOADING"; entityType: string; loading: boolean }
+  | { type: "SET_ERROR"; entityType: string; error: string | null }
+  | { type: "CLEAR_ALL" }
+
+function entityReducer(state: CREPEntityState, action: EntityAction): CREPEntityState {
+  switch (action.type) {
+    case "SET_ENTITIES": {
+      const newState = { ...state }
+      const key = action.entityType as keyof Pick<
+        CREPEntityState,
+        "aircraft" | "vessels" | "satellites" | "fungalObservations" | "globalEvents" | "devices"
+      >
+      if (key in newState && Array.isArray(newState[key])) {
+        ;(newState as Record<string, unknown>)[key] = action.entities
+      }
+      newState.lastRefresh = {
+        ...newState.lastRefresh,
+        [action.entityType]: Date.now(),
+      }
+      // Rebuild allEntities
+      newState.allEntities = [
+        ...newState.aircraft,
+        ...newState.vessels,
+        ...newState.satellites,
+        ...newState.fungalObservations,
+        ...newState.globalEvents,
+        ...newState.devices,
+      ]
+      return newState
+    }
+    case "ADD_ENTITY": {
+      const e = action.entity
+      const typeKey = getEntityTypeKey(e.type)
+      if (!typeKey) return state
+      const newState = { ...state }
+      const existing = (newState as Record<string, unknown>)[typeKey] as UnifiedEntity[]
+      const idx = existing.findIndex((x) => x.id === e.id)
+      if (idx >= 0) {
+        const updated = [...existing]
+        updated[idx] = e
+        ;(newState as Record<string, unknown>)[typeKey] = updated
+      } else {
+        ;(newState as Record<string, unknown>)[typeKey] = [...existing, e]
+      }
+      newState.allEntities = [
+        ...newState.aircraft,
+        ...newState.vessels,
+        ...newState.satellites,
+        ...newState.fungalObservations,
+        ...newState.globalEvents,
+        ...newState.devices,
+      ]
+      return newState
+    }
+    case "UPDATE_ENTITY": {
+      const e = action.entity
+      const typeKey = getEntityTypeKey(e.type)
+      if (!typeKey) return state
+      const newState = { ...state }
+      const existing = (newState as Record<string, unknown>)[typeKey] as UnifiedEntity[]
+      const idx = existing.findIndex((x) => x.id === e.id)
+      if (idx >= 0) {
+        const updated = [...existing]
+        updated[idx] = e
+        ;(newState as Record<string, unknown>)[typeKey] = updated
+        newState.allEntities = [
+          ...newState.aircraft,
+          ...newState.vessels,
+          ...newState.satellites,
+          ...newState.fungalObservations,
+          ...newState.globalEvents,
+          ...newState.devices,
+        ]
+      }
+      return newState
+    }
+    case "SELECT_ENTITY":
+      return { ...state, selectedEntity: action.entity }
+    case "SET_LOADING":
+      return {
+        ...state,
+        loading: { ...state.loading, [action.entityType]: action.loading },
+      }
+    case "SET_ERROR":
+      return {
+        ...state,
+        errors: { ...state.errors, [action.entityType]: action.error },
+      }
+    case "CLEAR_ALL":
+      return createInitialEntityState()
+    default:
+      return state
+  }
+}
+
+function getEntityTypeKey(type: string): string | null {
+  const map: Record<string, string> = {
+    aircraft: "aircraft",
+    vessel: "vessels",
+    satellite: "satellites",
+    fungal: "fungalObservations",
+    weather: "globalEvents",
+    earthquake: "globalEvents",
+    device: "devices",
+    elephant: "devices",
+  }
+  return map[type] || null
+}
+
+function createInitialEntityState(): CREPEntityState {
+  return {
+    aircraft: [],
+    vessels: [],
+    satellites: [],
+    fungalObservations: [],
+    globalEvents: [],
+    devices: [],
+    allEntities: [],
+    selectedEntity: null,
+    loading: {},
+    errors: {},
+    lastRefresh: {},
+  }
+}
+
+interface CREPEntityContextValue {
+  state: CREPEntityState
+  dispatch: React.Dispatch<EntityAction>
+  /** Convenience: set entities for a type */
+  setEntities: (entityType: string, entities: UnifiedEntity[]) => void
+  /** Convenience: select an entity */
+  selectEntity: (entity: UnifiedEntity | null) => void
+  /** Get entity counts */
+  counts: Record<string, number>
+}
+
+export const CREPEntityContext = createContext<CREPEntityContextValue | null>(null)
+
+// ============================================================================
+// Map Context
+// ============================================================================
+
+export interface CREPMapState {
+  center: [number, number]
+  zoom: number
+  bearing: number
+  pitch: number
+}
+
+export interface CREPMapOperations {
+  flyTo: (lng: number, lat: number, zoom?: number) => void
+  setZoom: (zoom: number) => void
+  zoomBy: (delta: number) => void
+  panBy: (dx: number, dy: number) => void
+  resetView: () => void
+  geocodeAndFlyTo: (query: string) => Promise<void>
+  /** Current map state */
+  mapState: CREPMapState
+  /** Update map state (called from map move events) */
+  updateMapState: (state: Partial<CREPMapState>) => void
+  /** Map ref for direct access */
+  mapRef: React.MutableRefObject<unknown>
+}
+
+export const CREPMapContext = createContext<CREPMapOperations | null>(null)
+
+// ============================================================================
+// Layer Context
+// ============================================================================
+
+export interface LayerVisibility {
+  aircraft: boolean
+  vessels: boolean
+  satellites: boolean
+  fungalObservations: boolean
+  globalEvents: boolean
+  devices: boolean
+  weather: boolean
+  sporeDispersal: boolean
+  wind: boolean
+  precipitation: boolean
+  clouds: boolean
+  pressure: boolean
+  humidity: boolean
+  stormCells: boolean
+  fire: boolean
+  lightning: boolean
+  smoke: boolean
+  trajectories: boolean
+  orbitPaths: boolean
+}
+
+interface CREPLayerContextValue {
+  layers: LayerVisibility
+  setLayerVisible: (layer: keyof LayerVisibility, visible: boolean) => void
+  toggleLayer: (layer: keyof LayerVisibility) => void
+  showAllLayers: () => void
+  hideAllLayers: () => void
+  /** Layer opacity per layer */
+  opacity: Record<string, number>
+  setOpacity: (layer: string, opacity: number) => void
+}
+
+const DEFAULT_LAYERS: LayerVisibility = {
+  aircraft: false,
+  vessels: false,
+  satellites: false,
+  fungalObservations: true,
+  globalEvents: true,
+  devices: true,
+  weather: true,
+  sporeDispersal: false,
+  wind: false,
+  precipitation: false,
+  clouds: false,
+  pressure: false,
+  humidity: false,
+  stormCells: false,
+  fire: false,
+  lightning: false,
+  smoke: false,
+  trajectories: true,
+  orbitPaths: false,
+}
+
+export const CREPLayerContext = createContext<CREPLayerContextValue | null>(null)
+
+// ============================================================================
+// Mission Context
+// ============================================================================
+
+export interface MissionContext {
+  id: string
+  name: string
+  type: "monitoring" | "research" | "alert" | "tracking" | "analysis"
+  status: "active" | "paused" | "completed"
+  objective: string
+  progress: number
+  targets: number
+  alerts: number
+  startTime: Date
+}
+
+interface CREPMissionContextValue {
+  mission: MissionContext | null
+  setMission: (mission: MissionContext | null) => void
+  updateMission: (updates: Partial<MissionContext>) => void
+}
+
+export const CREPMissionContext = createContext<CREPMissionContextValue | null>(null)
+
+// ============================================================================
+// Stream Context
+// ============================================================================
+
+interface CREPStreamContextValue {
+  connectionState: ConnectionState
+  messageCount: number
+  client: EntityStreamClient | null
+}
+
+export const CREPStreamContext = createContext<CREPStreamContextValue | null>(null)
+
+// ============================================================================
+// Combined Provider
+// ============================================================================
+
+export function CREPProvider({ children }: { children: React.ReactNode }) {
+  // Entity state
+  const [entityState, entityDispatch] = useReducer(entityReducer, createInitialEntityState())
+
+  const setEntities = useCallback(
+    (entityType: string, entities: UnifiedEntity[]) => {
+      entityDispatch({ type: "SET_ENTITIES", entityType, entities })
+    },
+    []
+  )
+
+  const selectEntity = useCallback(
+    (entity: UnifiedEntity | null) => {
+      entityDispatch({ type: "SELECT_ENTITY", entity })
+    },
+    []
+  )
+
+  const counts = useMemo(
+    () => ({
+      aircraft: entityState.aircraft.length,
+      vessels: entityState.vessels.length,
+      satellites: entityState.satellites.length,
+      fungalObservations: entityState.fungalObservations.length,
+      globalEvents: entityState.globalEvents.length,
+      devices: entityState.devices.length,
+      total: entityState.allEntities.length,
+    }),
+    [entityState.aircraft.length, entityState.vessels.length, entityState.satellites.length, entityState.fungalObservations.length, entityState.globalEvents.length, entityState.devices.length, entityState.allEntities.length]
+  )
+
+  const entityContextValue = useMemo<CREPEntityContextValue>(
+    () => ({
+      state: entityState,
+      dispatch: entityDispatch,
+      setEntities,
+      selectEntity,
+      counts,
+    }),
+    [entityState, setEntities, selectEntity, counts]
+  )
+
+  // Map state
+  const mapRef = useRef<unknown>(null)
+  const [mapState, setMapState] = useState<CREPMapState>({
+    center: [0, 20],
+    zoom: 2.5,
+    bearing: 0,
+    pitch: 0,
+  })
+
+  const updateMapState = useCallback((partial: Partial<CREPMapState>) => {
+    setMapState((prev) => ({ ...prev, ...partial }))
+  }, [])
+
+  const flyTo = useCallback((lng: number, lat: number, zoom?: number) => {
+    const map = mapRef.current as { flyTo?: (opts: Record<string, unknown>) => void } | null
+    if (map?.flyTo) {
+      map.flyTo({ center: [lng, lat], zoom: zoom || 8, duration: 1500 })
+    }
+  }, [])
+
+  const setZoom = useCallback((zoom: number) => {
+    const map = mapRef.current as { setZoom?: (z: number) => void } | null
+    map?.setZoom?.(zoom)
+  }, [])
+
+  const zoomBy = useCallback((delta: number) => {
+    setMapState((prev) => {
+      const newZoom = Math.max(1, Math.min(20, prev.zoom + delta))
+      const map = mapRef.current as { setZoom?: (z: number) => void } | null
+      map?.setZoom?.(newZoom)
+      return { ...prev, zoom: newZoom }
+    })
+  }, [])
+
+  const panBy = useCallback((dx: number, dy: number) => {
+    const map = mapRef.current as { panBy?: (offset: [number, number]) => void } | null
+    map?.panBy?.([dx, dy])
+  }, [])
+
+  const resetView = useCallback(() => {
+    flyTo(0, 20, 2.5)
+  }, [flyTo])
+
+  const geocodeAndFlyTo = useCallback(
+    async (query: string) => {
+      try {
+        const response = await fetch(
+          `/api/search/location?q=${encodeURIComponent(query)}`
+        )
+        if (response.ok) {
+          const data = await response.json()
+          if (data.lat && data.lng) {
+            flyTo(data.lng, data.lat, 10)
+          }
+        }
+      } catch (error) {
+        console.warn("[CREP Map] Geocode failed:", error)
+      }
+    },
+    [flyTo]
+  )
+
+  const mapContextValue = useMemo<CREPMapOperations>(
+    () => ({
+      flyTo,
+      setZoom,
+      zoomBy,
+      panBy,
+      resetView,
+      geocodeAndFlyTo,
+      mapState,
+      updateMapState,
+      mapRef,
+    }),
+    [flyTo, setZoom, zoomBy, panBy, resetView, geocodeAndFlyTo, mapState, updateMapState]
+  )
+
+  // Layer state
+  const [layers, setLayers] = useState<LayerVisibility>(DEFAULT_LAYERS)
+  const [opacity, setOpacityState] = useState<Record<string, number>>({})
+
+  const setLayerVisible = useCallback(
+    (layer: keyof LayerVisibility, visible: boolean) => {
+      setLayers((prev) => ({ ...prev, [layer]: visible }))
+    },
+    []
+  )
+
+  const toggleLayer = useCallback((layer: keyof LayerVisibility) => {
+    setLayers((prev) => ({ ...prev, [layer]: !prev[layer] }))
+  }, [])
+
+  const showAllLayers = useCallback(() => {
+    setLayers((prev) => {
+      const next = { ...prev }
+      for (const k of Object.keys(next) as Array<keyof LayerVisibility>) {
+        next[k] = true
+      }
+      return next
+    })
+  }, [])
+
+  const hideAllLayers = useCallback(() => {
+    setLayers((prev) => {
+      const next = { ...prev }
+      for (const k of Object.keys(next) as Array<keyof LayerVisibility>) {
+        next[k] = false
+      }
+      return next
+    })
+  }, [])
+
+  const setOpacity = useCallback((layer: string, value: number) => {
+    setOpacityState((prev) => ({ ...prev, [layer]: value }))
+  }, [])
+
+  const layerContextValue = useMemo<CREPLayerContextValue>(
+    () => ({
+      layers,
+      setLayerVisible,
+      toggleLayer,
+      showAllLayers,
+      hideAllLayers,
+      opacity,
+      setOpacity,
+    }),
+    [layers, setLayerVisible, toggleLayer, showAllLayers, hideAllLayers, opacity, setOpacity]
+  )
+
+  // Mission state
+  const [mission, setMission] = useState<MissionContext | null>(null)
+
+  const updateMission = useCallback((updates: Partial<MissionContext>) => {
+    setMission((prev) => (prev ? { ...prev, ...updates } : null))
+  }, [])
+
+  const missionContextValue = useMemo<CREPMissionContextValue>(
+    () => ({ mission, setMission, updateMission }),
+    [mission, updateMission]
+  )
+
+  // Streaming state
+  const [connectionState, setConnectionState] = useState<ConnectionState>("disconnected")
+  const [messageCount, setMessageCount] = useState(0)
+  const clientRef = useRef<EntityStreamClient | null>(null)
+
+  useEffect(() => {
+    const client = new EntityStreamClient()
+    clientRef.current = client
+
+    client.connect(
+      (entity) => {
+        entityDispatch({ type: "ADD_ENTITY", entity })
+        setMessageCount((prev) => prev + 1)
+      },
+      {},
+      {
+        onConnectionStateChange: setConnectionState,
+        onError: (error) => {
+          console.error("[CREP Stream] Error:", error.message)
+        },
+      }
+    )
+
+    return () => {
+      client.disconnect()
+      clientRef.current = null
+    }
+  }, [])
+
+  const streamContextValue = useMemo<CREPStreamContextValue>(
+    () => ({
+      connectionState,
+      messageCount,
+      client: clientRef.current,
+    }),
+    [connectionState, messageCount]
+  )
+
+  return (
+    <CREPEntityContext.Provider value={entityContextValue}>
+      <CREPMapContext.Provider value={mapContextValue}>
+        <CREPLayerContext.Provider value={layerContextValue}>
+          <CREPMissionContext.Provider value={missionContextValue}>
+            <CREPStreamContext.Provider value={streamContextValue}>
+              {children}
+            </CREPStreamContext.Provider>
+          </CREPMissionContext.Provider>
+        </CREPLayerContext.Provider>
+      </CREPMapContext.Provider>
+    </CREPEntityContext.Provider>
+  )
+}
+
+// ============================================================================
+// Hooks
+// ============================================================================
+
+export function useCREPEntities(): CREPEntityContextValue {
+  const ctx = useContext(CREPEntityContext)
+  if (!ctx) throw new Error("useCREPEntities must be used within CREPProvider")
+  return ctx
+}
+
+export function useCREPMap(): CREPMapOperations {
+  const ctx = useContext(CREPMapContext)
+  if (!ctx) throw new Error("useCREPMap must be used within CREPProvider")
+  return ctx
+}
+
+export function useCREPLayers(): CREPLayerContextValue {
+  const ctx = useContext(CREPLayerContext)
+  if (!ctx) throw new Error("useCREPLayers must be used within CREPProvider")
+  return ctx
+}
+
+export function useCREPMission(): CREPMissionContextValue {
+  const ctx = useContext(CREPMissionContext)
+  if (!ctx) throw new Error("useCREPMission must be used within CREPProvider")
+  return ctx
+}
+
+export function useCREPStream(): CREPStreamContextValue {
+  const ctx = useContext(CREPStreamContext)
+  if (!ctx) throw new Error("useCREPStream must be used within CREPProvider")
+  return ctx
+}
+
+/** Optional access — returns null if not within CREPProvider */
+export function useOptionalCREPEntities(): CREPEntityContextValue | null {
+  return useContext(CREPEntityContext)
+}
+
+export function useOptionalCREPMap(): CREPMapOperations | null {
+  return useContext(CREPMapContext)
+}

--- a/hooks/use-crep-data.ts
+++ b/hooks/use-crep-data.ts
@@ -15,6 +15,17 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from "react"
+import { useOptionalCREPEntities } from "@/contexts/crep-context"
+import {
+  convertBatch,
+  convertSimpleAircraft,
+  convertSimpleVessel,
+  convertSimpleSatellite,
+  convertGlobalEvent as convertGlobalEventToUnified,
+  convertFungalObservation as convertFungalObservationToUnified,
+  convertDevice as convertDeviceToUnified,
+} from "@/lib/crep/entities/entity-converters"
+import { validateBatch } from "@/lib/crep/entities/entity-validators"
 
 // Data interfaces
 export interface CREPDataState {
@@ -310,6 +321,9 @@ export function useCREPData(options: UseCREPDataOptions = {}) {
     initialFetch = true,
   } = options
 
+  // Connect to CREP entity context if available (bidirectional sync)
+  const crepEntities = useOptionalCREPEntities()
+
   // Initialize from global cache if available
   const [data, setData] = useState<CREPDataState>(globalCache || DEFAULT_STATE)
   const [isLoading, setIsLoading] = useState(!globalCache)
@@ -376,6 +390,46 @@ export function useCREPData(options: UseCREPDataOptions = {}) {
         setData(newData)
         setLastUpdated(result.timestamp)
         console.log(`[useCREPData] Loaded data - Aircraft: ${newData.aircraft.length}, Vessels: ${newData.vessels.length}, Satellites: ${newData.satellites.length}`)
+      }
+
+      // Sync to CREP entity context (if available) for bidirectional integration
+      if (crepEntities) {
+        try {
+          const aircraftEntities = validateBatch(
+            convertBatch(newData.aircraft as Parameters<typeof convertSimpleAircraft>[0][], convertSimpleAircraft)
+          )
+          const vesselEntities = validateBatch(
+            convertBatch(newData.vessels as Parameters<typeof convertSimpleVessel>[0][], convertSimpleVessel)
+          )
+          const satelliteEntities = validateBatch(
+            convertBatch(newData.satellites as Parameters<typeof convertSimpleSatellite>[0][], convertSimpleSatellite)
+          )
+          const eventEntities = validateBatch(
+            convertBatch(newData.globalEvents as Parameters<typeof convertGlobalEventToUnified>[0][], convertGlobalEventToUnified)
+          )
+          const fungalEntities = validateBatch(
+            convertBatch(newData.fungalObservations.map(f => ({
+              id: f.id,
+              species: f.species,
+              lat: f.latitude,
+              lng: f.longitude,
+              observedOn: f.observed_on,
+              location: f.location,
+            })), convertFungalObservationToUnified)
+          )
+          const deviceEntities = validateBatch(
+            convertBatch(newData.devices as Parameters<typeof convertDeviceToUnified>[0][], convertDeviceToUnified)
+          )
+
+          crepEntities.setEntities("aircraft", aircraftEntities)
+          crepEntities.setEntities("vessels", vesselEntities)
+          crepEntities.setEntities("satellites", satelliteEntities)
+          crepEntities.setEntities("globalEvents", eventEntities)
+          crepEntities.setEntities("fungalObservations", fungalEntities)
+          crepEntities.setEntities("devices", deviceEntities)
+        } catch (syncError) {
+          console.warn("[useCREPData] Context sync error:", syncError)
+        }
       }
 
       // Fetch additional data sources that aren't in unified endpoint

--- a/lib/crep/crep-data-service.ts
+++ b/lib/crep/crep-data-service.ts
@@ -1,19 +1,24 @@
 /**
  * CREP Data Service
- * 
+ *
  * Unified service for all CREP data fetching with:
- * - Centralized caching
- * - Rate limiting
- * - Error handling
- * - Background refresh
- * 
- * This prevents the dev server from being overwhelmed by
- * managing all external API calls through a single service.
+ * - Centralized caching (memory + Redis multi-layer)
+ * - Rate limiting and request deduplication
+ * - Error handling with typed error responses
+ * - Background refresh (stale-while-revalidate)
+ * - Pagination support for large datasets
+ * - Abort signal support for cleanup on unmount
+ *
+ * Uses centralized API_URLS config — no hard-coded IPs.
  */
 
 import { getCachedData, getCacheStats, invalidateCache } from "./data-cache"
+import { API_URLS } from "@/lib/config/api-urls"
 
-// Data types
+// ============================================================================
+// Types
+// ============================================================================
+
 export interface CREPDataSummary {
   aircraft: number
   vessels: number
@@ -24,70 +29,23 @@ export interface CREPDataSummary {
   lastUpdated: string
 }
 
-interface FetchOptions {
+export interface FetchOptions {
   forceRefresh?: boolean
   timeout?: number
+  limit?: number
+  offset?: number
+  signal?: AbortSignal
 }
 
-// Base URL for internal API calls
-const getBaseUrl = () => {
-  if (typeof window !== "undefined") {
-    return ""
-  }
-  return process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3010"
+export interface PaginatedResult<T> {
+  data: T[]
+  total: number
+  limit: number
+  offset: number
+  hasMore: boolean
 }
 
-/**
- * Fetch with timeout and error handling
- */
-async function fetchWithTimeout(
-  url: string,
-  options: RequestInit = {},
-  timeoutMs: number = 10000
-): Promise<Response> {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-
-  try {
-    const response = await fetch(url, {
-      ...options,
-      signal: controller.signal,
-    })
-    return response
-  } finally {
-    clearTimeout(timeoutId)
-  }
-}
-
-/**
- * Safe JSON fetch with error handling
- */
-async function safeFetch<T>(
-  url: string,
-  defaultValue: T,
-  timeoutMs: number = 10000
-): Promise<T> {
-  try {
-    const response = await fetchWithTimeout(url, {}, timeoutMs)
-    if (!response.ok) {
-      console.warn(`[CREP Service] ${url} returned ${response.status}`)
-      return defaultValue
-    }
-    return await response.json()
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      console.warn(`[CREP Service] ${url} timed out`)
-    } else {
-      console.warn(`[CREP Service] ${url} failed:`, error)
-    }
-    return defaultValue
-  }
-}
-
-// ============================================================================
-// Aircraft Data
-// ============================================================================
-
+// Data types — canonical flat format for crep-data-service consumers
 export interface Aircraft {
   id: string
   callsign: string
@@ -101,29 +59,6 @@ export interface Aircraft {
   destination?: string
 }
 
-export async function getAircraft(options?: FetchOptions): Promise<Aircraft[]> {
-  if (options?.forceRefresh) {
-    invalidateCache("aircraft")
-  }
-
-  return getCachedData<Aircraft[]>(
-    "aircraft",
-    async () => {
-      const baseUrl = getBaseUrl()
-      const data = await safeFetch<{ aircraft?: Aircraft[] }>(
-        `${baseUrl}/api/oei/flightradar24`,
-        { aircraft: [] },
-        options?.timeout || 15000
-      )
-      return data.aircraft || []
-    }
-  )
-}
-
-// ============================================================================
-// Vessel Data
-// ============================================================================
-
 export interface Vessel {
   id: string
   mmsi: string
@@ -136,29 +71,6 @@ export interface Vessel {
   destination?: string
 }
 
-export async function getVessels(options?: FetchOptions): Promise<Vessel[]> {
-  if (options?.forceRefresh) {
-    invalidateCache("vessels")
-  }
-
-  return getCachedData<Vessel[]>(
-    "vessels",
-    async () => {
-      const baseUrl = getBaseUrl()
-      const data = await safeFetch<{ vessels?: Vessel[] }>(
-        `${baseUrl}/api/oei/aisstream`,
-        { vessels: [] },
-        options?.timeout || 15000
-      )
-      return data.vessels || []
-    }
-  )
-}
-
-// ============================================================================
-// Satellite Data
-// ============================================================================
-
 export interface Satellite {
   id: string
   name: string
@@ -170,74 +82,12 @@ export interface Satellite {
   category?: string
 }
 
-const SATELLITE_CATEGORIES = ["weather", "science", "gps-ops", "active"]
-
-export async function getSatellites(options?: FetchOptions): Promise<Satellite[]> {
-  if (options?.forceRefresh) {
-    invalidateCache("satellites")
-  }
-
-  return getCachedData<Satellite[]>(
-    "satellites",
-    async () => {
-      const baseUrl = getBaseUrl()
-      const allSatellites: Satellite[] = []
-
-      // Fetch categories sequentially to avoid overwhelming external APIs
-      for (const category of SATELLITE_CATEGORIES) {
-        try {
-          const data = await safeFetch<{ satellites?: Satellite[] }>(
-            `${baseUrl}/api/oei/satellites?category=${category}`,
-            { satellites: [] },
-            options?.timeout || 20000
-          )
-          if (data.satellites) {
-            allSatellites.push(...data.satellites)
-          }
-        } catch (error) {
-          console.warn(`[CREP Service] Satellite category ${category} failed`)
-        }
-        // Small delay between requests to avoid rate limiting
-        await new Promise(resolve => setTimeout(resolve, 500))
-      }
-
-      return allSatellites
-    }
-  )
-}
-
-// ============================================================================
-// Space Weather Data
-// ============================================================================
-
 export interface SpaceWeatherData {
   solarFlares: unknown[]
   geomagneticStorms: unknown[]
   solarWind: unknown
   alerts: unknown[]
 }
-
-export async function getSpaceWeather(options?: FetchOptions): Promise<SpaceWeatherData> {
-  if (options?.forceRefresh) {
-    invalidateCache("spaceWeather")
-  }
-
-  return getCachedData<SpaceWeatherData>(
-    "spaceWeather",
-    async () => {
-      const baseUrl = getBaseUrl()
-      return safeFetch<SpaceWeatherData>(
-        `${baseUrl}/api/oei/space-weather`,
-        { solarFlares: [], geomagneticStorms: [], solarWind: null, alerts: [] },
-        options?.timeout || 15000
-      )
-    }
-  )
-}
-
-// ============================================================================
-// Global Events
-// ============================================================================
 
 export interface GlobalEvent {
   id: string
@@ -249,29 +99,6 @@ export interface GlobalEvent {
   timestamp?: string
 }
 
-export async function getGlobalEvents(options?: FetchOptions): Promise<GlobalEvent[]> {
-  if (options?.forceRefresh) {
-    invalidateCache("globalEvents")
-  }
-
-  return getCachedData<GlobalEvent[]>(
-    "globalEvents",
-    async () => {
-      const baseUrl = getBaseUrl()
-      const data = await safeFetch<{ events?: GlobalEvent[] }>(
-        `${baseUrl}/api/natureos/global-events`,
-        { events: [] },
-        options?.timeout || 15000
-      )
-      return data.events || []
-    }
-  )
-}
-
-// ============================================================================
-// Fungal Observations
-// ============================================================================
-
 export interface FungalObservation {
   id: string
   species: string
@@ -280,29 +107,6 @@ export interface FungalObservation {
   observedOn?: string
   location?: string
 }
-
-export async function getFungalObservations(options?: FetchOptions): Promise<FungalObservation[]> {
-  if (options?.forceRefresh) {
-    invalidateCache("fungalObservations")
-  }
-
-  return getCachedData<FungalObservation[]>(
-    "fungalObservations",
-    async () => {
-      const baseUrl = getBaseUrl()
-      const data = await safeFetch<{ observations?: FungalObservation[] }>(
-        `${baseUrl}/api/crep/fungal`,
-        { observations: [] },
-        options?.timeout || 20000
-      )
-      return data.observations || []
-    }
-  )
-}
-
-// ============================================================================
-// MycoBrain Devices
-// ============================================================================
 
 export interface Device {
   id: string
@@ -314,41 +118,269 @@ export interface Device {
   lastSeen?: string
 }
 
-export async function getDevices(options?: FetchOptions): Promise<Device[]> {
-  if (options?.forceRefresh) {
-    invalidateCache("devices")
+// ============================================================================
+// URL Configuration
+// ============================================================================
+
+const getBaseUrl = () => {
+  if (typeof window !== "undefined") return ""
+  return API_URLS.LOCAL_BASE
+}
+
+// ============================================================================
+// Fetch Utilities
+// ============================================================================
+
+async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs = 10000
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  // Merge with external signal if provided
+  const externalSignal = options.signal
+  if (externalSignal) {
+    externalSignal.addEventListener("abort", () => controller.abort())
   }
 
-  return getCachedData<Device[]>(
-    "devices",
-    async () => {
-      const baseUrl = getBaseUrl()
-      const data = await safeFetch<{ devices?: Device[] }>(
-        `${baseUrl}/api/mycobrain/devices`,
-        { devices: [] },
-        options?.timeout || 10000
-      )
-      return data.devices || []
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    })
+    return response
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+async function safeFetch<T>(
+  url: string,
+  defaultValue: T,
+  timeoutMs = 10000,
+  signal?: AbortSignal
+): Promise<T> {
+  try {
+    const response = await fetchWithTimeout(url, signal ? { signal } : {}, timeoutMs)
+    if (!response.ok) {
+      console.warn(`[CREP Service] ${url} returned ${response.status}`)
+      return defaultValue
     }
-  )
+    return await response.json()
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      console.warn(`[CREP Service] ${url} timed out or aborted`)
+    } else {
+      console.warn(`[CREP Service] ${url} failed:`, error)
+    }
+    return defaultValue
+  }
+}
+
+// ============================================================================
+// Aircraft Data
+// ============================================================================
+
+export async function getAircraft(options?: FetchOptions): Promise<Aircraft[]> {
+  if (options?.forceRefresh) invalidateCache("aircraft")
+
+  return getCachedData<Aircraft[]>("aircraft", async () => {
+    const baseUrl = getBaseUrl()
+    const url = new URL(`${baseUrl}/api/oei/flightradar24`)
+    if (options?.limit) url.searchParams.set("limit", String(options.limit))
+
+    const data = await safeFetch<{ aircraft?: Aircraft[] }>(
+      url.toString(),
+      { aircraft: [] },
+      options?.timeout || 15000,
+      options?.signal
+    )
+    return data.aircraft || []
+  })
+}
+
+export async function getAircraftPaginated(
+  options?: FetchOptions
+): Promise<PaginatedResult<Aircraft>> {
+  const all = await getAircraft(options)
+  const offset = options?.offset || 0
+  const limit = options?.limit || 100
+  const sliced = all.slice(offset, offset + limit)
+
+  return {
+    data: sliced,
+    total: all.length,
+    limit,
+    offset,
+    hasMore: offset + limit < all.length,
+  }
+}
+
+// ============================================================================
+// Vessel Data
+// ============================================================================
+
+export async function getVessels(options?: FetchOptions): Promise<Vessel[]> {
+  if (options?.forceRefresh) invalidateCache("vessels")
+
+  return getCachedData<Vessel[]>("vessels", async () => {
+    const baseUrl = getBaseUrl()
+    const data = await safeFetch<{ vessels?: Vessel[] }>(
+      `${baseUrl}/api/oei/aisstream`,
+      { vessels: [] },
+      options?.timeout || 15000,
+      options?.signal
+    )
+    return data.vessels || []
+  })
+}
+
+export async function getVesselsPaginated(
+  options?: FetchOptions
+): Promise<PaginatedResult<Vessel>> {
+  const all = await getVessels(options)
+  const offset = options?.offset || 0
+  const limit = options?.limit || 100
+  const sliced = all.slice(offset, offset + limit)
+
+  return {
+    data: sliced,
+    total: all.length,
+    limit,
+    offset,
+    hasMore: offset + limit < all.length,
+  }
+}
+
+// ============================================================================
+// Satellite Data
+// ============================================================================
+
+const SATELLITE_CATEGORIES = ["weather", "science", "gps-ops", "active"]
+
+export async function getSatellites(options?: FetchOptions): Promise<Satellite[]> {
+  if (options?.forceRefresh) invalidateCache("satellites")
+
+  return getCachedData<Satellite[]>("satellites", async () => {
+    const baseUrl = getBaseUrl()
+    const allSatellites: Satellite[] = []
+
+    // Fetch categories in parallel for faster load
+    const results = await Promise.allSettled(
+      SATELLITE_CATEGORIES.map((category) =>
+        safeFetch<{ satellites?: Satellite[] }>(
+          `${baseUrl}/api/oei/satellites?category=${category}`,
+          { satellites: [] },
+          options?.timeout || 20000,
+          options?.signal
+        )
+      )
+    )
+
+    for (const result of results) {
+      if (result.status === "fulfilled" && result.value.satellites) {
+        allSatellites.push(...result.value.satellites)
+      }
+    }
+
+    return allSatellites
+  })
+}
+
+// ============================================================================
+// Space Weather Data
+// ============================================================================
+
+export async function getSpaceWeather(options?: FetchOptions): Promise<SpaceWeatherData> {
+  if (options?.forceRefresh) invalidateCache("spaceWeather")
+
+  return getCachedData<SpaceWeatherData>("spaceWeather", async () => {
+    const baseUrl = getBaseUrl()
+    return safeFetch<SpaceWeatherData>(
+      `${baseUrl}/api/oei/space-weather`,
+      { solarFlares: [], geomagneticStorms: [], solarWind: null, alerts: [] },
+      options?.timeout || 15000,
+      options?.signal
+    )
+  })
+}
+
+// ============================================================================
+// Global Events
+// ============================================================================
+
+export async function getGlobalEvents(options?: FetchOptions): Promise<GlobalEvent[]> {
+  if (options?.forceRefresh) invalidateCache("globalEvents")
+
+  return getCachedData<GlobalEvent[]>("globalEvents", async () => {
+    const baseUrl = getBaseUrl()
+    const data = await safeFetch<{ events?: GlobalEvent[] }>(
+      `${baseUrl}/api/natureos/global-events`,
+      { events: [] },
+      options?.timeout || 15000,
+      options?.signal
+    )
+    return data.events || []
+  })
+}
+
+// ============================================================================
+// Fungal Observations
+// ============================================================================
+
+export async function getFungalObservations(options?: FetchOptions): Promise<FungalObservation[]> {
+  if (options?.forceRefresh) invalidateCache("fungalObservations")
+
+  return getCachedData<FungalObservation[]>("fungalObservations", async () => {
+    const baseUrl = getBaseUrl()
+    const url = new URL(`${baseUrl}/api/crep/fungal`)
+    if (options?.limit) url.searchParams.set("limit", String(options.limit))
+
+    const data = await safeFetch<{ observations?: FungalObservation[] }>(
+      url.toString(),
+      { observations: [] },
+      options?.timeout || 20000,
+      options?.signal
+    )
+    return data.observations || []
+  })
+}
+
+// ============================================================================
+// MycoBrain Devices
+// ============================================================================
+
+export async function getDevices(options?: FetchOptions): Promise<Device[]> {
+  if (options?.forceRefresh) invalidateCache("devices")
+
+  return getCachedData<Device[]>("devices", async () => {
+    const baseUrl = getBaseUrl()
+    const data = await safeFetch<{ devices?: Device[] }>(
+      `${baseUrl}/api/mycobrain/devices`,
+      { devices: [] },
+      options?.timeout || 10000,
+      options?.signal
+    )
+    return data.devices || []
+  })
 }
 
 // ============================================================================
 // Aggregated Data
 // ============================================================================
 
-/**
- * Get summary of all CREP data counts
- */
-export async function getDataSummary(): Promise<CREPDataSummary> {
-  const [aircraft, vessels, satellites, fungalObservations, globalEvents, devices] = 
+export async function getDataSummary(signal?: AbortSignal): Promise<CREPDataSummary> {
+  const opts: FetchOptions = { signal }
+  const [aircraft, vessels, satellites, fungalObservations, globalEvents, devices] =
     await Promise.all([
-      getAircraft().catch(() => []),
-      getVessels().catch(() => []),
-      getSatellites().catch(() => []),
-      getFungalObservations().catch(() => []),
-      getGlobalEvents().catch(() => []),
-      getDevices().catch(() => []),
+      getAircraft(opts).catch(() => []),
+      getVessels(opts).catch(() => []),
+      getSatellites(opts).catch(() => []),
+      getFungalObservations(opts).catch(() => []),
+      getGlobalEvents(opts).catch(() => []),
+      getDevices(opts).catch(() => []),
     ])
 
   return {
@@ -363,11 +395,12 @@ export async function getDataSummary(): Promise<CREPDataSummary> {
 }
 
 /**
- * Fetch all data sources (for initial load)
- * Returns data as it becomes available via the callback
+ * Fetch all data sources with progressive loading callback.
+ * Supports abort signal for cleanup on component unmount.
  */
 export async function fetchAllData(
-  onDataReady?: (type: string, data: unknown[]) => void
+  onDataReady?: (type: string, data: unknown[]) => void,
+  signal?: AbortSignal
 ): Promise<{
   aircraft: Aircraft[]
   vessels: Vessel[]
@@ -376,6 +409,7 @@ export async function fetchAllData(
   globalEvents: GlobalEvent[]
   devices: Device[]
 }> {
+  const opts: FetchOptions = { signal }
   const results = {
     aircraft: [] as Aircraft[],
     vessels: [] as Vessel[],
@@ -385,42 +419,38 @@ export async function fetchAllData(
     devices: [] as Device[],
   }
 
-  // Fetch in parallel but with controlled concurrency
   const fetchers = [
     async () => {
-      results.aircraft = await getAircraft()
+      results.aircraft = await getAircraft(opts)
       onDataReady?.("aircraft", results.aircraft)
     },
     async () => {
-      results.vessels = await getVessels()
+      results.vessels = await getVessels(opts)
       onDataReady?.("vessels", results.vessels)
     },
     async () => {
-      results.satellites = await getSatellites()
+      results.satellites = await getSatellites(opts)
       onDataReady?.("satellites", results.satellites)
     },
     async () => {
-      results.fungalObservations = await getFungalObservations()
+      results.fungalObservations = await getFungalObservations(opts)
       onDataReady?.("fungalObservations", results.fungalObservations)
     },
     async () => {
-      results.globalEvents = await getGlobalEvents()
+      results.globalEvents = await getGlobalEvents(opts)
       onDataReady?.("globalEvents", results.globalEvents)
     },
     async () => {
-      results.devices = await getDevices()
+      results.devices = await getDevices(opts)
       onDataReady?.("devices", results.devices)
     },
   ]
 
-  await Promise.allSettled(fetchers.map(f => f()))
+  await Promise.allSettled(fetchers.map((f) => f()))
 
   return results
 }
 
-/**
- * Get cache statistics
- */
 export function getServiceStats() {
   return {
     cache: getCacheStats(),

--- a/lib/crep/entities/entity-converters.ts
+++ b/lib/crep/entities/entity-converters.ts
@@ -1,0 +1,408 @@
+/**
+ * Entity Converters - Unified Data Model
+ *
+ * Converts all CREP data formats into the canonical UnifiedEntity schema.
+ * Eliminates `as any` casts by providing proper type-safe converters for
+ * every data source format (API responses, WebSocket, MINDEX, etc.)
+ *
+ * All location data flows through GeoJSON Point geometry [lng, lat].
+ */
+
+import type {
+  UnifiedEntity,
+  UnifiedPointGeometry,
+  UnifiedEntityState,
+  UnifiedEntityTime,
+} from "./unified-entity-schema"
+import type { AircraftEntity, VesselEntity, SatelliteEntity } from "@/types/oei"
+import type { Aircraft, Vessel, Satellite, GlobalEvent, FungalObservation, Device } from "../crep-data-service"
+
+// ============================================================================
+// Coordinate Helpers
+// ============================================================================
+
+/** Validate that coordinates are within valid WGS84 bounds */
+export function isValidCoordinate(lng: number, lat: number): boolean {
+  return (
+    typeof lng === "number" &&
+    typeof lat === "number" &&
+    !isNaN(lng) &&
+    !isNaN(lat) &&
+    lng >= -180 &&
+    lng <= 180 &&
+    lat >= -90 &&
+    lat <= 90
+  )
+}
+
+/** Extract [lng, lat] from any known location format, returns null if invalid */
+export function extractCoordinates(
+  location: unknown
+): [number, number] | null {
+  if (!location || typeof location !== "object") return null
+
+  const loc = location as Record<string, unknown>
+
+  // GeoJSON format: { type: "Point", coordinates: [lng, lat] }
+  if (loc.type === "Point" && Array.isArray(loc.coordinates)) {
+    const [lng, lat] = loc.coordinates as number[]
+    if (isValidCoordinate(lng, lat)) return [lng, lat]
+  }
+
+  // { longitude, latitude } format (OEI entities)
+  if (typeof loc.longitude === "number" && typeof loc.latitude === "number") {
+    if (isValidCoordinate(loc.longitude, loc.latitude)) {
+      return [loc.longitude, loc.latitude]
+    }
+  }
+
+  // { lng, lat } format (CREP data service)
+  if (typeof loc.lng === "number" && typeof loc.lat === "number") {
+    if (isValidCoordinate(loc.lng, loc.lat)) return [loc.lng, loc.lat]
+  }
+
+  return null
+}
+
+/** Create a valid UnifiedPointGeometry from coordinates */
+export function makePoint(
+  lng: number,
+  lat: number,
+  alt?: number
+): UnifiedPointGeometry {
+  return {
+    type: "Point",
+    coordinates: alt !== undefined ? [lng, lat, alt] : [lng, lat],
+  }
+}
+
+// ============================================================================
+// Aircraft Converters
+// ============================================================================
+
+/** Convert crep-data-service Aircraft (lat/lng) to UnifiedEntity */
+export function convertSimpleAircraft(a: Aircraft): UnifiedEntity | null {
+  if (!isValidCoordinate(a.lng, a.lat)) return null
+
+  return {
+    id: a.id,
+    type: "aircraft",
+    geometry: makePoint(a.lng, a.lat, a.altitude),
+    state: {
+      velocity: { x: a.speed || 0, y: 0 },
+      heading: a.heading,
+      altitude: a.altitude,
+      classification: a.type || "unknown",
+    },
+    time: {
+      observed_at: new Date().toISOString(),
+      valid_from: new Date().toISOString(),
+    },
+    confidence: 0.8,
+    source: "flightradar24",
+    properties: {
+      callsign: a.callsign,
+      origin: a.origin,
+      destination: a.destination,
+      aircraftType: a.type,
+    },
+    s2_cell: "",
+  }
+}
+
+/** Convert OEI AircraftEntity (GeoJSON location) to UnifiedEntity */
+export function convertAircraftEntity(a: AircraftEntity): UnifiedEntity | null {
+  const coords = extractCoordinates(a.location)
+  if (!coords) return null
+
+  return {
+    id: a.id,
+    type: "aircraft",
+    geometry: makePoint(coords[0], coords[1], a.altitude ?? undefined),
+    state: {
+      velocity: { x: a.velocity ?? 0, y: a.verticalRate ?? 0 },
+      heading: a.heading ?? undefined,
+      altitude: a.altitude ?? undefined,
+      classification: a.aircraftType || "unknown",
+    },
+    time: {
+      observed_at: a.lastSeen,
+      valid_from: a.lastSeen,
+    },
+    confidence: a.provenance?.reliability ?? 0.8,
+    source: a.provenance?.source || "opensky",
+    properties: {
+      icao24: a.icao24,
+      callsign: a.callsign,
+      origin: a.origin,
+      destination: a.destination,
+      airline: a.airline,
+      flightNumber: a.flightNumber,
+      registration: a.registration,
+      onGround: a.onGround,
+      squawk: a.squawk,
+    },
+    s2_cell: "",
+  }
+}
+
+// ============================================================================
+// Vessel Converters
+// ============================================================================
+
+/** Convert crep-data-service Vessel (lat/lng) to UnifiedEntity */
+export function convertSimpleVessel(v: Vessel): UnifiedEntity | null {
+  if (!isValidCoordinate(v.lng, v.lat)) return null
+
+  return {
+    id: v.id,
+    type: "vessel",
+    geometry: makePoint(v.lng, v.lat),
+    state: {
+      velocity: { x: v.speed || 0, y: 0 },
+      heading: v.heading,
+      classification: v.type || "cargo",
+    },
+    time: {
+      observed_at: new Date().toISOString(),
+      valid_from: new Date().toISOString(),
+    },
+    confidence: 0.8,
+    source: "aisstream",
+    properties: {
+      mmsi: v.mmsi,
+      name: v.name,
+      destination: v.destination,
+      shipType: v.type,
+    },
+    s2_cell: "",
+  }
+}
+
+/** Convert OEI VesselEntity (GeoJSON location) to UnifiedEntity */
+export function convertVesselEntity(v: VesselEntity): UnifiedEntity | null {
+  const coords = extractCoordinates(v.location)
+  if (!coords) return null
+
+  return {
+    id: v.id,
+    type: "vessel",
+    geometry: makePoint(coords[0], coords[1]),
+    state: {
+      velocity: { x: v.sog ?? 0, y: 0 },
+      heading: v.heading ?? v.cog ?? undefined,
+      classification: String(v.shipType || "unknown"),
+    },
+    time: {
+      observed_at: v.lastSeen,
+      valid_from: v.lastSeen,
+    },
+    confidence: v.provenance?.reliability ?? 0.8,
+    source: v.provenance?.source || "aisstream",
+    properties: {
+      mmsi: v.mmsi,
+      name: v.name,
+      imo: v.imo,
+      callsign: v.callsign,
+      flag: v.flag,
+      destination: v.destination,
+      navStatus: v.navStatus,
+      length: v.length,
+      width: v.width,
+      draught: v.draught,
+    },
+    s2_cell: "",
+  }
+}
+
+// ============================================================================
+// Satellite Converters
+// ============================================================================
+
+/** Convert crep-data-service Satellite (lat/lng) to UnifiedEntity */
+export function convertSimpleSatellite(s: Satellite): UnifiedEntity | null {
+  if (!isValidCoordinate(s.lng, s.lat)) return null
+
+  return {
+    id: s.id,
+    type: "satellite",
+    geometry: makePoint(s.lng, s.lat, s.altitude),
+    state: {
+      velocity: { x: s.velocity || 0, y: 0 },
+      altitude: s.altitude,
+      classification: s.category || "active",
+    },
+    time: {
+      observed_at: new Date().toISOString(),
+      valid_from: new Date().toISOString(),
+    },
+    confidence: 0.7,
+    source: "celestrak",
+    properties: {
+      name: s.name,
+      noradId: s.noradId,
+      category: s.category,
+    },
+    s2_cell: "",
+  }
+}
+
+/** Convert OEI SatelliteEntity to UnifiedEntity */
+export function convertSatelliteEntity(s: SatelliteEntity): UnifiedEntity | null {
+  const pos = s.estimatedPosition
+  if (!pos || !isValidCoordinate(pos.longitude, pos.latitude)) return null
+
+  return {
+    id: s.id,
+    type: "satellite",
+    geometry: makePoint(pos.longitude, pos.latitude, pos.altitude),
+    state: {
+      altitude: pos.altitude,
+      classification: s.orbitType || "UNKNOWN",
+    },
+    time: {
+      observed_at: s.lastSeen,
+      valid_from: s.lastSeen,
+    },
+    confidence: 0.7,
+    source: s.provenance?.source || "celestrak",
+    properties: {
+      name: s.name,
+      noradId: s.noradId,
+      intlDesignator: s.intlDesignator,
+      objectType: s.objectType,
+      country: s.country,
+      orbitType: s.orbitType,
+      orbitalParams: s.orbitalParams,
+      launchDate: s.launchDate,
+    },
+    s2_cell: "",
+  }
+}
+
+// ============================================================================
+// Event Converters
+// ============================================================================
+
+/** Convert crep-data-service GlobalEvent to UnifiedEntity */
+export function convertGlobalEvent(e: GlobalEvent): UnifiedEntity | null {
+  if (!isValidCoordinate(e.lng, e.lat)) return null
+
+  return {
+    id: e.id,
+    type: "weather", // events are typed as weather/earthquake based on e.type
+    geometry: makePoint(e.lng, e.lat),
+    state: {
+      classification: e.type,
+    },
+    time: {
+      observed_at: e.timestamp || new Date().toISOString(),
+      valid_from: e.timestamp || new Date().toISOString(),
+    },
+    confidence: 0.9,
+    source: "global-events",
+    properties: {
+      title: e.title,
+      severity: e.severity,
+      eventType: e.type,
+    },
+    s2_cell: "",
+  }
+}
+
+// ============================================================================
+// Fungal Observation Converters
+// ============================================================================
+
+/** Convert crep-data-service FungalObservation to UnifiedEntity */
+export function convertFungalObservation(f: FungalObservation): UnifiedEntity | null {
+  if (!isValidCoordinate(f.lng, f.lat)) return null
+
+  return {
+    id: f.id,
+    type: "fungal",
+    geometry: makePoint(f.lng, f.lat),
+    state: {
+      classification: f.species,
+    },
+    time: {
+      observed_at: f.observedOn || new Date().toISOString(),
+      valid_from: f.observedOn || new Date().toISOString(),
+    },
+    confidence: 0.75,
+    source: "mindex",
+    properties: {
+      species: f.species,
+      location: f.location,
+      observedOn: f.observedOn,
+    },
+    s2_cell: "",
+  }
+}
+
+// ============================================================================
+// Device Converters
+// ============================================================================
+
+/** Convert crep-data-service Device to UnifiedEntity */
+export function convertDevice(d: Device): UnifiedEntity | null {
+  if (!d.lat || !d.lng || !isValidCoordinate(d.lng, d.lat)) return null
+
+  return {
+    id: d.id,
+    type: "device",
+    geometry: makePoint(d.lng, d.lat),
+    state: {
+      classification: d.type || "mycobrain",
+    },
+    time: {
+      observed_at: d.lastSeen || new Date().toISOString(),
+      valid_from: d.lastSeen || new Date().toISOString(),
+    },
+    confidence: d.status === "online" ? 1.0 : 0.5,
+    source: "mycobrain",
+    properties: {
+      name: d.name,
+      type: d.type,
+      status: d.status,
+    },
+    s2_cell: "",
+  }
+}
+
+// ============================================================================
+// Batch Converters
+// ============================================================================
+
+/** Convert arrays of any entity type, filtering out invalid entries */
+export function convertBatch<T>(
+  items: T[],
+  converter: (item: T) => UnifiedEntity | null
+): UnifiedEntity[] {
+  const results: UnifiedEntity[] = []
+  for (const item of items) {
+    const entity = converter(item)
+    if (entity) results.push(entity)
+  }
+  return results
+}
+
+/** Get [lng, lat] from a UnifiedEntity, returns null if not a Point */
+export function getEntityCoordinates(entity: UnifiedEntity): [number, number] | null {
+  if (entity.geometry.type !== "Point") return null
+  const [lng, lat] = entity.geometry.coordinates
+  if (!isValidCoordinate(lng, lat)) return null
+  return [lng, lat]
+}
+
+/** Get latitude from a UnifiedEntity */
+export function getEntityLatitude(entity: UnifiedEntity): number | null {
+  const coords = getEntityCoordinates(entity)
+  return coords ? coords[1] : null
+}
+
+/** Get longitude from a UnifiedEntity */
+export function getEntityLongitude(entity: UnifiedEntity): number | null {
+  const coords = getEntityCoordinates(entity)
+  return coords ? coords[0] : null
+}

--- a/lib/crep/entities/entity-validators.ts
+++ b/lib/crep/entities/entity-validators.ts
@@ -1,0 +1,230 @@
+/**
+ * Entity Validators
+ *
+ * Runtime validation for all CREP entity data at API boundaries.
+ * Catches invalid coordinates, unrealistic values, and malformed data
+ * before it reaches the UI layer.
+ */
+
+import type { UnifiedEntity } from "./unified-entity-schema"
+import { isValidCoordinate } from "./entity-converters"
+
+// ============================================================================
+// Validation Result Type
+// ============================================================================
+
+export interface ValidationResult {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+}
+
+// ============================================================================
+// Coordinate Validation
+// ============================================================================
+
+export function validateCoordinates(lng: number, lat: number): ValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  if (typeof lng !== "number" || isNaN(lng)) {
+    errors.push("Longitude is not a valid number")
+  } else if (lng < -180 || lng > 180) {
+    errors.push(`Longitude ${lng} out of range [-180, 180]`)
+  }
+
+  if (typeof lat !== "number" || isNaN(lat)) {
+    errors.push("Latitude is not a valid number")
+  } else if (lat < -90 || lat > 90) {
+    errors.push(`Latitude ${lat} out of range [-90, 90]`)
+  }
+
+  // Warn about null island (0,0) which is often a data quality issue
+  if (lng === 0 && lat === 0) {
+    warnings.push("Coordinates are at null island (0,0) - possible data quality issue")
+  }
+
+  return { valid: errors.length === 0, errors, warnings }
+}
+
+// ============================================================================
+// Aircraft Validation
+// ============================================================================
+
+const MAX_AIRCRAFT_ALTITUDE_FT = 60000
+const MAX_AIRCRAFT_SPEED_KTS = 2500
+
+export function validateAircraftData(props: Record<string, unknown>): ValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  const altitude = props.altitude as number | undefined
+  if (altitude !== undefined && altitude !== null) {
+    if (altitude < -1000 || altitude > MAX_AIRCRAFT_ALTITUDE_FT) {
+      warnings.push(`Aircraft altitude ${altitude}ft outside realistic range`)
+    }
+  }
+
+  const speed = props.velocity as number | undefined
+  if (speed !== undefined && speed !== null) {
+    if (speed < 0 || speed > MAX_AIRCRAFT_SPEED_KTS) {
+      warnings.push(`Aircraft speed ${speed}kts outside realistic range`)
+    }
+  }
+
+  const heading = props.heading as number | undefined
+  if (heading !== undefined && heading !== null) {
+    if (heading < 0 || heading > 360) {
+      warnings.push(`Aircraft heading ${heading}° outside [0, 360]`)
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings }
+}
+
+// ============================================================================
+// Vessel Validation
+// ============================================================================
+
+const MAX_VESSEL_SPEED_KTS = 50
+
+export function validateVesselData(props: Record<string, unknown>): ValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  const speed = props.sog as number | undefined
+  if (speed !== undefined && speed !== null) {
+    if (speed < 0 || speed > MAX_VESSEL_SPEED_KTS) {
+      warnings.push(`Vessel speed ${speed}kts outside realistic range [0, ${MAX_VESSEL_SPEED_KTS}]`)
+    }
+  }
+
+  const heading = props.heading as number | undefined
+  if (heading !== undefined && heading !== null) {
+    if (heading < 0 || heading > 360) {
+      warnings.push(`Vessel heading ${heading}° outside [0, 360]`)
+    }
+  }
+
+  const draught = props.draught as number | undefined
+  if (draught !== undefined && draught !== null) {
+    if (draught < 0 || draught > 30) {
+      warnings.push(`Vessel draught ${draught}m outside realistic range [0, 30]`)
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings }
+}
+
+// ============================================================================
+// Satellite Validation
+// ============================================================================
+
+const MIN_SATELLITE_PERIOD_MIN = 85
+const MAX_SATELLITE_PERIOD_MIN = 1500
+
+export function validateSatelliteData(props: Record<string, unknown>): ValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  const orbitalParams = props.orbitalParams as Record<string, number> | undefined
+  if (orbitalParams?.period !== undefined) {
+    if (orbitalParams.period < MIN_SATELLITE_PERIOD_MIN || orbitalParams.period > MAX_SATELLITE_PERIOD_MIN) {
+      warnings.push(
+        `Satellite period ${orbitalParams.period}min outside realistic range [${MIN_SATELLITE_PERIOD_MIN}, ${MAX_SATELLITE_PERIOD_MIN}]`
+      )
+    }
+  }
+
+  const altitude = props.altitude as number | undefined
+  if (altitude !== undefined && altitude !== null) {
+    if (altitude < 100 || altitude > 42000) {
+      warnings.push(`Satellite altitude ${altitude}km outside realistic range [100, 42000]`)
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings }
+}
+
+// ============================================================================
+// Unified Entity Validation
+// ============================================================================
+
+export function validateEntity(entity: UnifiedEntity): ValidationResult {
+  const allErrors: string[] = []
+  const allWarnings: string[] = []
+
+  // ID validation
+  if (!entity.id || typeof entity.id !== "string") {
+    allErrors.push("Entity missing valid ID")
+  }
+
+  // Type validation
+  const validTypes = ["aircraft", "vessel", "satellite", "fungal", "weather", "earthquake", "elephant", "device"]
+  if (!validTypes.includes(entity.type)) {
+    allWarnings.push(`Unknown entity type: ${entity.type}`)
+  }
+
+  // Geometry validation
+  if (entity.geometry.type === "Point") {
+    const [lng, lat] = entity.geometry.coordinates
+    const coordResult = validateCoordinates(lng, lat)
+    allErrors.push(...coordResult.errors)
+    allWarnings.push(...coordResult.warnings)
+  }
+
+  // Type-specific validation
+  switch (entity.type) {
+    case "aircraft":
+      const aircraftResult = validateAircraftData(entity.properties)
+      allErrors.push(...aircraftResult.errors)
+      allWarnings.push(...aircraftResult.warnings)
+      break
+    case "vessel":
+      const vesselResult = validateVesselData(entity.properties)
+      allErrors.push(...vesselResult.errors)
+      allWarnings.push(...vesselResult.warnings)
+      break
+    case "satellite":
+      const satResult = validateSatelliteData(entity.properties)
+      allErrors.push(...satResult.errors)
+      allWarnings.push(...satResult.warnings)
+      break
+  }
+
+  // Time validation
+  if (!entity.time?.observed_at) {
+    allWarnings.push("Entity missing observed_at timestamp")
+  }
+
+  // Confidence validation
+  if (entity.confidence < 0 || entity.confidence > 1) {
+    allWarnings.push(`Confidence ${entity.confidence} outside [0, 1]`)
+  }
+
+  return {
+    valid: allErrors.length === 0,
+    errors: allErrors,
+    warnings: allWarnings,
+  }
+}
+
+/** Validate and filter an array of entities, logging warnings */
+export function validateBatch(
+  entities: UnifiedEntity[],
+  logWarnings = false
+): UnifiedEntity[] {
+  return entities.filter((entity) => {
+    const result = validateEntity(entity)
+    if (!result.valid) {
+      if (logWarnings) {
+        console.warn(`[CREP Validator] Dropping invalid entity ${entity.id}:`, result.errors)
+      }
+      return false
+    }
+    if (logWarnings && result.warnings.length > 0) {
+      console.debug(`[CREP Validator] Warnings for ${entity.id}:`, result.warnings)
+    }
+    return true
+  })
+}

--- a/lib/crep/index.ts
+++ b/lib/crep/index.ts
@@ -53,6 +53,62 @@ export type {
   UnifiedEntityWithTimeline,
 } from "./entities/unified-entity-schema"
 
+// Entity Converters
+export {
+  isValidCoordinate,
+  extractCoordinates,
+  makePoint,
+  convertSimpleAircraft,
+  convertAircraftEntity,
+  convertSimpleVessel,
+  convertVesselEntity,
+  convertSimpleSatellite,
+  convertSatelliteEntity,
+  convertGlobalEvent,
+  convertFungalObservation,
+  convertDevice,
+  convertBatch,
+  getEntityCoordinates,
+  getEntityLatitude,
+  getEntityLongitude,
+} from "./entities/entity-converters"
+
+// Entity Validators
+export {
+  validateCoordinates,
+  validateEntity,
+  validateBatch,
+  type ValidationResult,
+} from "./entities/entity-validators"
+
+// MYCA-CREP Integration Bridge
+export {
+  parseMYCACommandForCREP,
+  buildCREPContextForMYCA,
+  buildEntityContextForMYCA,
+  CREP_VOICE_COMMANDS,
+  type CREPCommand,
+  type CREPCommandResult,
+  type CREPCommandType,
+  type CREPContextForMYCA,
+} from "./myca-integration"
+
+// MINDEX-CREP Integration Pipeline
+export {
+  fetchMINDEXObservations,
+  convertMINDEXToEntities,
+  fetchSpeciesDetails,
+  buildEnvironmentalContext,
+  correlateWeatherWithFungal,
+  type MINDEXObservation,
+  type MINDEXSpeciesDetail,
+  type MINDEXSearchParams,
+  type MINDEXSearchResult,
+} from "./mindex-integration"
+
+// Streaming Client
+export { EntityStreamClient, type ConnectionState, type EntityStreamConnectOptions } from "./streaming/entity-websocket-client"
+
 // S2 Spatial Indexing
 export {
   getS2CellId,

--- a/lib/crep/mindex-integration.ts
+++ b/lib/crep/mindex-integration.ts
@@ -1,0 +1,345 @@
+/**
+ * MINDEX-CREP Bidirectional Data Pipeline
+ *
+ * Connects MINDEX fungal/biodiversity database with CREP map visualization.
+ *
+ * MINDEX → CREP:
+ * - Fungal observation geopoints for map markers
+ * - Species data enrichment for popups/details
+ * - Research data for CREP entity analysis
+ * - Biodiversity hotspot heatmaps
+ *
+ * CREP → MINDEX:
+ * - Viewport-bounded observation queries
+ * - Device sensor data enrichment (correlate environmental with fungal)
+ * - Event-observation correlation (weather events → fungal growth)
+ * - CREP entity data for MINDEX research analysis
+ *
+ * Uses centralized API_URLS config.
+ */
+
+import { API_URLS, MINDEX_ENDPOINTS } from "@/lib/config/api-urls"
+import type { UnifiedEntity } from "@/lib/crep/entities/unified-entity-schema"
+import { makePoint, isValidCoordinate } from "@/lib/crep/entities/entity-converters"
+import type { GeoBounds } from "@/types/oei"
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface MINDEXObservation {
+  id: string
+  species_name: string
+  scientific_name: string
+  common_name?: string
+  latitude: number
+  longitude: number
+  observed_on: string
+  observer?: string
+  image_url?: string
+  thumbnail_url?: string
+  source: "mindex" | "inaturalist" | "gbif"
+  source_url?: string
+  quality_grade?: "research" | "needs_id" | "casual"
+  is_toxic?: boolean
+  habitat?: string
+  notes?: string
+}
+
+export interface MINDEXSpeciesDetail {
+  id: string
+  scientific_name: string
+  common_name: string
+  kingdom: string
+  phylum: string
+  class: string
+  order: string
+  family: string
+  genus: string
+  description?: string
+  edibility?: "edible" | "inedible" | "toxic" | "deadly" | "unknown"
+  habitat?: string[]
+  season?: string[]
+  images: Array<{ url: string; attribution?: string }>
+  observation_count: number
+  compounds?: Array<{ name: string; type: string }>
+}
+
+export interface MINDEXSearchParams {
+  query?: string
+  bounds?: GeoBounds
+  species?: string
+  source?: "mindex" | "inaturalist" | "gbif"
+  limit?: number
+  offset?: number
+  quality?: "research" | "needs_id" | "casual"
+  since?: string
+}
+
+export interface MINDEXSearchResult {
+  observations: MINDEXObservation[]
+  total: number
+  page: number
+  hasMore: boolean
+  sources: {
+    mindex: number
+    inaturalist: number
+    gbif: number
+  }
+}
+
+// ============================================================================
+// MINDEX → CREP: Fetch & Convert
+// ============================================================================
+
+/** Fetch fungal observations from MINDEX within map bounds */
+export async function fetchMINDEXObservations(
+  params: MINDEXSearchParams
+): Promise<MINDEXSearchResult> {
+  try {
+    const url = new URL(`${API_URLS.LOCAL_BASE}/api/crep/fungal`)
+
+    if (params.query) url.searchParams.set("q", params.query)
+    if (params.species) url.searchParams.set("species", params.species)
+    if (params.source) url.searchParams.set("source", params.source)
+    if (params.limit) url.searchParams.set("limit", String(params.limit))
+    if (params.offset) url.searchParams.set("offset", String(params.offset))
+    if (params.quality) url.searchParams.set("quality", params.quality)
+    if (params.since) url.searchParams.set("since", params.since)
+
+    if (params.bounds) {
+      url.searchParams.set("north", String(params.bounds.north))
+      url.searchParams.set("south", String(params.bounds.south))
+      url.searchParams.set("east", String(params.bounds.east))
+      url.searchParams.set("west", String(params.bounds.west))
+    }
+
+    const response = await fetch(url.toString(), {
+      signal: AbortSignal.timeout(15000),
+    })
+
+    if (!response.ok) {
+      console.warn(`[MINDEX] Fetch failed: ${response.status}`)
+      return { observations: [], total: 0, page: 0, hasMore: false, sources: { mindex: 0, inaturalist: 0, gbif: 0 } }
+    }
+
+    const data = await response.json()
+
+    // Normalize response format
+    const observations: MINDEXObservation[] = (data.observations || data.results || []).map(
+      (obs: Record<string, unknown>) => ({
+        id: obs.id || obs.uuid || `obs-${Math.random().toString(36).slice(2)}`,
+        species_name: obs.species_name || obs.species || obs.taxon_name || "Unknown",
+        scientific_name: obs.scientific_name || obs.scientificName || obs.species_name || "Unknown",
+        common_name: obs.common_name || obs.commonName,
+        latitude: Number(obs.latitude || obs.lat || 0),
+        longitude: Number(obs.longitude || obs.lng || obs.lon || 0),
+        observed_on: obs.observed_on || obs.observedOn || obs.observed_at || new Date().toISOString(),
+        observer: obs.observer || obs.user_name,
+        image_url: obs.image_url || obs.imageUrl,
+        thumbnail_url: obs.thumbnail_url || obs.thumbnailUrl,
+        source: obs.source || "mindex",
+        source_url: obs.source_url || obs.sourceUrl,
+        quality_grade: obs.quality_grade || obs.qualityGrade,
+        is_toxic: obs.is_toxic || obs.isToxic,
+        habitat: obs.habitat,
+        notes: obs.notes,
+      })
+    )
+
+    return {
+      observations,
+      total: data.total || observations.length,
+      page: data.page || 0,
+      hasMore: data.hasMore ?? observations.length === (params.limit || 50),
+      sources: data.sources || { mindex: observations.length, inaturalist: 0, gbif: 0 },
+    }
+  } catch (error) {
+    console.error("[MINDEX] Fetch error:", error)
+    return { observations: [], total: 0, page: 0, hasMore: false, sources: { mindex: 0, inaturalist: 0, gbif: 0 } }
+  }
+}
+
+/** Convert MINDEX observations to UnifiedEntities for CREP map */
+export function convertMINDEXToEntities(observations: MINDEXObservation[]): UnifiedEntity[] {
+  return observations
+    .filter((obs) => isValidCoordinate(obs.longitude, obs.latitude))
+    .map((obs) => ({
+      id: obs.id,
+      type: "fungal" as const,
+      geometry: makePoint(obs.longitude, obs.latitude),
+      state: {
+        classification: obs.scientific_name,
+      },
+      time: {
+        observed_at: obs.observed_on,
+        valid_from: obs.observed_on,
+      },
+      confidence: obs.quality_grade === "research" ? 0.95 : obs.quality_grade === "needs_id" ? 0.6 : 0.4,
+      source: obs.source,
+      properties: {
+        species: obs.species_name,
+        scientificName: obs.scientific_name,
+        commonName: obs.common_name,
+        observer: obs.observer,
+        imageUrl: obs.image_url,
+        thumbnailUrl: obs.thumbnail_url,
+        sourceUrl: obs.source_url,
+        isToxic: obs.is_toxic,
+        habitat: obs.habitat,
+        qualityGrade: obs.quality_grade,
+      },
+      s2_cell: "",
+    }))
+}
+
+/** Fetch species details from MINDEX for entity enrichment */
+export async function fetchSpeciesDetails(
+  scientificName: string
+): Promise<MINDEXSpeciesDetail | null> {
+  try {
+    const response = await fetch(
+      `${API_URLS.LOCAL_BASE}/api/natureos/mindex/search?q=${encodeURIComponent(scientificName)}&limit=1`,
+      { signal: AbortSignal.timeout(10000) }
+    )
+
+    if (!response.ok) return null
+
+    const data = await response.json()
+    const species = data.results?.[0] || data.species?.[0]
+    if (!species) return null
+
+    return {
+      id: species.id || scientificName,
+      scientific_name: species.scientific_name || species.scientificName || scientificName,
+      common_name: species.common_name || species.commonName || "",
+      kingdom: species.kingdom || "Fungi",
+      phylum: species.phylum || "",
+      class: species.class || "",
+      order: species.order || "",
+      family: species.family || "",
+      genus: species.genus || "",
+      description: species.description,
+      edibility: species.edibility,
+      habitat: species.habitat,
+      season: species.season,
+      images: species.images || [],
+      observation_count: species.observation_count || species.observationCount || 0,
+      compounds: species.compounds,
+    }
+  } catch (error) {
+    console.warn("[MINDEX] Species detail fetch error:", error)
+    return null
+  }
+}
+
+// ============================================================================
+// CREP → MINDEX: Context & Enrichment
+// ============================================================================
+
+/** Build environmental context from CREP data for MINDEX enrichment */
+export function buildEnvironmentalContext(
+  entities: UnifiedEntity[],
+  viewport: { center: [number, number]; zoom: number }
+): Record<string, unknown> {
+  // Count entity types in viewport
+  const typeCounts: Record<string, number> = {}
+  for (const e of entities) {
+    typeCounts[e.type] = (typeCounts[e.type] || 0) + 1
+  }
+
+  // Find weather events that could affect fungal growth
+  const weatherEvents = entities
+    .filter((e) => e.type === "weather" || e.type === "earthquake")
+    .map((e) => ({
+      type: e.properties.eventType || e.state.classification,
+      severity: e.properties.severity,
+      title: e.properties.title,
+    }))
+
+  // Find device sensor data
+  const deviceReadings = entities
+    .filter((e) => e.type === "device" && e.properties.status === "online")
+    .map((e) => ({
+      name: e.properties.name,
+      humidity: e.properties.humidity,
+      temperature: e.properties.temperature,
+      pressure: e.properties.pressure,
+    }))
+
+  return {
+    viewport: {
+      center: viewport.center,
+      zoom: viewport.zoom,
+    },
+    entityCounts: typeCounts,
+    weatherEvents,
+    deviceReadings,
+    timestamp: new Date().toISOString(),
+  }
+}
+
+/** Correlate weather events with fungal observation density */
+export function correlateWeatherWithFungal(
+  weatherEntities: UnifiedEntity[],
+  fungalEntities: UnifiedEntity[],
+  radiusKm = 100
+): Array<{
+  event: UnifiedEntity
+  nearbyFungalCount: number
+  correlation: string
+}> {
+  const results: Array<{
+    event: UnifiedEntity
+    nearbyFungalCount: number
+    correlation: string
+  }> = []
+
+  for (const event of weatherEntities) {
+    if (event.geometry.type !== "Point") continue
+    const [eLng, eLat] = event.geometry.coordinates
+
+    let nearbyCount = 0
+    for (const fungal of fungalEntities) {
+      if (fungal.geometry.type !== "Point") continue
+      const [fLng, fLat] = fungal.geometry.coordinates
+      const dist = haversineDistance(eLat, eLng, fLat, fLng)
+      if (dist <= radiusKm) nearbyCount++
+    }
+
+    const eventType = String(event.state.classification || "")
+    let correlation = "none"
+    if (nearbyCount > 10) {
+      correlation = eventType.includes("rain") || eventType.includes("storm")
+        ? "high_moisture_fungal_bloom"
+        : eventType.includes("fire")
+          ? "post_fire_pioneer_species"
+          : "spatial_correlation"
+    } else if (nearbyCount > 0) {
+      correlation = "weak_spatial_correlation"
+    }
+
+    results.push({ event, nearbyFungalCount: nearbyCount, correlation })
+  }
+
+  return results
+}
+
+/** Simple haversine distance in km */
+function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): number {
+  const R = 6371
+  const dLat = ((lat2 - lat1) * Math.PI) / 180
+  const dLon = ((lon2 - lon1) * Math.PI) / 180
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2)
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}

--- a/lib/crep/myca-integration.ts
+++ b/lib/crep/myca-integration.ts
@@ -1,0 +1,377 @@
+/**
+ * MYCA-CREP Bidirectional Integration Bridge
+ *
+ * Connects MYCA AI capabilities with the CREP dashboard for:
+ *
+ * MYCA → CREP:
+ * - Voice commands for map navigation (fly to, zoom, pan)
+ * - Natural language entity queries ("show me aircraft near San Diego")
+ * - AI-driven layer control ("enable weather layers")
+ * - Mission creation and management via conversation
+ * - Entity analysis and identification
+ *
+ * CREP → MYCA:
+ * - Entity context for AI conversations ("tell me about this aircraft")
+ * - Map viewport context for location-aware responses
+ * - Event notifications for AI processing
+ * - Sensor data summaries from devices
+ * - Anomaly detection alerts
+ *
+ * Integrates with PersonaPlex for voice control on the map.
+ */
+
+import type { UnifiedEntity } from "@/lib/crep/entities/unified-entity-schema"
+import type { MYCAMessage, MYCASendOptions } from "@/contexts/myca-context"
+import type { CREPMapState, MissionContext, LayerVisibility } from "@/contexts/crep-context"
+import { getEntityCoordinates } from "@/lib/crep/entities/entity-converters"
+
+// ============================================================================
+// MYCA → CREP: Command Types
+// ============================================================================
+
+export type CREPCommandType =
+  | "fly_to"
+  | "zoom"
+  | "pan"
+  | "reset_view"
+  | "show_layer"
+  | "hide_layer"
+  | "toggle_layer"
+  | "select_entity"
+  | "filter_entities"
+  | "create_mission"
+  | "update_mission"
+  | "search_entities"
+  | "get_entity_details"
+  | "get_view_context"
+  | "get_system_status"
+  | "analyze_area"
+  | "track_entity"
+
+export interface CREPCommand {
+  type: CREPCommandType
+  params: Record<string, unknown>
+  source: "myca" | "voice" | "search"
+  timestamp: string
+}
+
+export interface CREPCommandResult {
+  success: boolean
+  message: string
+  data?: unknown
+}
+
+// ============================================================================
+// CREP → MYCA: Context Types
+// ============================================================================
+
+export interface CREPContextForMYCA {
+  /** Current map viewport */
+  viewport: {
+    center: [number, number]
+    zoom: number
+    bounds?: { north: number; south: number; east: number; west: number }
+  }
+  /** Summary of visible entities */
+  entitySummary: {
+    aircraft: number
+    vessels: number
+    satellites: number
+    fungalObservations: number
+    globalEvents: number
+    devices: number
+    total: number
+  }
+  /** Active mission context */
+  mission?: {
+    name: string
+    type: string
+    objective: string
+    status: string
+  }
+  /** Active layers */
+  activeLayers: string[]
+  /** Recent events (last 5) */
+  recentEvents: Array<{
+    type: string
+    title: string
+    severity: string
+    timestamp: string
+  }>
+  /** Selected entity details */
+  selectedEntity?: {
+    id: string
+    type: string
+    properties: Record<string, unknown>
+    coordinates: [number, number] | null
+  }
+  /** Stream connection status */
+  streamStatus: string
+}
+
+// ============================================================================
+// Command Parser — Extracts CREP commands from MYCA responses
+// ============================================================================
+
+/** Parse MYCA natural language into CREP commands */
+export function parseMYCACommandForCREP(
+  text: string,
+  currentContext?: CREPContextForMYCA
+): CREPCommand | null {
+  const lower = text.toLowerCase().trim()
+
+  // Map navigation commands
+  if (/\b(fly\s*to|go\s*to|navigate\s*to|show\s*me|zoom\s*to)\b/i.test(lower)) {
+    // Extract location from text
+    const locationMatch = lower.match(
+      /(?:fly\s*to|go\s*to|navigate\s*to|show\s*me|zoom\s*to)\s+(.+?)(?:\.|$)/i
+    )
+    if (locationMatch) {
+      return {
+        type: "fly_to",
+        params: { query: locationMatch[1].trim() },
+        source: "myca",
+        timestamp: new Date().toISOString(),
+      }
+    }
+  }
+
+  // Zoom commands
+  if (/\b(zoom\s*in|zoom\s*out|zoom\s*level)\b/i.test(lower)) {
+    const zoomIn = /zoom\s*in/i.test(lower)
+    const levelMatch = lower.match(/zoom\s*(?:level\s*)?(\d+)/i)
+    return {
+      type: "zoom",
+      params: levelMatch
+        ? { level: parseInt(levelMatch[1]) }
+        : { delta: zoomIn ? 2 : -2 },
+      source: "myca",
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  // Layer commands
+  const layerMatch = lower.match(
+    /\b(show|hide|enable|disable|toggle|turn\s*on|turn\s*off)\b.*?\b(aircraft|vessels?|ships?|satellites?|weather|wind|precipitation|clouds?|fungal|mushroom|devices?|events?|trajectories?|fire|storms?|spore|pressure|humidity)\b/i
+  )
+  if (layerMatch) {
+    const action = layerMatch[1].toLowerCase()
+    const show = /show|enable|turn\s*on/i.test(action)
+    const hide = /hide|disable|turn\s*off/i.test(action)
+
+    const layerMap: Record<string, keyof LayerVisibility> = {
+      aircraft: "aircraft",
+      vessel: "vessels",
+      vessels: "vessels",
+      ship: "vessels",
+      ships: "vessels",
+      satellite: "satellites",
+      satellites: "satellites",
+      weather: "weather",
+      wind: "wind",
+      precipitation: "precipitation",
+      cloud: "clouds",
+      clouds: "clouds",
+      fungal: "fungalObservations",
+      mushroom: "fungalObservations",
+      device: "devices",
+      devices: "devices",
+      event: "globalEvents",
+      events: "globalEvents",
+      trajectory: "trajectories",
+      trajectories: "trajectories",
+      fire: "fire",
+      storm: "stormCells",
+      storms: "stormCells",
+      spore: "sporeDispersal",
+      pressure: "pressure",
+      humidity: "humidity",
+    }
+
+    const layerKey = layerMap[layerMatch[2].toLowerCase()]
+    if (layerKey) {
+      return {
+        type: show ? "show_layer" : hide ? "hide_layer" : "toggle_layer",
+        params: { layer: layerKey },
+        source: "myca",
+        timestamp: new Date().toISOString(),
+      }
+    }
+  }
+
+  // Entity search commands
+  if (/\b(find|search|locate|where\s*is|where\s*are)\b/i.test(lower)) {
+    return {
+      type: "search_entities",
+      params: { query: lower },
+      source: "myca",
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  // Status/context commands
+  if (/\b(status|what.*seeing|what.*visible|view\s*context|system\s*status)\b/i.test(lower)) {
+    return {
+      type: "get_system_status",
+      params: {},
+      source: "myca",
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  // Mission commands
+  if (/\b(create|start|begin|new)\s*(mission|operation|task)\b/i.test(lower)) {
+    const nameMatch = lower.match(/(?:called|named)\s+"?(.+?)"?(?:\s|$)/i)
+    return {
+      type: "create_mission",
+      params: {
+        name: nameMatch?.[1] || undefined,
+        query: lower,
+      },
+      source: "myca",
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  // Reset commands
+  if (/\b(reset|default|home)\s*(view|map|position)?\b/i.test(lower)) {
+    return {
+      type: "reset_view",
+      params: {},
+      source: "myca",
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  return null
+}
+
+// ============================================================================
+// Context Builder — Builds CREP context for MYCA conversations
+// ============================================================================
+
+/** Build context string for MYCA about current CREP state */
+export function buildCREPContextForMYCA(context: CREPContextForMYCA): string {
+  const parts: string[] = []
+
+  // Viewport context
+  parts.push(
+    `CREP Dashboard viewport: center [${context.viewport.center[0].toFixed(2)}, ${context.viewport.center[1].toFixed(2)}], zoom ${context.viewport.zoom.toFixed(1)}`
+  )
+
+  // Entity summary
+  const { entitySummary } = context
+  const entityParts: string[] = []
+  if (entitySummary.aircraft > 0) entityParts.push(`${entitySummary.aircraft} aircraft`)
+  if (entitySummary.vessels > 0) entityParts.push(`${entitySummary.vessels} vessels`)
+  if (entitySummary.satellites > 0) entityParts.push(`${entitySummary.satellites} satellites`)
+  if (entitySummary.fungalObservations > 0) entityParts.push(`${entitySummary.fungalObservations} fungal observations`)
+  if (entitySummary.globalEvents > 0) entityParts.push(`${entitySummary.globalEvents} global events`)
+  if (entitySummary.devices > 0) entityParts.push(`${entitySummary.devices} MycoBrain devices`)
+  if (entityParts.length > 0) {
+    parts.push(`Visible entities: ${entityParts.join(", ")} (${entitySummary.total} total)`)
+  }
+
+  // Mission context
+  if (context.mission) {
+    parts.push(
+      `Active mission: "${context.mission.name}" (${context.mission.type}) - ${context.mission.status}: ${context.mission.objective}`
+    )
+  }
+
+  // Active layers
+  if (context.activeLayers.length > 0) {
+    parts.push(`Active layers: ${context.activeLayers.join(", ")}`)
+  }
+
+  // Selected entity
+  if (context.selectedEntity) {
+    const { selectedEntity } = context
+    parts.push(
+      `Selected entity: ${selectedEntity.type} "${selectedEntity.id}" at [${selectedEntity.coordinates?.join(", ") || "unknown"}]`
+    )
+  }
+
+  // Recent events
+  if (context.recentEvents.length > 0) {
+    const eventSummary = context.recentEvents
+      .map((e) => `${e.type}: ${e.title} (${e.severity})`)
+      .join("; ")
+    parts.push(`Recent events: ${eventSummary}`)
+  }
+
+  // Stream status
+  parts.push(`Stream status: ${context.streamStatus}`)
+
+  return parts.join("\n")
+}
+
+/** Build context for a specific entity to send to MYCA */
+export function buildEntityContextForMYCA(entity: UnifiedEntity): string {
+  const coords = getEntityCoordinates(entity)
+  const parts: string[] = [
+    `Entity type: ${entity.type}`,
+    `ID: ${entity.id}`,
+    `Source: ${entity.source}`,
+    `Observed at: ${entity.time.observed_at}`,
+  ]
+
+  if (coords) {
+    parts.push(`Location: [${coords[0].toFixed(4)}, ${coords[1].toFixed(4)}]`)
+  }
+
+  if (entity.state.altitude !== undefined) {
+    parts.push(`Altitude: ${entity.state.altitude}`)
+  }
+
+  if (entity.state.heading !== undefined) {
+    parts.push(`Heading: ${entity.state.heading}°`)
+  }
+
+  // Add type-specific properties
+  const props = entity.properties
+  switch (entity.type) {
+    case "aircraft":
+      if (props.callsign) parts.push(`Callsign: ${props.callsign}`)
+      if (props.airline) parts.push(`Airline: ${props.airline}`)
+      if (props.origin && props.destination) {
+        parts.push(`Route: ${props.origin} → ${props.destination}`)
+      }
+      break
+    case "vessel":
+      if (props.name) parts.push(`Name: ${props.name}`)
+      if (props.mmsi) parts.push(`MMSI: ${props.mmsi}`)
+      if (props.destination) parts.push(`Destination: ${props.destination}`)
+      break
+    case "satellite":
+      if (props.name) parts.push(`Name: ${props.name}`)
+      if (props.orbitType) parts.push(`Orbit: ${props.orbitType}`)
+      break
+    case "fungal":
+      if (props.species) parts.push(`Species: ${props.species}`)
+      if (props.location) parts.push(`Location: ${props.location}`)
+      break
+    case "device":
+      if (props.name) parts.push(`Device: ${props.name}`)
+      if (props.status) parts.push(`Status: ${props.status}`)
+      break
+  }
+
+  return parts.join("\n")
+}
+
+// ============================================================================
+// MYCA Voice Command Definitions for CREP
+// ============================================================================
+
+export const CREP_VOICE_COMMANDS = [
+  { pattern: "fly to *", description: "Navigate map to a location" },
+  { pattern: "zoom in/out", description: "Adjust map zoom level" },
+  { pattern: "show/hide [layer]", description: "Toggle map layers" },
+  { pattern: "what am I looking at", description: "Get CREP viewport context" },
+  { pattern: "tell me about this [entity]", description: "Get entity details" },
+  { pattern: "find [entity type] near *", description: "Search for entities" },
+  { pattern: "create mission *", description: "Start a new CREP mission" },
+  { pattern: "system status", description: "Get CREP system health" },
+  { pattern: "reset view", description: "Reset map to default position" },
+] as const

--- a/lib/crep/redis-cache.ts
+++ b/lib/crep/redis-cache.ts
@@ -26,6 +26,8 @@ export const CACHE_NAMESPACES = {
   SEARCH_TAXA: "search:taxa:",
   SEARCH_COMPOUNDS: "search:compounds:",
   SEARCH_OBSERVATIONS: "search:observations:",
+  SEARCH_CREP: "search:crep:",
+  CREP_ENTITIES: "crep:entities:",
 } as const
 
 // TTL configurations (in seconds)
@@ -38,6 +40,8 @@ export const CACHE_TTL = {
   SEARCH_TAXA: 3600,        // 1 hour - taxa don't change often
   SEARCH_COMPOUNDS: 3600,   // 1 hour - compounds are stable
   SEARCH_OBSERVATIONS: 300, // 5 minutes - observations update moderately
+  SEARCH_CREP: 120,         // 2 minutes - CREP search results
+  CREP_ENTITIES: 30,        // 30 seconds - real-time entity data
 } as const
 
 // Cache entry interface

--- a/lib/crep/streaming/entity-websocket-client.ts
+++ b/lib/crep/streaming/entity-websocket-client.ts
@@ -1,114 +1,238 @@
+/**
+ * Entity WebSocket Stream Client
+ *
+ * Connects to MAS WebSocket for real-time entity position updates.
+ * Features:
+ * - Exponential backoff reconnection (1.5s → 3s → 6s → 12s → 24s max)
+ * - Binary protobuf and JSON message support
+ * - S2 cell-based viewport filtering
+ * - Connection health monitoring
+ * - Proper error logging (no silent drops)
+ *
+ * Uses centralized API_URLS config — no hard-coded development IPs.
+ */
+
 import {
   decodeEntityBatchFromBinary,
   decodeEntityFromBinary,
-} from "@/lib/crep/proto/entity-codec";
-import { getViewportCells, MapBounds } from "@/lib/crep/spatial/s2-indexer";
-import type { UnifiedEntity } from "@/lib/crep/entities/unified-entity-schema";
-import { getSecureWebSocketUrl } from "@/lib/utils/websocket-url";
+} from "@/lib/crep/proto/entity-codec"
+import { getViewportCells, MapBounds } from "@/lib/crep/spatial/s2-indexer"
+import type { UnifiedEntity } from "@/lib/crep/entities/unified-entity-schema"
+import { getSecureWebSocketUrl } from "@/lib/utils/websocket-url"
+import { API_URLS } from "@/lib/config/api-urls"
 
 export interface EntityStreamConnectOptions {
-  types?: string[];
-  timeFrom?: string;
+  types?: string[]
+  timeFrom?: string
 }
 
+export type ConnectionState = "disconnected" | "connecting" | "connected" | "reconnecting"
+
+const BASE_RECONNECT_MS = 1500
+const MAX_RECONNECT_MS = 24000
+const MAX_RECONNECT_ATTEMPTS = 10
+
 export class EntityStreamClient {
-  private ws: WebSocket | null = null;
-  private cells = new Set<string>();
-  private readonly endpointBase: string;
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private onEntityHandler: ((entity: UnifiedEntity) => void) | null = null;
-  private options: EntityStreamConnectOptions = {};
+  private ws: WebSocket | null = null
+  private cells = new Set<string>()
+  private readonly endpointBase: string
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
+  private onEntityHandler: ((entity: UnifiedEntity) => void) | null = null
+  private onConnectionStateChange: ((state: ConnectionState) => void) | null = null
+  private onError: ((error: Error) => void) | null = null
+  private options: EntityStreamConnectOptions = {}
+  private _connectionState: ConnectionState = "disconnected"
+  private messageCount = 0
+  private lastMessageAt = 0
 
   constructor(endpointBase?: string) {
-    this.endpointBase =
-      endpointBase ||
-      process.env.NEXT_PUBLIC_MAS_WS_URL ||
-      "ws://192.168.0.188:8001";
+    // Use centralized API_URLS config with env var override — no hard-coded IPs
+    const masUrl = endpointBase || API_URLS.MAS
+    // Convert http(s) to ws(s)
+    this.endpointBase = masUrl.replace(/^http/, "ws")
   }
 
-  connect(onEntity: (entity: UnifiedEntity) => void, options: EntityStreamConnectOptions = {}): void {
-    this.onEntityHandler = onEntity;
-    this.options = options;
-    this.openSocket();
+  get connectionState(): ConnectionState {
+    return this._connectionState
+  }
+
+  get stats() {
+    return {
+      messageCount: this.messageCount,
+      lastMessageAt: this.lastMessageAt,
+      reconnectAttempts: this.reconnectAttempts,
+      connectionState: this._connectionState,
+      cellCount: this.cells.size,
+    }
+  }
+
+  connect(
+    onEntity: (entity: UnifiedEntity) => void,
+    options: EntityStreamConnectOptions = {},
+    callbacks?: {
+      onConnectionStateChange?: (state: ConnectionState) => void
+      onError?: (error: Error) => void
+    }
+  ): void {
+    this.onEntityHandler = onEntity
+    this.options = options
+    this.onConnectionStateChange = callbacks?.onConnectionStateChange || null
+    this.onError = callbacks?.onError || null
+    this.reconnectAttempts = 0
+    this.openSocket()
   }
 
   disconnect(): void {
     if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
     }
     if (this.ws) {
-      this.ws.close();
-      this.ws = null;
+      this.ws.onclose = null // Prevent reconnect on intentional close
+      this.ws.close()
+      this.ws = null
     }
+    this.setConnectionState("disconnected")
   }
 
   updateViewport(bounds: MapBounds, zoom: number): void {
-    const nextCells = new Set(getViewportCells(bounds, zoom));
-    if (this.setsEqual(this.cells, nextCells)) return;
-    this.cells = nextCells;
-    this.reconnect();
+    const nextCells = new Set(getViewportCells(bounds, zoom))
+    if (this.setsEqual(this.cells, nextCells)) return
+    this.cells = nextCells
+    this.reconnect()
+  }
+
+  private setConnectionState(state: ConnectionState): void {
+    if (this._connectionState === state) return
+    this._connectionState = state
+    this.onConnectionStateChange?.(state)
+  }
+
+  private getReconnectDelay(): number {
+    // Exponential backoff: 1.5s, 3s, 6s, 12s, 24s (capped)
+    const delay = Math.min(
+      BASE_RECONNECT_MS * Math.pow(2, this.reconnectAttempts),
+      MAX_RECONNECT_MS
+    )
+    return delay
   }
 
   private openSocket(): void {
-    if (!this.onEntityHandler) return;
+    if (!this.onEntityHandler) return
 
-    const wsBase = getSecureWebSocketUrl(this.endpointBase);
-    const url = new URL(`${wsBase.replace(/\/$/, "")}/api/entities/stream`);
+    this.setConnectionState("connecting")
+
+    const wsBase = getSecureWebSocketUrl(this.endpointBase)
+    const url = new URL(`${wsBase.replace(/\/$/, "")}/api/entities/stream`)
     if (this.cells.size > 0) {
-      url.searchParams.set("cells", [...this.cells].join(","));
+      url.searchParams.set("cells", [...this.cells].join(","))
     }
     if (this.options.types?.length) {
-      url.searchParams.set("types", this.options.types.join(","));
+      url.searchParams.set("types", this.options.types.join(","))
     }
     if (this.options.timeFrom) {
-      url.searchParams.set("time_from", this.options.timeFrom);
+      url.searchParams.set("time_from", this.options.timeFrom)
     }
 
-    this.ws = new WebSocket(url.toString());
-    this.ws.binaryType = "arraybuffer";
+    try {
+      this.ws = new WebSocket(url.toString())
+      this.ws.binaryType = "arraybuffer"
+    } catch (error) {
+      console.error("[EntityStream] Failed to create WebSocket:", error)
+      this.onError?.(error instanceof Error ? error : new Error(String(error)))
+      this.scheduleReconnect()
+      return
+    }
+
+    this.ws.onopen = () => {
+      this.reconnectAttempts = 0
+      this.setConnectionState("connected")
+      console.log("[EntityStream] Connected to MAS entity stream")
+    }
 
     this.ws.onmessage = (event: MessageEvent<ArrayBuffer | string>) => {
-      if (!this.onEntityHandler) return;
+      if (!this.onEntityHandler) return
+      this.messageCount++
+      this.lastMessageAt = Date.now()
+
       try {
         if (typeof event.data === "string") {
-          const parsed = JSON.parse(event.data) as UnifiedEntity;
-          this.onEntityHandler(parsed);
-          return;
+          const parsed = JSON.parse(event.data) as UnifiedEntity
+          this.onEntityHandler(parsed)
+          return
         }
 
-        const batch = decodeEntityBatchFromBinary(event.data);
+        // Try batch decode first (most common for binary)
+        const batch = decodeEntityBatchFromBinary(event.data)
         for (const entity of batch.entities) {
-          this.onEntityHandler(entity);
+          this.onEntityHandler(entity)
         }
-      } catch {
+      } catch (batchError) {
+        // Fallback: try single entity decode
         try {
           if (typeof event.data !== "string") {
-            const entity = decodeEntityFromBinary(event.data);
-            this.onEntityHandler(entity);
+            const entity = decodeEntityFromBinary(event.data)
+            this.onEntityHandler(entity)
           }
-        } catch {
-          // No-op: malformed payload from upstream source.
+        } catch (singleError) {
+          // Log decode failures instead of silently dropping
+          console.warn(
+            "[EntityStream] Failed to decode message:",
+            batchError instanceof Error ? batchError.message : "Unknown batch decode error"
+          )
         }
       }
-    };
+    }
 
-    this.ws.onclose = () => {
-      this.reconnectTimer = setTimeout(() => this.openSocket(), 1500);
-    };
+    this.ws.onerror = (event) => {
+      console.error("[EntityStream] WebSocket error:", event)
+      this.onError?.(new Error("WebSocket connection error"))
+    }
+
+    this.ws.onclose = (event) => {
+      console.log(
+        `[EntityStream] Connection closed (code: ${event.code}, reason: ${event.reason || "none"})`
+      )
+      this.scheduleReconnect()
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      console.error(
+        `[EntityStream] Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached. Giving up.`
+      )
+      this.setConnectionState("disconnected")
+      this.onError?.(
+        new Error(`Failed to reconnect after ${MAX_RECONNECT_ATTEMPTS} attempts`)
+      )
+      return
+    }
+
+    this.setConnectionState("reconnecting")
+    const delay = this.getReconnectDelay()
+    this.reconnectAttempts++
+
+    console.log(
+      `[EntityStream] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`
+    )
+
+    this.reconnectTimer = setTimeout(() => this.openSocket(), delay)
   }
 
   private reconnect(): void {
-    if (!this.onEntityHandler) return;
-    this.disconnect();
-    this.openSocket();
+    if (!this.onEntityHandler) return
+    this.disconnect()
+    this.reconnectAttempts = 0
+    this.openSocket()
   }
 
   private setsEqual(a: Set<string>, b: Set<string>): boolean {
-    if (a.size !== b.size) return false;
+    if (a.size !== b.size) return false
     for (const value of a) {
-      if (!b.has(value)) return false;
+      if (!b.has(value)) return false
     }
-    return true;
+    return true
   }
 }

--- a/lib/search/intent-parser.ts
+++ b/lib/search/intent-parser.ts
@@ -8,7 +8,7 @@
  * - Query type (factual, comparison, list, etc.)
  */
 
-export type EntityType = "species" | "compound" | "media" | "research" | "location" | "general"
+export type EntityType = "species" | "compound" | "media" | "research" | "location" | "crep" | "general"
 
 export type ToxicityFilter = "poisonous" | "toxic" | "deadly" | "edible" | "medicinal" | "psychedelic" | "hallucinogenic"
 
@@ -112,6 +112,18 @@ const COMPOUND_KEYWORDS = [
   "chitin", "melanin", "antioxidant", "formula", "structure",
 ]
 
+// CREP/environmental monitoring keywords
+const CREP_KEYWORDS = [
+  "aircraft", "airplane", "flight", "aviation", "plane", "planes",
+  "vessel", "ship", "maritime", "boat", "tanker", "cargo",
+  "satellite", "orbit", "space station", "iss", "starlink",
+  "earthquake", "seismic", "wildfire", "storm", "tsunami", "volcano",
+  "environmental", "radar", "tracking", "crep", "monitor",
+  "sensor", "device", "mycobrain", "spore", "dispersal",
+  "weather", "wind", "precipitation", "pressure",
+  "observation", "sighting", "observation map",
+]
+
 // Research keywords
 const RESEARCH_KEYWORDS = [
   "research", "study", "studies", "paper", "papers", "journal",
@@ -202,6 +214,9 @@ export function parseSearchIntent(query: string): SearchIntent {
   if (filters.mediaType) {
     type = "media"
     confidence = 0.85
+  } else if (CREP_KEYWORDS.some(kw => normalizedQuery.includes(kw))) {
+    type = "crep"
+    confidence = 0.85
   } else if (RESEARCH_KEYWORDS.some(kw => normalizedQuery.includes(kw))) {
     type = "research"
     confidence = 0.8
@@ -272,8 +287,12 @@ export function getSearchParamsFromIntent(intent: SearchIntent): {
       types.push("media")
       includeAI = true // AI can provide media info
       break
+    case "crep":
+      types.push("crep", "species", "observations")
+      locationBased = true
+      break
     case "location":
-      types.push("species", "observations")
+      types.push("species", "observations", "crep")
       locationBased = true
       break
     default:


### PR DESCRIPTION
## Summary by Sourcery

Unify CREP dashboard data and streaming around a centralized configuration and entity model, add bidirectional integrations with MYCA and MINDEX, and harden health, search, and error handling for CREP-related features.

New Features:
- Introduce a CREP React context provider with sub-contexts for entities, map state, layers, missions, and streaming, and wire it into the CREP dashboard loader.
- Add unified entity converters and validators to normalize and validate data across CREP services, WebSocket streams, and MINDEX.
- Expose a new CREP search API endpoint and integrate it into the fluid search UI and CrepWidget, including support for mixed CREP entity sources.
- Implement MYCA–CREP and MINDEX–CREP integration utilities to share context, commands, and environmental data between systems.
- Add a CREP-specific error boundary component to isolate and gracefully handle dashboard rendering failures.

Bug Fixes:
- Ensure CREP streaming and health endpoints no longer rely on hard-coded development IPs and instead use centralized configuration.

Enhancements:
- Extend the CREP data service with pagination, abort-signal support, richer type definitions, and centralized API_URLS configuration, removing hard-coded URLs.
- Upgrade the entity WebSocket client with configurable reconnect backoff, connection state tracking, statistics, better error reporting, and API_URLS-based endpoint selection.
- Improve the CREP SSE stream API and health check endpoints with centralized MAS/MINDEX URLs, richer payloads, and more detailed status metadata.
- Refine CREP voice map controls and PersonaPlex interaction with type-safe context access and fallbacks.

Chores:
- Extend Redis cache namespaces and TTL settings for CREP search and entity data to support the new integrations.