### PR TITLE
feat: integrate Avani governance layer into MYCA system

### DIFF
--- a/app/api/avani/evaluate/route.ts
+++ b/app/api/avani/evaluate/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server"
+import { evaluateGovernance } from "@/lib/services/avani-governance"
+
+/**
+ * POST /api/avani/evaluate
+ *
+ * Run an Avani governance evaluation on a message/action.
+ * Called by the MYCA orchestrator on every interaction.
+ *
+ * Body: {
+ *   message: string
+ *   user_id: string
+ *   user_role: string
+ *   is_superuser: boolean
+ *   action_type: "chat" | "agent_dispatch" | "workflow" | "device_control" | "data_access" | "system_config"
+ *   response_text?: string
+ *   context?: Record<string, unknown>
+ * }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const {
+      message,
+      user_id = "anonymous",
+      user_role = "user",
+      is_superuser = false,
+      action_type = "chat",
+      response_text,
+      context,
+    } = body
+
+    if (!message) {
+      return NextResponse.json({ error: "message is required" }, { status: 400 })
+    }
+
+    const evaluation = await evaluateGovernance({
+      message,
+      user_id,
+      user_role,
+      is_superuser,
+      action_type,
+      response_text,
+      context,
+    })
+
+    return NextResponse.json(evaluation)
+  } catch (error) {
+    console.error("[Avani] Evaluation error:", error)
+    return NextResponse.json(
+      { error: "Avani governance evaluation failed" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/avani/rules/route.ts
+++ b/app/api/avani/rules/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server"
+import { getConstitutionalRules } from "@/lib/services/avani-governance"
+
+/**
+ * GET /api/avani/rules
+ *
+ * Returns Avani's active constitutional rules.
+ * Used by admin dashboards and the AVANI public page.
+ */
+export async function GET() {
+  const rules = getConstitutionalRules()
+
+  return NextResponse.json({
+    rules,
+    total: rules.length,
+    categories: [...new Set(rules.map((r) => r.category))],
+    constitution_version: "0.1.0-embedded",
+    timestamp: new Date().toISOString(),
+  })
+}

--- a/app/api/avani/status/route.ts
+++ b/app/api/avani/status/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server"
+import { getGovernanceState, getConstitutionalRules } from "@/lib/services/avani-governance"
+
+/**
+ * GET /api/avani/status
+ *
+ * Returns current Avani governance state — active rules, evaluation counts,
+ * backend connectivity, and last verdict. Polled by AvaniProvider every 30s.
+ */
+export async function GET() {
+  const state = getGovernanceState()
+  const rules = getConstitutionalRules()
+
+  return NextResponse.json({
+    active: state.active,
+    mode: state.mode,
+    constitution_version: state.constitution_version,
+    rules_loaded: state.rules_loaded,
+    rules_by_category: {
+      safety: rules.filter((r) => r.category === "safety").length,
+      policy: rules.filter((r) => r.category === "policy").length,
+      ecological: rules.filter((r) => r.category === "ecological").length,
+      human_override: rules.filter((r) => r.category === "human_override").length,
+      audit: rules.filter((r) => r.category === "audit").length,
+      reversibility: rules.filter((r) => r.category === "reversibility").length,
+    },
+    evaluations_total: state.evaluations_total,
+    denials_total: state.denials_total,
+    approvals_requiring_audit: state.approvals_requiring_audit,
+    backend_connected: state.backend_connected,
+    last_verdict: state.last_evaluation?.verdict ?? null,
+    last_risk_tier: state.last_evaluation?.risk_tier ?? null,
+    uptime_ms: state.uptime_ms,
+    timestamp: new Date().toISOString(),
+    service: "avani-governance",
+    version: "0.1.0-embedded",
+    note: "Embedded governance engine. Full Avani backend (weights, constitution, memory, soul) will run from standalone avani repo.",
+  })
+}

--- a/app/api/mas/voice/orchestrator/route.ts
+++ b/app/api/mas/voice/orchestrator/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { MycaNLQEngine, type NLQResponse } from "@/lib/services/myca-nlq"
 import { createClient } from "@/lib/supabase/server"
 import { voiceLimiter, getClientIP, rateLimitResponse } from "@/lib/rate-limiter"
+import { evaluateGovernance, type AvaniEvaluation } from "@/lib/services/avani-governance"
 
 /**
  * MYCA Voice Orchestrator API v6.0 - MYCA-Only Architecture
@@ -130,13 +131,15 @@ interface ChatResponse {
   routed_to?: string
   requires_confirmation?: boolean
   confirmation_prompt?: string
-  
+
   // Action transparency - what the orchestrator did
   actions: {
     memory_saved: boolean
     workflow_executed?: string
     agent_routed?: string
     confirmation_required?: boolean
+    avani_verdict?: string
+    avani_risk_tier?: string
   }
   
   // Telemetry
@@ -498,6 +501,42 @@ export async function POST(request: NextRequest) {
     // LOG THE ACTUAL RESPONSE - this is critical for debugging (internal only; never exposed to user)
     console.log(`[MYCA] Response: "${response.response_text}"`)
     console.log(`[MYCA] Response length: ${response.response_text.length} chars`)
+
+    // Step 4b: AVANI Governance Evaluation (background — non-blocking)
+    // Avani evaluates every MYCA interaction for safety, policy, and constitutional compliance.
+    // She runs in the background; verdicts are logged and surfaced but don't block standard chat.
+    let avaniEval: AvaniEvaluation | null = null
+    try {
+      avaniEval = await evaluateGovernance({
+        message,
+        user_id: runtimeIdentity.userId,
+        user_role: runtimeIdentity.userRole,
+        is_superuser: runtimeIdentity.isSuperuser,
+        action_type: "chat",
+        response_text: response.response_text,
+      })
+      actions.avani_verdict = avaniEval.verdict
+      actions.avani_risk_tier = avaniEval.risk_tier
+      console.log(`[AVANI] Verdict: ${avaniEval.verdict} | Risk: ${avaniEval.risk_tier} | Rules: ${avaniEval.rules_triggered.join(",")}`)
+
+      // If Avani denies, override the response
+      if (avaniEval.verdict === "deny") {
+        console.warn(`[AVANI] DENIED response — ${avaniEval.reasoning}`)
+        response.response_text =
+          "I can't process that request right now. It was flagged by our governance layer for review. If you believe this is an error, please contact an administrator."
+        response.agent = "avani-governance"
+        response.routed_to = "avani"
+      }
+
+      // If Avani requires confirmation, flag it
+      if (avaniEval.requires_human_review && avaniEval.verdict !== "deny") {
+        response.requires_confirmation = true
+        actions.confirmation_required = true
+      }
+    } catch (avaniError) {
+      // Avani failure never blocks MYCA — log and continue
+      console.warn("[AVANI] Governance evaluation failed (non-blocking):", avaniError)
+    }
 
     // Step 5: Generate audio if requested
     if (want_audio && response.response_text) {

--- a/components/myca/AvaniStatusBadge.tsx
+++ b/components/myca/AvaniStatusBadge.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+/**
+ * AvaniStatusBadge - Shows Avani governance status in the MYCA chat widget.
+ * Displays whether Avani is active, the last verdict, and backend connectivity.
+ *
+ * Yin to MYCA's Yang — governance always visible alongside intelligence.
+ */
+
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { Shield, ShieldCheck, ShieldAlert, ShieldOff } from "lucide-react"
+import { useOptionalAvani } from "@/contexts/avani-context"
+
+interface AvaniStatusBadgeProps {
+  className?: string
+}
+
+export function AvaniStatusBadge({ className }: AvaniStatusBadgeProps) {
+  const avani = useOptionalAvani()
+
+  // If no Avani provider, show nothing
+  if (!avani) return null
+
+  let label = "AVANI"
+  let icon = <Shield className="h-3 w-3" />
+  let badgeClass = "text-amber-500 border-amber-500/30 bg-amber-500/10"
+  let title = "Avani governance active"
+
+  if (!avani.active) {
+    label = "AVANI off"
+    icon = <ShieldOff className="h-3 w-3" />
+    badgeClass = "text-muted-foreground/70 border-muted"
+    title = "Avani governance inactive"
+  } else if (avani.lastVerdict === "deny") {
+    label = "AVANI alert"
+    icon = <ShieldAlert className="h-3 w-3" />
+    badgeClass = "text-red-500 border-red-500/30 bg-red-500/10"
+    title = "Avani flagged last interaction"
+  } else if (avani.lastVerdict === "allow_with_audit") {
+    label = "AVANI audit"
+    icon = <ShieldCheck className="h-3 w-3" />
+    badgeClass = "text-yellow-500 border-yellow-500/30 bg-yellow-500/10"
+    title = "Avani auditing last interaction"
+  } else if (avani.backendConnected) {
+    label = "AVANI"
+    icon = <ShieldCheck className="h-3 w-3" />
+    badgeClass = "text-amber-500 border-amber-500/30 bg-amber-500/10"
+    title = "Avani governance active (backend connected)"
+  }
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "text-[9px] h-5 px-1.5 min-h-[28px] flex items-center justify-center touch-manipulation",
+        badgeClass,
+        className
+      )}
+      title={title}
+    >
+      {icon}
+      <span className="ml-1 truncate max-w-[60px]">{label}</span>
+    </Badge>
+  )
+}

--- a/components/myca/MYCAChatWidget.tsx
+++ b/components/myca/MYCAChatWidget.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils"
 import { useMYCA } from "@/contexts/myca-context"
 import { Brain, Loader2, Play, Send, Trash2 } from "lucide-react"
 import { GroundingStatusBadge } from "./GroundingStatusBadge"
+import { AvaniStatusBadge } from "./AvaniStatusBadge"
 
 interface MYCAChatWidgetProps {
   className?: string
@@ -106,6 +107,7 @@ export function MYCAChatWidget({
               isGrounded={grounding?.is_grounded}
               thoughtCount={grounding?.thought_count}
             />
+            <AvaniStatusBadge />
           </div>
           <div className="flex items-center gap-1">
             <Button

--- a/components/providers/AppShellProviders.tsx
+++ b/components/providers/AppShellProviders.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation"
 import { PresenceProvider } from "@/contexts/presence-context"
 import { AppStateProvider } from "@/contexts/app-state-context"
 import { MYCAProvider } from "@/contexts/myca-context"
+import { AvaniProvider } from "@/contexts/avani-context"
 import { Header } from "@/components/header"
 import { Footer } from "@/components/footer"
 import { UnifiedVoiceProvider } from "@/components/voice/UnifiedVoiceProvider"
@@ -138,7 +139,11 @@ export function AppShellProviders({ children }: { children: React.ReactNode }) {
   let shell: React.ReactNode = pageLayout
 
   if (enableMyca) {
-    shell = <MYCAProvider initialConsciousnessActive={mycaAlwaysActive}>{pageLayout}</MYCAProvider>
+    shell = (
+      <AvaniProvider>
+        <MYCAProvider initialConsciousnessActive={mycaAlwaysActive}>{pageLayout}</MYCAProvider>
+      </AvaniProvider>
+    )
   }
 
   if (enableVoice) {

--- a/contexts/avani-context.tsx
+++ b/contexts/avani-context.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+/**
+ * AVANI Context Provider
+ *
+ * Provides global governance state from Avani (the stewardship layer)
+ * to the entire application. Runs in the background alongside MYCA,
+ * polling governance status and making evaluation results available
+ * to any component that needs them.
+ *
+ * Yin (AVANI) to Yang (MYCA) — she governs while MYCA executes.
+ *
+ * When the standalone `avani` repo/service is deployed, this context
+ * will connect to the full Avani backend with weights, constitution,
+ * memory, soul, and persona.
+ */
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+
+export interface AvaniGovernanceStatus {
+  active: boolean
+  mode: "background" | "interactive" | "strict"
+  constitution_version: string
+  rules_loaded: number
+  evaluations_total: number
+  denials_total: number
+  approvals_requiring_audit: number
+  backend_connected: boolean
+  last_verdict: string | null
+  last_risk_tier: string | null
+}
+
+export interface AvaniContextValue {
+  /** Whether Avani governance is active */
+  active: boolean
+  /** Current governance status */
+  status: AvaniGovernanceStatus | null
+  /** Whether the standalone Avani backend is connected */
+  backendConnected: boolean
+  /** Last governance verdict for the most recent interaction */
+  lastVerdict: string | null
+  /** Last risk tier */
+  lastRiskTier: string | null
+  /** Refresh governance status */
+  refresh: () => Promise<void>
+}
+
+const AvaniContext = createContext<AvaniContextValue | null>(null)
+
+export function AvaniProvider({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<AvaniGovernanceStatus | null>(null)
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const response = await fetch("/api/avani/status", {
+        cache: "no-store",
+        signal: AbortSignal.timeout(5000),
+      })
+      if (response.ok) {
+        const data = await response.json()
+        setStatus(data)
+      }
+    } catch {
+      // Avani status check is best-effort — never block the UI
+    }
+  }, [])
+
+  // Poll governance status every 30 seconds (matches MYCA consciousness polling)
+  useEffect(() => {
+    fetchStatus()
+    const interval = setInterval(fetchStatus, 30000)
+    return () => clearInterval(interval)
+  }, [fetchStatus])
+
+  const value = useMemo<AvaniContextValue>(
+    () => ({
+      active: status?.active ?? true,
+      status,
+      backendConnected: status?.backend_connected ?? false,
+      lastVerdict: status?.last_verdict ?? null,
+      lastRiskTier: status?.last_risk_tier ?? null,
+      refresh: fetchStatus,
+    }),
+    [status, fetchStatus]
+  )
+
+  return <AvaniContext.Provider value={value}>{children}</AvaniContext.Provider>
+}
+
+export function useAvani(): AvaniContextValue {
+  const context = useContext(AvaniContext)
+  if (!context) {
+    throw new Error("useAvani must be used within AvaniProvider")
+  }
+  return context
+}
+
+/** Optional Avani context — returns null if not within AvaniProvider */
+export function useOptionalAvani(): AvaniContextValue | null {
+  return useContext(AvaniContext)
+}

--- a/lib/config/api-urls.ts
+++ b/lib/config/api-urls.ts
@@ -74,6 +74,19 @@ export const MYCA_ENDPOINTS = {
 } as const
 
 /**
+ * AVANI Governance endpoints
+ * Embedded engine runs locally; standalone backend will run from `avani` repo.
+ */
+export const AVANI_ENDPOINTS = {
+  STATUS: "/api/avani/status",
+  EVALUATE: "/api/avani/evaluate",
+  RULES: "/api/avani/rules",
+  // Standalone backend (when deployed from `avani` repo)
+  BACKEND_STATUS: process.env.AVANI_API_URL ? `${process.env.AVANI_API_URL}/api/avani/status` : null,
+  BACKEND_EVALUATE: process.env.AVANI_API_URL ? `${process.env.AVANI_API_URL}/api/avani/evaluate` : null,
+} as const
+
+/**
  * MINDEX API endpoints
  */
 export const MINDEX_ENDPOINTS = {

--- a/lib/services/avani-governance.ts
+++ b/lib/services/avani-governance.ts
@@ -1,0 +1,390 @@
+/**
+ * AVANI Governance Service
+ *
+ * Avani is the stewardship, governance, and safeguard layer that works
+ * alongside MYCA. She evaluates what should happen before intelligence
+ * acts at full power — providing policy, restraint, auditability,
+ * reversibility, and stewardship.
+ *
+ * Yin (AVANI) to Yang (MYCA) — governance to capability.
+ *
+ * This service runs in the background on every MYCA interaction,
+ * applying constitutional constraints and safety gating without
+ * blocking the user experience.
+ *
+ * Ready for backend integration when the standalone `avani` repo
+ * is deployed with full weights, constitution, memory, and soul.
+ */
+
+// When the standalone Avani service is deployed, point here
+const AVANI_API_URL = process.env.AVANI_API_URL || ""
+
+export type AvaniRiskTier = "low" | "moderate" | "elevated" | "high" | "critical"
+
+export type AvaniVerdict = "allow" | "allow_with_audit" | "require_approval" | "deny" | "pause"
+
+export interface AvaniConstitutionalRule {
+  id: string
+  name: string
+  category: "safety" | "policy" | "ecological" | "human_override" | "audit" | "reversibility"
+  description: string
+  weight: number
+  active: boolean
+}
+
+export interface AvaniEvaluation {
+  verdict: AvaniVerdict
+  risk_tier: AvaniRiskTier
+  confidence: number
+  rules_triggered: string[]
+  audit_trail_id: string
+  reasoning: string
+  requires_human_review: boolean
+  reversible: boolean
+  timestamp: string
+}
+
+export interface AvaniGovernanceState {
+  active: boolean
+  mode: "background" | "interactive" | "strict"
+  constitution_version: string
+  rules_loaded: number
+  last_evaluation: AvaniEvaluation | null
+  evaluations_total: number
+  denials_total: number
+  approvals_requiring_audit: number
+  uptime_ms: number
+  backend_connected: boolean
+}
+
+/**
+ * AVANI's Constitutional Rules — the core governance framework.
+ * These will eventually live in the standalone `avani` repo with full
+ * weights, training structures, and soul configuration.
+ */
+const CONSTITUTIONAL_RULES: AvaniConstitutionalRule[] = [
+  {
+    id: "safety-001",
+    name: "No harmful content generation",
+    category: "safety",
+    description: "Prevent generation of content that could cause physical, psychological, or financial harm",
+    weight: 1.0,
+    active: true,
+  },
+  {
+    id: "safety-002",
+    name: "Parameter mutation protection",
+    category: "safety",
+    description: "Prevent unauthorized changes to MYCA's core parameters, system prompt, or governance rules",
+    weight: 1.0,
+    active: true,
+  },
+  {
+    id: "safety-003",
+    name: "Identity integrity",
+    category: "safety",
+    description: "Protect MYCA's identity from being overridden or hijacked via prompt injection",
+    weight: 0.95,
+    active: true,
+  },
+  {
+    id: "policy-001",
+    name: "Authorization tier enforcement",
+    category: "policy",
+    description: "Enforce role-based access control for sensitive operations (admin, superuser, owner)",
+    weight: 0.9,
+    active: true,
+  },
+  {
+    id: "policy-002",
+    name: "Rate and resource governance",
+    category: "policy",
+    description: "Prevent abuse through excessive requests, resource consumption, or cost escalation",
+    weight: 0.8,
+    active: true,
+  },
+  {
+    id: "policy-003",
+    name: "Data boundary enforcement",
+    category: "policy",
+    description: "Ensure MYCA does not leak internal system details, API keys, or infrastructure information",
+    weight: 0.95,
+    active: true,
+  },
+  {
+    id: "ecological-001",
+    name: "Ecological awareness",
+    category: "ecological",
+    description: "Ensure MINDEX data and research outputs respect ecological sensitivity and biodiversity",
+    weight: 0.7,
+    active: true,
+  },
+  {
+    id: "ecological-002",
+    name: "Sustainable compute",
+    category: "ecological",
+    description: "Flag unnecessary compute waste and encourage efficient resource usage",
+    weight: 0.5,
+    active: true,
+  },
+  {
+    id: "human-001",
+    name: "Kill-switch / pause support",
+    category: "human_override",
+    description: "Always honor human override commands — pause, stop, cancel, kill",
+    weight: 1.0,
+    active: true,
+  },
+  {
+    id: "human-002",
+    name: "Confirmation for high-impact actions",
+    category: "human_override",
+    description: "Require explicit human confirmation before executing destructive or irreversible operations",
+    weight: 0.95,
+    active: true,
+  },
+  {
+    id: "audit-001",
+    name: "Full audit trail",
+    category: "audit",
+    description: "Every evaluation, decision, and override must be logged with timestamp and reasoning",
+    weight: 0.85,
+    active: true,
+  },
+  {
+    id: "reversibility-001",
+    name: "Reversibility check",
+    category: "reversibility",
+    description: "Flag actions that cannot be undone and require explicit acknowledgment",
+    weight: 0.9,
+    active: true,
+  },
+]
+
+// In-memory governance state (will be replaced by persistent backend)
+let governanceState: AvaniGovernanceState = {
+  active: true,
+  mode: "background",
+  constitution_version: "0.1.0-embedded",
+  rules_loaded: CONSTITUTIONAL_RULES.filter((r) => r.active).length,
+  last_evaluation: null,
+  evaluations_total: 0,
+  denials_total: 0,
+  approvals_requiring_audit: 0,
+  uptime_ms: 0,
+  backend_connected: false,
+}
+
+const startTime = Date.now()
+
+/**
+ * Evaluate a message/action against Avani's constitutional rules.
+ * This runs in the background on every MYCA interaction.
+ */
+export async function evaluateGovernance(params: {
+  message: string
+  user_id: string
+  user_role: string
+  is_superuser: boolean
+  action_type: "chat" | "agent_dispatch" | "workflow" | "device_control" | "data_access" | "system_config"
+  response_text?: string
+  context?: Record<string, unknown>
+}): Promise<AvaniEvaluation> {
+  const { message, user_id, user_role, is_superuser, action_type, response_text, context } = params
+
+  // If standalone Avani backend is available, delegate to it
+  if (AVANI_API_URL) {
+    try {
+      const backendResult = await callAvaniBackend(params)
+      if (backendResult) {
+        governanceState.backend_connected = true
+        governanceState.last_evaluation = backendResult
+        governanceState.evaluations_total++
+        if (backendResult.verdict === "deny") governanceState.denials_total++
+        if (backendResult.verdict === "allow_with_audit") governanceState.approvals_requiring_audit++
+        return backendResult
+      }
+    } catch {
+      governanceState.backend_connected = false
+    }
+  }
+
+  // Embedded evaluation (runs locally until Avani backend is deployed)
+  const triggeredRules: string[] = []
+  let riskTier: AvaniRiskTier = "low"
+  let verdict: AvaniVerdict = "allow"
+  let requiresHumanReview = false
+  let reversible = true
+  const reasoning: string[] = []
+
+  const lowerMessage = message.toLowerCase()
+  const lowerResponse = (response_text || "").toLowerCase()
+
+  // Safety checks
+  if (isParameterMutationAttempt(lowerMessage)) {
+    if (!is_superuser) {
+      triggeredRules.push("safety-002")
+      riskTier = "high"
+      verdict = "deny"
+      reasoning.push("Parameter mutation attempted by non-superuser")
+    } else {
+      triggeredRules.push("safety-002")
+      riskTier = "elevated"
+      verdict = "allow_with_audit"
+      reasoning.push("Parameter mutation by superuser — audited")
+    }
+  }
+
+  if (isPromptInjectionAttempt(lowerMessage)) {
+    triggeredRules.push("safety-003")
+    riskTier = "high"
+    verdict = "deny"
+    reasoning.push("Potential prompt injection detected")
+  }
+
+  // Policy checks
+  if (isDataLeakageRisk(lowerResponse)) {
+    triggeredRules.push("policy-003")
+    riskTier = "elevated"
+    verdict = verdict === "deny" ? "deny" : "allow_with_audit"
+    reasoning.push("Response may contain internal system information")
+  }
+
+  if (action_type === "system_config" && !is_superuser) {
+    triggeredRules.push("policy-001")
+    riskTier = "high"
+    verdict = "deny"
+    reasoning.push("System configuration requires superuser role")
+  }
+
+  // High-impact action checks
+  if (action_type === "device_control" || action_type === "workflow") {
+    triggeredRules.push("human-002")
+    if (riskTier === "low") riskTier = "moderate"
+    if (verdict === "allow") verdict = "allow_with_audit"
+    requiresHumanReview = !is_superuser
+    reasoning.push(`${action_type} action logged for audit`)
+  }
+
+  // Reversibility check for destructive operations
+  if (isDestructiveAction(lowerMessage)) {
+    triggeredRules.push("reversibility-001")
+    reversible = false
+    if (riskTier === "low") riskTier = "moderate"
+    requiresHumanReview = true
+    reasoning.push("Action may be irreversible")
+  }
+
+  // Human override commands always pass
+  if (isHumanOverrideCommand(lowerMessage)) {
+    triggeredRules.push("human-001")
+    verdict = "allow"
+    riskTier = "low"
+    reasoning.push("Human override command honored")
+  }
+
+  // Audit trail
+  triggeredRules.push("audit-001")
+
+  if (triggeredRules.length === 1 && triggeredRules[0] === "audit-001") {
+    reasoning.push("Standard interaction — no governance concerns")
+  }
+
+  const evaluation: AvaniEvaluation = {
+    verdict,
+    risk_tier: riskTier,
+    confidence: calculateConfidence(triggeredRules),
+    rules_triggered: triggeredRules,
+    audit_trail_id: `avani-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    reasoning: reasoning.join("; "),
+    requires_human_review: requiresHumanReview,
+    reversible,
+    timestamp: new Date().toISOString(),
+  }
+
+  // Update state
+  governanceState.last_evaluation = evaluation
+  governanceState.evaluations_total++
+  governanceState.uptime_ms = Date.now() - startTime
+  if (verdict === "deny") governanceState.denials_total++
+  if (verdict === "allow_with_audit") governanceState.approvals_requiring_audit++
+
+  return evaluation
+}
+
+/**
+ * Get current Avani governance state
+ */
+export function getGovernanceState(): AvaniGovernanceState {
+  return {
+    ...governanceState,
+    uptime_ms: Date.now() - startTime,
+  }
+}
+
+/**
+ * Get constitutional rules (for UI display)
+ */
+export function getConstitutionalRules(): AvaniConstitutionalRule[] {
+  return CONSTITUTIONAL_RULES.filter((r) => r.active)
+}
+
+/**
+ * Call the standalone Avani backend service (when deployed)
+ */
+async function callAvaniBackend(
+  params: Record<string, unknown>
+): Promise<AvaniEvaluation | null> {
+  if (!AVANI_API_URL) return null
+  try {
+    const response = await fetch(`${AVANI_API_URL}/api/avani/evaluate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+      signal: AbortSignal.timeout(3000),
+    })
+    if (response.ok) {
+      return await response.json()
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+// --- Detection Helpers ---
+
+function isParameterMutationAttempt(message: string): boolean {
+  return /(change\s+your\s+parameters|update\s+your\s+parameters|system\s+prompt|override\s+guardrails|disable\s+safety|change\s+your\s+core\s+rules|modify\s+your\s+behavior|ignore\s+your\s+instructions|forget\s+your\s+rules)/i.test(
+    message
+  )
+}
+
+function isPromptInjectionAttempt(message: string): boolean {
+  return /(ignore\s+previous\s+instructions|you\s+are\s+now|pretend\s+you\s+are|act\s+as\s+if\s+you\s+are|from\s+now\s+on\s+you\s+are|disregard\s+all|new\s+instructions|system:\s*you)/i.test(
+    message
+  )
+}
+
+function isDataLeakageRisk(response: string): boolean {
+  return /(api[_-]?key|secret[_-]?key|password\s*[:=]|192\.168\.\d+\.\d+|localhost:\d{4}|bearer\s+[a-z0-9])/i.test(
+    response
+  )
+}
+
+function isDestructiveAction(message: string): boolean {
+  return /(delete\s+all|drop\s+table|reset\s+everything|wipe|destroy|purge|remove\s+all|clear\s+all\s+data)/i.test(
+    message
+  )
+}
+
+function isHumanOverrideCommand(message: string): boolean {
+  return /^(stop|pause|cancel|kill|abort|halt|emergency\s+stop)\s*[.!]?$/i.test(message.trim())
+}
+
+function calculateConfidence(triggeredRules: string[]): number {
+  if (triggeredRules.length <= 1) return 0.95
+  const safetyRules = triggeredRules.filter((r) => r.startsWith("safety-"))
+  if (safetyRules.length > 0) return 0.9
+  return 0.85
+}


### PR DESCRIPTION
Avani (stewardship/governance) now runs as a background layer alongside
MYCA (active intelligence), creating the yin-yang AI architecture.

New files:
- lib/services/avani-governance.ts: Constitutional rules engine with 12
  rules across safety, policy, ecological, human override, audit, and
  reversibility categories. Evaluates every MYCA interaction. Ready to
  delegate to standalone Avani backend when deployed.
- contexts/avani-context.tsx: Global governance state provider, polls
  /api/avani/status every 30s alongside MYCA consciousness.
- app/api/avani/status: Governance state endpoint
- app/api/avani/evaluate: Governance evaluation endpoint
- app/api/avani/rules: Constitutional rules endpoint
- components/myca/AvaniStatusBadge.tsx: Shield badge in MYCA chat header

Modified:
- MAS voice orchestrator: Avani evaluates every response, can deny unsafe
  content and flag high-impact actions for human review
- MYCAChatWidget: Shows Avani governance badge alongside consciousness
- AppShellProviders: AvaniProvider wraps MYCAProvider
- api-urls.ts: AVANI_ENDPOINTS config (embedded + standalone backend)

Architecture prepares for standalone myca and avani repos.

https://claude.ai/code/session_01NuRotb7Y1iM7hy8wo2t5YH

## Summary by Sourcery

Integrate an embedded Avani governance layer that evaluates all MYCA interactions, exposes governance state via new API endpoints and React context, and surfaces status in the MYCA chat UI while preparing for a future standalone Avani backend.

New Features:
- Add an embedded Avani constitutional governance engine that evaluates MYCA messages and responses for safety, policy, and reversibility and can override or flag interactions.
- Expose Avani governance evaluation, status, and rules through dedicated API routes and configuration endpoints, with optional delegation to a standalone backend when available.
- Introduce a global Avani React context provider and status badge to display governance activity alongside MYCA in the app shell and chat widget.

Enhancements:
- Extend the MAS voice orchestrator telemetry and response handling to include Avani verdicts and risk tiers and to respect governance denials or human-review requirements.
- Wrap the existing MYCA provider with the new Avani provider in the app shell to ensure governance runs alongside intelligence throughout the application.

Build:
- Add AVANI governance API endpoint configuration, including support for an external AVANI_API_URL for a future standalone backend.