### PR TITLE
fix: cloudflared tunnel healthcheck, auto-restart, and deploy reliability

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -219,7 +219,7 @@ jobs:
     name: Deploy to Production (Proxmox)
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true')
     environment: production
     continue-on-error: false
     timeout-minutes: 30

--- a/_complete_deploy_sandbox.py
+++ b/_complete_deploy_sandbox.py
@@ -177,6 +177,33 @@ try:
         print(f"\n>> Container logs:")
         print(logs)
     
+    # Step 6b: Restart Cloudflare tunnel (systemd service on sandbox VM)
+    print(f"\n>> Restarting Cloudflare tunnel...")
+    for svc_name in ["cloudflared", "cloudflare-tunnel"]:
+        stdin, stdout, stderr = sandbox_client.exec_command(
+            f"sudo -S systemctl restart {svc_name} 2>&1", get_pty=True
+        )
+        stdin.write(password + "\n")
+        stdin.flush()
+        exit_status = stdout.channel.recv_exit_status()
+        svc_output = (stdout.read() + stderr.read()).decode().strip()
+        if exit_status == 0:
+            print(f"    Restarted {svc_name} successfully")
+            break
+        elif "could not be found" not in svc_output.lower() and "no such" not in svc_output.lower():
+            print(f"    {svc_name}: {svc_output[:200]}")
+    else:
+        # Also try restarting a cloudflared docker container if present
+        stdin, stdout, stderr = sandbox_client.exec_command(
+            "docker restart mycosoft-tunnel 2>&1 || true"
+        )
+        stdout.channel.recv_exit_status()
+        tunnel_output = stdout.read().decode().strip()
+        if tunnel_output and "No such" not in tunnel_output:
+            print(f"    Restarted Docker tunnel container: {tunnel_output}")
+        else:
+            print(f"    No cloudflare tunnel service or container found (tunnel may be external)")
+
     # Cleanup
     sandbox_client.close()
     if mas_client:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -35,7 +35,7 @@ services:
   cloudflared:
     image: cloudflare/cloudflared:latest
     container_name: mycosoft-tunnel
-    command: tunnel --no-autoupdate run
+    command: tunnel --no-autoupdate --metrics 0.0.0.0:2000 run
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
     restart: always
@@ -43,11 +43,11 @@ services:
       website:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "cloudflared", "tunnel", "info", "--output", "json"]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:2000/ready 2>/dev/null || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 15s
+      start_period: 30s
     networks:
       - mycosoft-network
     labels:

--- a/scripts/_restart_sandbox_tunnel.py
+++ b/scripts/_restart_sandbox_tunnel.py
@@ -56,6 +56,7 @@ for c in cmds:
     print()
 
 # Restart cloudflared (try common service names)
+restarted = False
 for svc in ["cloudflared", "cloudflare-tunnel"]:
     stdin, out, err = sb.exec_command(f"sudo -S systemctl restart {svc} 2>&1", get_pty=True)
     stdin.write(password + "\n")
@@ -64,9 +65,30 @@ for svc in ["cloudflared", "cloudflare-tunnel"]:
     txt = (out.read() + err.read()).decode().strip()
     if code == 0:
         print(f">> Restarted {svc} successfully")
+        restarted = True
         break
     if "not found" not in txt.lower() and "failed" in txt.lower() and "no such" not in txt.lower():
         print(f">> {svc}: {txt[:200]}")
+
+# Fallback: try restarting Docker tunnel container
+if not restarted:
+    print(">> No systemd service found, trying Docker container...")
+    _, out, _ = sb.exec_command("docker restart mycosoft-tunnel 2>&1")
+    code = out.channel.recv_exit_status()
+    txt = out.read().decode().strip()
+    if code == 0:
+        print(f">> Restarted Docker tunnel container: {txt}")
+    else:
+        print(f">> Docker restart failed: {txt}")
+        # Last resort: start tunnel via docker-compose if available
+        _, out, _ = sb.exec_command(
+            "cd /opt/mycosoft && docker compose -f docker-compose.production.yml up -d cloudflared 2>&1 || "
+            "cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml up -d cloudflared 2>&1"
+        )
+        code = out.channel.recv_exit_status()
+        txt = out.read().decode().strip()
+        print(f">> docker-compose up cloudflared: {txt}")
+
 sb.close()
 if mas:
     mas.close()

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -223,13 +223,31 @@ fi
 log "Checking Cloudflare tunnel..."
 if docker ps --format '{{.Names}}' | grep -q mycosoft-tunnel; then
   TUNNEL_STATUS=$(docker inspect mycosoft-tunnel --format='{{.State.Health.Status}}' 2>/dev/null || echo "unknown")
-  if [ "$TUNNEL_STATUS" = "healthy" ]; then
-    ok "Cloudflare tunnel: healthy"
+  # Also check the tunnel ready endpoint directly
+  TUNNEL_READY=$(curl -sf http://localhost:2000/ready 2>/dev/null && echo "ready" || echo "not ready")
+  if [ "$TUNNEL_STATUS" = "healthy" ] || [ "$TUNNEL_READY" = "ready" ]; then
+    ok "Cloudflare tunnel: healthy (${TUNNEL_READY})"
   else
-    warn "Cloudflare tunnel status: $TUNNEL_STATUS"
+    warn "Cloudflare tunnel status: $TUNNEL_STATUS ($TUNNEL_READY)"
+    log "Attempting tunnel restart..."
+    docker compose -f "$COMPOSE_FILE" restart cloudflared
+    sleep 10
+    TUNNEL_READY=$(curl -sf http://localhost:2000/ready 2>/dev/null && echo "ready" || echo "not ready")
+    if [ "$TUNNEL_READY" = "ready" ]; then
+      ok "Cloudflare tunnel recovered after restart"
+    else
+      warn "Cloudflare tunnel still not ready after restart"
+    fi
   fi
 else
-  warn "Cloudflare tunnel container not running"
+  warn "Cloudflare tunnel container not running — starting it..."
+  docker compose -f "$COMPOSE_FILE" up -d cloudflared
+  sleep 15
+  if docker ps --format '{{.Names}}' | grep -q mycosoft-tunnel; then
+    ok "Cloudflare tunnel container started"
+  else
+    err "Failed to start Cloudflare tunnel container"
+  fi
 fi
 
 # ============================================================


### PR DESCRIPTION
- Fix broken cloudflared healthcheck in docker-compose.production.yml:
  `tunnel info --output json` requires API creds and always fails in-container.
  Now uses `--metrics 0.0.0.0:2000` and checks `/ready` endpoint via wget.
- Increase cloudflared healthcheck start_period from 15s to 30s for post-reboot.
- Sandbox deploy script now restarts cloudflare tunnel after website deploy
  (tries systemd service first, then Docker container fallback).
- Tunnel restart script now falls back to Docker container and docker-compose
  when no systemd service is found.
- Deploy production script now auto-restarts tunnel if unhealthy and starts
  it if not running at all.
- CI/CD workflow_dispatch with deploy=true now triggers production deploy
  regardless of branch (for emergency deployments).

https://claude.ai/code/session_01WHKwWDjmmWCGKLVv4T55WC

## Summary by Sourcery

Improve reliability of Cloudflare tunnel health checks, restarts, and production deployments.

Bug Fixes:
- Fix Cloudflare tunnel Docker healthcheck by switching to metrics-based /ready endpoint instead of tunnel info JSON command that fails without API credentials.

Enhancements:
- Extend Cloudflare tunnel healthcheck start period to better tolerate post-reboot startup time.
- Add sandbox deploy step to restart the Cloudflare tunnel via systemd, with a Docker container fallback when no service is found.
- Enhance sandbox tunnel restart script to fall back to restarting the Docker tunnel container and, if needed, starting it via docker-compose.
- Make production deploy script automatically restart an unhealthy Cloudflare tunnel and start it if the container is not running, using the /ready endpoint to verify recovery.

CI:
- Allow the production deploy job to run on workflow_dispatch with deploy=true regardless of branch to support emergency deployments.