### PR TITLE
fix: resolve build failures and deployment config issues for go-live

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic"
+
 import NextAuth, { type NextAuthOptions, type User } from "next-auth"
 import CredentialsProvider from "next-auth/providers/credentials"
 import GoogleProvider from "next-auth/providers/google"
@@ -267,8 +269,11 @@ export const authOptions: NextAuthOptions = {
     maxAge: 7 * 24 * 60 * 60, // 7 days (reduced from 30 for security)
   },
   // SECURITY: No hardcoded fallback — NEXTAUTH_SECRET must be set in environment
+  // Deferred to runtime: during build, NODE_ENV=production but secrets aren't available yet.
+  // NextAuth will read NEXTAUTH_SECRET from env at request time if secret is undefined.
   secret: process.env.NEXTAUTH_SECRET || (() => {
-    if (process.env.NODE_ENV === 'production') {
+    // During build (next build), process.env vars aren't populated — skip the fatal check
+    if (process.env.NODE_ENV === 'production' && !process.env.NEXT_PHASE) {
       throw new Error('FATAL: NEXTAUTH_SECRET environment variable is required in production')
     }
     console.error('[SECURITY] WARNING: NEXTAUTH_SECRET is not set. Using random secret (sessions will not persist across restarts)')

--- a/app/natureos/layout.tsx
+++ b/app/natureos/layout.tsx
@@ -1,22 +1,8 @@
 import type React from "react"
 import { DashboardNav } from "@/components/dashboard/nav"
 import { TopNav } from "@/components/dashboard/top-nav"
-import { SidebarProvider, Sidebar, SidebarContent, SidebarTrigger, useSidebar } from "@/components/ui/sidebar"
-
-// Create a new component for the animated navigation title
-function NavigationTitle() {
-  const { isOpen } = useSidebar()
-
-  return (
-    <span
-      className={`font-semibold text-sm transition-all duration-300 ${
-        isOpen ? "opacity-100 w-auto" : "opacity-0 w-0 overflow-hidden"
-      }`}
-    >
-      Navigation
-    </span>
-  )
-}
+import { NavigationTitle } from "@/components/dashboard/navigation-title"
+import { SidebarProvider, Sidebar, SidebarContent, SidebarTrigger } from "@/components/ui/sidebar"
 
 export default function NatureOSLayout({
   children,

--- a/components/dashboard/navigation-title.tsx
+++ b/components/dashboard/navigation-title.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useSidebar } from "@/components/ui/sidebar"
+
+export function NavigationTitle() {
+  const { isOpen } = useSidebar()
+
+  return (
+    <span
+      className={`font-semibold text-sm transition-all duration-300 ${
+        isOpen ? "opacity-100 w-auto" : "opacity-0 w-0 overflow-hidden"
+      }`}
+    >
+      Navigation
+    </span>
+  )
+}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -109,7 +109,7 @@ services:
       redis:
         condition: service_healthy
       ollama:
-        condition: service_started
+        condition: service_healthy
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
@@ -173,7 +173,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-mycosoft}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./migrations:/docker-entrypoint-initdb.d
+      - ./supabase/migrations:/docker-entrypoint-initdb.d
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-mycosoft}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-mycosoft}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./migrations:/docker-entrypoint-initdb.d
+      - ./supabase/migrations:/docker-entrypoint-initdb.d
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U mycosoft"]

--- a/env.production.example
+++ b/env.production.example
@@ -67,6 +67,12 @@ XAI_API_KEY=
 ELEVENLABS_API_KEY=
 
 # =============================================================================
+# CACHE (Redis)
+# =============================================================================
+REDIS_URL=redis://redis:6379
+REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
+
+# =============================================================================
 # LOCAL LLM (Ollama — runs in-stack, zero cost, always available)
 # =============================================================================
 # The Ollama container handles this automatically.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -22,26 +22,27 @@ scrape_configs:
     metrics_path: /api/tags
     scrape_interval: 30s
 
-  - job_name: 'mycobrain'
-    static_configs:
-      - targets: ['mycobrain:8765']
-    scrape_interval: 30s
+  # External services — uncomment when running on VMs with these services
+  # - job_name: 'mycobrain'
+  #   static_configs:
+  #     - targets: ['mycobrain:8765']
+  #   scrape_interval: 30s
 
-  - job_name: 'collectors'
-    static_configs:
-      - targets:
-          - 'aviation-collector:8101'
-          - 'maritime-collector:8102'
-          - 'satellite-collector:8103'
-          - 'spaceweather-collector:8104'
-    scrape_interval: 60s
+  # - job_name: 'collectors'
+  #   static_configs:
+  #     - targets:
+  #         - 'aviation-collector:8101'
+  #         - 'maritime-collector:8102'
+  #         - 'satellite-collector:8103'
+  #         - 'spaceweather-collector:8104'
+  #   scrape_interval: 60s
 
-  - job_name: 'mindex'
-    static_configs:
-      - targets: ['mindex:8001']
-    scrape_interval: 30s
+  # - job_name: 'mindex'
+  #   static_configs:
+  #     - targets: ['mindex:8001']
+  #   scrape_interval: 30s
 
-  - job_name: 'node-exporter'
-    static_configs:
-      - targets: ['node-exporter:9100']
-    scrape_interval: 15s
+  # - job_name: 'node-exporter'
+  #   static_configs:
+  #     - targets: ['node-exporter:9100']
+  #   scrape_interval: 15s


### PR DESCRIPTION
- Fix missing NavigationTitle component (extracted shared component from natureos layout)
- Fix NEXTAUTH_SECRET crash during build by skipping fatal check at build phase
- Fix postgres migrations mount path (./migrations → ./supabase/migrations)
- Fix Ollama dependency to use service_healthy instead of service_started
- Comment out Prometheus scrape targets for services not in production compose
- Add REDIS_PASSWORD to env.production.example template

https://claude.ai/code/session_017Swonkn8LhDmEZejtMNZV5

## Summary by Sourcery

Resolve build and deployment issues ahead of production go-live by stabilizing auth configuration, database initialization, monitoring, and shared UI layout components.

Bug Fixes:
- Prevent build-time crashes from NEXTAUTH_SECRET checks by deferring the fatal secret requirement to runtime only.
- Correct Postgres migration mount paths in both local and production Docker Compose configurations to use the supabase migrations directory.
- Update the Ollama service dependency to wait for a healthy status before starting the dependent service.

Enhancements:
- Extract the NavigationTitle into a shared dashboard component and reuse it in the NatureOS layout.
- Comment out Prometheus scrape jobs for external services that are not present in the default production compose setup.
- Add the REDIS_PASSWORD placeholder to the production environment example file.