### PR TITLE
feat: add auth-gated platform pages and context-aware settings

### DIFF
--- a/app/platform/analytics/page.tsx
+++ b/app/platform/analytics/page.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { BarChart3, TrendingUp, Users, Cpu, HardDrive, Zap } from 'lucide-react'
+import { useState } from 'react'
+
+const metrics = [
+  { label: 'Active Users', value: '8', change: '+2', icon: Users, color: 'text-blue-500' },
+  { label: 'Experiments Run', value: '142', change: '+23', icon: Zap, color: 'text-amber-500' },
+  { label: 'Compute Hours', value: '384h', change: '+56h', icon: Cpu, color: 'text-purple-500' },
+  { label: 'Storage Used', value: '12.4 GB', change: '+1.2 GB', icon: HardDrive, color: 'text-green-500' },
+]
+
+const usageBreakdown = [
+  { label: 'Simulations', used: 78, limit: 100 },
+  { label: 'Experiments', used: 142, limit: 200 },
+  { label: 'API Calls', used: 12847, limit: 50000 },
+  { label: 'Storage (GB)', used: 12.4, limit: 50 },
+  { label: 'Compute Hours', used: 384, limit: 500 },
+]
+
+export default function PlatformAnalyticsPage() {
+  const [period, setPeriod] = useState('30d')
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Platform Analytics</h1>
+          <p className="text-muted-foreground">Usage metrics and resource consumption</p>
+        </div>
+        <Select value={period} onValueChange={setPeriod}>
+          <SelectTrigger className="w-36">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="7d">Last 7 days</SelectItem>
+            <SelectItem value="30d">Last 30 days</SelectItem>
+            <SelectItem value="90d">Last 90 days</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {metrics.map((m) => (
+          <Card key={m.label}>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-muted-foreground">{m.label}</p>
+                  <p className="text-2xl font-bold">{m.value}</p>
+                </div>
+                <m.icon className={`h-8 w-8 ${m.color}`} />
+              </div>
+              <div className="mt-2">
+                <Badge variant="outline" className="text-green-600">
+                  <TrendingUp className="h-3 w-3 mr-1" />
+                  {m.change}
+                </Badge>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5" />
+            Resource Usage
+          </CardTitle>
+          <CardDescription>Current usage against organization quotas</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {usageBreakdown.map((item) => {
+            const percent = Math.round((item.used / item.limit) * 100)
+            return (
+              <div key={item.label} className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-muted-foreground">
+                    {item.used.toLocaleString()} / {item.limit.toLocaleString()} ({percent}%)
+                  </span>
+                </div>
+                <Progress value={percent} className="h-2" />
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/platform/api-keys/page.tsx
+++ b/app/platform/api-keys/page.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Key, Plus, Copy, Trash2, Eye, EyeOff, AlertTriangle } from 'lucide-react'
+import { useAuth } from '@/contexts/auth-context'
+
+interface ApiKey {
+  id: string
+  name: string
+  prefix: string
+  scope: 'read' | 'write' | 'admin'
+  createdAt: string
+  lastUsed: string
+  status: 'active' | 'revoked'
+}
+
+const initialKeys: ApiKey[] = [
+  { id: '1', name: 'Production API', prefix: 'sk-myco-prod-xxxx', scope: 'admin', createdAt: 'Jan 15, 2026', lastUsed: '2 min ago', status: 'active' },
+  { id: '2', name: 'CI/CD Pipeline', prefix: 'sk-myco-ci-xxxx', scope: 'write', createdAt: 'Feb 1, 2026', lastUsed: '1h ago', status: 'active' },
+  { id: '3', name: 'Read-only Dashboard', prefix: 'sk-myco-dash-xxxx', scope: 'read', createdAt: 'Feb 20, 2026', lastUsed: '3h ago', status: 'active' },
+  { id: '4', name: 'Old Integration', prefix: 'sk-myco-old-xxxx', scope: 'write', createdAt: 'Nov 10, 2025', lastUsed: '30d ago', status: 'revoked' },
+]
+
+const scopeColors: Record<string, string> = {
+  read: 'bg-green-500',
+  write: 'bg-blue-500',
+  admin: 'bg-purple-500',
+}
+
+export default function PlatformApiKeysPage() {
+  const { user } = useAuth()
+  const [keys, setKeys] = useState<ApiKey[]>(initialKeys)
+  const [newKeyName, setNewKeyName] = useState('')
+  const [newKeyScope, setNewKeyScope] = useState('read')
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set())
+
+  const isAdmin = user?.email === 'morgan@mycosoft.org' || user?.role === 'admin' || user?.role === 'owner'
+
+  const handleCreate = () => {
+    if (!newKeyName) return
+    const key: ApiKey = {
+      id: `k-${Date.now()}`,
+      name: newKeyName,
+      prefix: `sk-myco-${newKeyName.toLowerCase().replace(/\s+/g, '-').slice(0, 6)}-xxxx`,
+      scope: newKeyScope as ApiKey['scope'],
+      createdAt: 'Just now',
+      lastUsed: 'Never',
+      status: 'active',
+    }
+    setKeys([key, ...keys])
+    setNewKeyName('')
+    setDialogOpen(false)
+  }
+
+  const handleRevoke = (id: string) => {
+    setKeys(keys.map(k => k.id === id ? { ...k, status: 'revoked' as const } : k))
+  }
+
+  const toggleVisible = (id: string) => {
+    const next = new Set(visibleKeys)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setVisibleKeys(next)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">API Keys</h1>
+          <p className="text-muted-foreground">Manage API keys for programmatic access</p>
+        </div>
+        {isAdmin && (
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button><Plus className="h-4 w-4 mr-2" /> Create Key</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Create API Key</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4 py-4">
+                <div>
+                  <label className="text-sm font-medium">Key Name</label>
+                  <Input
+                    value={newKeyName}
+                    onChange={(e) => setNewKeyName(e.target.value)}
+                    placeholder="e.g. Production API"
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Scope</label>
+                  <Select value={newKeyScope} onValueChange={setNewKeyScope}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="read">Read Only</SelectItem>
+                      <SelectItem value="write">Read & Write</SelectItem>
+                      <SelectItem value="admin">Admin (Full Access)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="flex items-start gap-2 p-3 bg-amber-500/10 rounded-lg text-sm">
+                  <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
+                  <p>The full key will only be shown once after creation. Store it securely.</p>
+                </div>
+                <Button onClick={handleCreate} className="w-full" disabled={!newKeyName}>
+                  Create Key
+                </Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Key className="h-5 w-5" />
+            Active Keys
+          </CardTitle>
+          <CardDescription>{keys.filter(k => k.status === 'active').length} active keys</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="divide-y">
+            {keys.map((key) => (
+              <div key={key.id} className="flex items-center gap-4 py-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{key.name}</span>
+                    <Badge className={scopeColors[key.scope]}>{key.scope}</Badge>
+                    {key.status === 'revoked' && <Badge variant="destructive">Revoked</Badge>}
+                  </div>
+                  <div className="flex items-center gap-1 mt-1">
+                    <code className="text-sm text-muted-foreground font-mono">
+                      {visibleKeys.has(key.id) ? key.prefix.replace('xxxx', 'a1b2c3d4') : key.prefix}
+                    </code>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Created {key.createdAt} &middot; Last used {key.lastUsed}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button size="sm" variant="ghost" onClick={() => toggleVisible(key.id)}>
+                    {visibleKeys.has(key.id) ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </Button>
+                  <Button size="sm" variant="ghost">
+                    <Copy className="h-4 w-4" />
+                  </Button>
+                  {isAdmin && key.status === 'active' && (
+                    <Button size="sm" variant="ghost" className="text-red-500" onClick={() => handleRevoke(key.id)}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/platform/billing/page.tsx
+++ b/app/platform/billing/page.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import { CreditCard, Receipt, ArrowUpCircle, CheckCircle2 } from 'lucide-react'
+
+const plans = [
+  {
+    name: 'Free',
+    price: 0,
+    features: ['5 team members', '10 experiments/month', '1 GB storage', 'Community support'],
+    current: false,
+  },
+  {
+    name: 'Starter',
+    price: 29,
+    features: ['15 team members', '50 experiments/month', '10 GB storage', 'Email support', 'API access'],
+    current: false,
+  },
+  {
+    name: 'Professional',
+    price: 99,
+    features: ['50 team members', '200 experiments/month', '50 GB storage', 'Priority support', 'API access', 'Federation'],
+    current: false,
+  },
+  {
+    name: 'Enterprise',
+    price: 299,
+    features: ['Unlimited members', 'Unlimited experiments', '500 GB storage', 'Dedicated support', 'Full API access', 'Federation', 'SSO & audit logs'],
+    current: true,
+  },
+]
+
+const invoices = [
+  { id: 'INV-2026-003', date: 'Mar 1, 2026', amount: '$299.00', status: 'Paid' },
+  { id: 'INV-2026-002', date: 'Feb 1, 2026', amount: '$299.00', status: 'Paid' },
+  { id: 'INV-2026-001', date: 'Jan 1, 2026', amount: '$299.00', status: 'Paid' },
+  { id: 'INV-2025-012', date: 'Dec 1, 2025', amount: '$299.00', status: 'Paid' },
+]
+
+export default function PlatformBillingPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Billing & Plans</h1>
+        <p className="text-muted-foreground">Manage your subscription and billing details</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Current Plan</CardTitle>
+              <CardDescription>Enterprise - $299/month</CardDescription>
+            </div>
+            <Badge className="bg-purple-500">Enterprise</Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div>
+              <p className="text-sm text-muted-foreground">Members</p>
+              <p className="font-medium">12 / Unlimited</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Experiments</p>
+              <p className="font-medium">142 / Unlimited</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Storage</p>
+              <div className="flex items-center gap-2">
+                <Progress value={25} className="flex-1 h-2" />
+                <span className="text-sm">12.4/500 GB</span>
+              </div>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Next billing</p>
+              <p className="font-medium">Apr 1, 2026</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Available Plans</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {plans.map((plan) => (
+            <Card key={plan.name} className={plan.current ? 'border-primary' : ''}>
+              <CardHeader>
+                <CardTitle className="text-lg">{plan.name}</CardTitle>
+                <CardDescription>
+                  {plan.price === 0 ? 'Free' : `$${plan.price}/mo`}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-2 text-sm mb-4">
+                  {plan.features.map((f) => (
+                    <li key={f} className="flex items-center gap-2">
+                      <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" />
+                      {f}
+                    </li>
+                  ))}
+                </ul>
+                {plan.current ? (
+                  <Button variant="outline" className="w-full" disabled>Current Plan</Button>
+                ) : (
+                  <Button variant="outline" className="w-full">
+                    <ArrowUpCircle className="h-4 w-4 mr-2" />
+                    {plan.price > 299 ? 'Contact Sales' : 'Switch'}
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Receipt className="h-5 w-5" />
+              Invoices
+            </CardTitle>
+            <CardDescription>Billing history</CardDescription>
+          </div>
+          <Button variant="outline" size="sm">
+            <CreditCard className="h-4 w-4 mr-2" />
+            Update Payment
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <div className="divide-y">
+            {invoices.map((inv) => (
+              <div key={inv.id} className="flex items-center justify-between py-3">
+                <div>
+                  <span className="font-medium">{inv.id}</span>
+                  <p className="text-sm text-muted-foreground">{inv.date}</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <span className="font-medium">{inv.amount}</span>
+                  <Badge variant="outline" className="text-green-600">{inv.status}</Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/platform/layout.tsx
+++ b/app/platform/layout.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useAuth } from "@/contexts/auth-context"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+import { Shield, Lock } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import Link from "next/link"
+
+const ALLOWED_DOMAIN = "mycosoft.org"
+
+function isCompanyEmail(email: string | null | undefined): boolean {
+  if (!email) return false
+  return email.endsWith(`@${ALLOWED_DOMAIN}`)
+}
+
+export default function PlatformLayout({ children }: { children: React.ReactNode }) {
+  const { user, isLoading } = useAuth()
+
+  if (isLoading) {
+    return (
+      <div className="container py-16 flex items-center justify-center">
+        <div className="animate-pulse text-muted-foreground">Loading...</div>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return (
+      <div className="container py-16 max-w-lg mx-auto">
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto p-3 rounded-full bg-muted w-fit mb-4">
+              <Lock className="h-8 w-8 text-muted-foreground" />
+            </div>
+            <CardTitle>Sign In Required</CardTitle>
+            <CardDescription>
+              You must be signed in with a company email to access the platform.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <Button asChild>
+              <Link href="/login?redirectTo=/platform">Sign In</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (!isCompanyEmail(user.email)) {
+    return (
+      <div className="container py-16 max-w-lg mx-auto">
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto p-3 rounded-full bg-destructive/10 w-fit mb-4">
+              <Shield className="h-8 w-8 text-destructive" />
+            </div>
+            <CardTitle>Access Denied</CardTitle>
+            <CardDescription>
+              Platform access is restricted to authorized users with a <strong>@{ALLOWED_DOMAIN}</strong> email address.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-center text-sm text-muted-foreground">
+            <p>Signed in as: {user.email}</p>
+            <p className="mt-2">Contact your administrator if you believe this is an error.</p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container py-8">
+      {children}
+    </div>
+  )
+}

--- a/app/platform/page.tsx
+++ b/app/platform/page.tsx
@@ -1,4 +1,4 @@
-﻿import { Metadata } from 'next'
+import { Metadata } from 'next'
 import { AdminConsole } from '@/components/platform/admin-console'
 
 export const metadata: Metadata = {

--- a/app/platform/security/page.tsx
+++ b/app/platform/security/page.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Shield, Lock, KeyRound, FileCheck, AlertTriangle, CheckCircle2 } from 'lucide-react'
+
+const securityPolicies = [
+  { label: 'Enforce SSO', description: 'Require single sign-on for all team members', enabled: true },
+  { label: 'Two-Factor Authentication', description: 'Require 2FA for all users', enabled: true },
+  { label: 'Session Timeout', description: 'Auto-logout after 8 hours of inactivity', enabled: true },
+  { label: 'IP Allowlist', description: 'Restrict access to approved IP addresses', enabled: false },
+  { label: 'Audit Logging', description: 'Log all user actions for compliance', enabled: true },
+  { label: 'Data Encryption at Rest', description: 'Encrypt all stored data with AES-256', enabled: true },
+]
+
+const recentEvents = [
+  { time: '10:30 AM', event: 'Login from new device', user: 'chris@mycosoft.org', severity: 'warning' },
+  { time: '10:15 AM', event: 'Password changed', user: 'alberto@mycosoft.org', severity: 'info' },
+  { time: '09:45 AM', event: 'API key created', user: 'garret@mycosoft.org', severity: 'info' },
+  { time: '09:30 AM', event: 'Failed login attempt', user: 'unknown@external.com', severity: 'error' },
+  { time: '09:00 AM', event: 'SSO configuration updated', user: 'morgan@mycosoft.org', severity: 'info' },
+  { time: '08:30 AM', event: 'Member role changed', user: 'rj@mycosoft.org', severity: 'info' },
+]
+
+const complianceChecks = [
+  { label: 'SOC 2 Type II', status: 'compliant' },
+  { label: 'GDPR Data Processing', status: 'compliant' },
+  { label: 'HIPAA (if applicable)', status: 'not-applicable' },
+  { label: 'Data Retention Policy', status: 'compliant' },
+  { label: 'Access Control Review', status: 'review-needed' },
+]
+
+export default function PlatformSecurityPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Security & Compliance</h1>
+        <p className="text-muted-foreground">Manage security policies and monitor compliance</p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Lock className="h-5 w-5" />
+              Security Policies
+            </CardTitle>
+            <CardDescription>Configure organization-wide security settings</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {securityPolicies.map((policy) => (
+              <div key={policy.label} className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label>{policy.label}</Label>
+                  <p className="text-sm text-muted-foreground">{policy.description}</p>
+                </div>
+                <Switch defaultChecked={policy.enabled} />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <FileCheck className="h-5 w-5" />
+              Compliance Status
+            </CardTitle>
+            <CardDescription>Regulatory and policy compliance checks</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {complianceChecks.map((check) => (
+              <div key={check.label} className="flex items-center justify-between p-3 border rounded-lg">
+                <span className="font-medium">{check.label}</span>
+                {check.status === 'compliant' && (
+                  <Badge className="bg-green-500"><CheckCircle2 className="h-3 w-3 mr-1" /> Compliant</Badge>
+                )}
+                {check.status === 'review-needed' && (
+                  <Badge variant="outline" className="text-amber-500 border-amber-500">
+                    <AlertTriangle className="h-3 w-3 mr-1" /> Review Needed
+                  </Badge>
+                )}
+                {check.status === 'not-applicable' && (
+                  <Badge variant="outline">N/A</Badge>
+                )}
+              </div>
+            ))}
+            <Button variant="outline" className="w-full mt-4">
+              <KeyRound className="h-4 w-4 mr-2" />
+              Run Full Compliance Audit
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Shield className="h-5 w-5" />
+            Security Events
+          </CardTitle>
+          <CardDescription>Recent security-related activity</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ScrollArea className="h-64">
+            <div className="space-y-2">
+              {recentEvents.map((evt, i) => (
+                <div key={i} className="flex items-center gap-3 p-3 border rounded-lg">
+                  <div className={`w-2 h-2 rounded-full shrink-0 ${
+                    evt.severity === 'error' ? 'bg-red-500' :
+                    evt.severity === 'warning' ? 'bg-amber-500' : 'bg-green-500'
+                  }`} />
+                  <span className="text-sm text-muted-foreground w-20">{evt.time}</span>
+                  <span className="text-sm flex-1">{evt.event}</span>
+                  <span className="text-sm text-muted-foreground">{evt.user}</span>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/platform/team/page.tsx
+++ b/app/platform/team/page.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Users, UserPlus, Shield, Mail, Clock, Search } from 'lucide-react'
+import { useAuth } from '@/contexts/auth-context'
+
+interface TeamMember {
+  id: string
+  name: string
+  email: string
+  role: 'owner' | 'admin' | 'scientist' | 'viewer'
+  status: 'active' | 'invited' | 'suspended'
+  lastActive: string
+}
+
+const initialMembers: TeamMember[] = [
+  { id: '1', name: 'Morgan', email: 'morgan@mycosoft.org', role: 'owner', status: 'active', lastActive: 'Now' },
+  { id: '2', name: 'Garret', email: 'garret@mycosoft.org', role: 'admin', status: 'active', lastActive: '2h ago' },
+  { id: '3', name: 'RJ', email: 'rj@mycosoft.org', role: 'admin', status: 'active', lastActive: '1h ago' },
+  { id: '4', name: 'Chris', email: 'chris@mycosoft.org', role: 'scientist', status: 'active', lastActive: '30m ago' },
+  { id: '5', name: 'Alberto', email: 'alberto@mycosoft.org', role: 'scientist', status: 'active', lastActive: '3h ago' },
+  { id: '6', name: 'Abelardo', email: 'abelardo@mycosoft.org', role: 'scientist', status: 'active', lastActive: '5h ago' },
+  { id: '7', name: 'MYCA', email: 'myca@mycosoft.org', role: 'viewer', status: 'active', lastActive: 'Always' },
+  { id: '8', name: 'Michelle', email: 'michelle@mycosoft.org', role: 'admin', status: 'active', lastActive: '1d ago' },
+]
+
+const roleColors: Record<string, string> = {
+  owner: 'bg-purple-500',
+  admin: 'bg-blue-500',
+  scientist: 'bg-green-500',
+  viewer: 'bg-gray-500',
+}
+
+export default function PlatformTeamPage() {
+  const { user } = useAuth()
+  const [members, setMembers] = useState<TeamMember[]>(initialMembers)
+  const [search, setSearch] = useState('')
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteRole, setInviteRole] = useState<string>('scientist')
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const isOwnerOrAdmin = user?.email === 'morgan@mycosoft.org' || user?.role === 'admin' || user?.role === 'owner'
+  const filtered = members.filter(m =>
+    m.name.toLowerCase().includes(search.toLowerCase()) ||
+    m.email.toLowerCase().includes(search.toLowerCase())
+  )
+
+  const handleInvite = () => {
+    if (!inviteEmail || !inviteEmail.endsWith('@mycosoft.org')) return
+    setMembers([...members, {
+      id: `m-${Date.now()}`,
+      name: inviteEmail.split('@')[0],
+      email: inviteEmail,
+      role: inviteRole as TeamMember['role'],
+      status: 'invited',
+      lastActive: 'Never',
+    }])
+    setInviteEmail('')
+    setDialogOpen(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Team Management</h1>
+          <p className="text-muted-foreground">Manage team members and their roles</p>
+        </div>
+        {isOwnerOrAdmin && (
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button><UserPlus className="h-4 w-4 mr-2" /> Invite Member</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Invite Team Member</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4 py-4">
+                <div>
+                  <label className="text-sm font-medium">Email Address</label>
+                  <Input
+                    type="email"
+                    value={inviteEmail}
+                    onChange={(e) => setInviteEmail(e.target.value)}
+                    placeholder="name@mycosoft.org"
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">Must be a @mycosoft.org email</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Role</label>
+                  <Select value={inviteRole} onValueChange={setInviteRole}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="admin">Admin</SelectItem>
+                      <SelectItem value="scientist">Scientist</SelectItem>
+                      <SelectItem value="viewer">Viewer</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button onClick={handleInvite} className="w-full" disabled={!inviteEmail.endsWith('@mycosoft.org')}>
+                  Send Invitation
+                </Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search members..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-10"
+          />
+        </div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Users className="h-4 w-4" />
+          {members.length} members
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          <div className="divide-y">
+            {filtered.map((member) => (
+              <div key={member.id} className="flex items-center gap-4 p-4">
+                <Avatar>
+                  <AvatarFallback>{member.name.split(' ').map(n => n[0]).join('').slice(0, 2)}</AvatarFallback>
+                </Avatar>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{member.name}</span>
+                    <Badge className={roleColors[member.role]}>{member.role}</Badge>
+                    {member.status === 'invited' && <Badge variant="outline">Pending</Badge>}
+                    {member.status === 'suspended' && <Badge variant="destructive">Suspended</Badge>}
+                  </div>
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-1"><Mail className="h-3 w-3" /> {member.email}</span>
+                    <span className="flex items-center gap-1"><Clock className="h-3 w-3" /> {member.lastActive}</span>
+                  </div>
+                </div>
+                {isOwnerOrAdmin && member.role !== 'owner' && (
+                  <Select defaultValue={member.role}>
+                    <SelectTrigger className="w-28">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="admin">Admin</SelectItem>
+                      <SelectItem value="scientist">Scientist</SelectItem>
+                      <SelectItem value="viewer">Viewer</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -8,12 +8,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Switch } from "@/components/ui/switch"
 import { useAuth } from "@/contexts/auth-context"
-import { Bell, Shield, Laptop, Globe, Brain } from "lucide-react"
+import { Bell, Shield, Laptop, Globe, Brain, Lock, User } from "lucide-react"
+import Link from "next/link"
 
 const GROUNDING_PREF_KEY = "myca_grounded_cognition_enabled"
 
 export default function SettingsPage() {
-  const { user } = useAuth()
+  const { user, isLoading } = useAuth()
   const [isSaving, setIsSaving] = useState(false)
   const [groundingEnabled, setGroundingEnabled] = useState(true)
 
@@ -42,16 +43,94 @@ export default function SettingsPage() {
     setIsSaving(false)
   }
 
-  if (!user) {
-    return null
+  if (isLoading) {
+    return (
+      <div className="container py-16 flex items-center justify-center">
+        <div className="animate-pulse text-muted-foreground">Loading...</div>
+      </div>
+    )
   }
 
+  // Logged-out view: show limited public settings
+  if (!user) {
+    return (
+      <div className="container py-8">
+        <div className="max-w-4xl mx-auto space-y-8">
+          <div>
+            <h1 className="text-3xl font-bold">Settings</h1>
+            <p className="text-muted-foreground">Preferences and display options</p>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Display Preferences</CardTitle>
+              <CardDescription>These settings are saved locally in your browser</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-2">
+                <Label htmlFor="language">Language</Label>
+                <select
+                  id="language"
+                  className="flex h-12 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-base file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <option value="en">English</option>
+                  <option value="es">Español</option>
+                  <option value="fr">Français</option>
+                </select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="timezone">Timezone</Label>
+                <select
+                  id="timezone"
+                  className="flex h-12 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-base file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <option value="utc">UTC</option>
+                  <option value="pst">Pacific Time</option>
+                  <option value="est">Eastern Time</option>
+                </select>
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="space-y-1">
+                  <Label>Compact Mode</Label>
+                  <p className="text-sm text-muted-foreground">Make the interface more compact</p>
+                </div>
+                <Switch />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center py-8 text-center">
+              <Lock className="h-8 w-8 text-muted-foreground mb-3" />
+              <h3 className="font-semibold text-lg">Sign in for more settings</h3>
+              <p className="text-sm text-muted-foreground mb-4 max-w-sm">
+                Sign in to access notifications, security, integrations, and account management settings.
+              </p>
+              <Button asChild>
+                <Link href="/login?redirectTo=/settings">Sign In</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  const isCompanyUser = user.email?.endsWith("@mycosoft.org")
+
+  // Logged-in view: full settings
   return (
     <div className="container py-8">
       <div className="max-w-4xl mx-auto space-y-8">
-        <div>
-          <h1 className="text-3xl font-bold">Settings</h1>
-          <p className="text-muted-foreground">Manage your account settings and preferences</p>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold">Settings</h1>
+            <p className="text-muted-foreground">Manage your account settings and preferences</p>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <User className="h-4 w-4" />
+            {user.email}
+          </div>
         </div>
 
         <Tabs defaultValue="general">
@@ -126,6 +205,46 @@ export default function SettingsPage() {
                 </div>
               </CardContent>
             </Card>
+
+            {isCompanyUser && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Platform Access</CardTitle>
+                  <CardDescription>Company account features</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                      <Label>Platform Admin Access</Label>
+                      <p className="text-sm text-muted-foreground">
+                        You have company email access to the platform admin panel.
+                      </p>
+                    </div>
+                    <Button variant="outline" asChild>
+                      <Link href="/platform">Open Platform</Link>
+                    </Button>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                      <Label>Default Experiment Visibility</Label>
+                      <p className="text-sm text-muted-foreground">Set default visibility for new experiments</p>
+                    </div>
+                    <select className="flex h-10 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                      <option value="private">Private</option>
+                      <option value="team">Team Only</option>
+                      <option value="org">Organization</option>
+                    </select>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                      <Label>Federation Data Sharing</Label>
+                      <p className="text-sm text-muted-foreground">Allow your data to be shared with federation peers</p>
+                    </div>
+                    <Switch />
+                  </div>
+                </CardContent>
+              </Card>
+            )}
           </TabsContent>
 
           <TabsContent value="notifications" className="space-y-4">
@@ -150,6 +269,27 @@ export default function SettingsPage() {
                     <Switch defaultChecked />
                   </div>
                 ))}
+                {isCompanyUser && (
+                  <>
+                    <div className="border-t pt-4 mt-2">
+                      <p className="text-sm font-medium text-muted-foreground mb-4">Company Notifications</p>
+                    </div>
+                    {[
+                      "Platform audit alerts",
+                      "Team member activity",
+                      "Federation sync updates",
+                      "Billing notifications",
+                    ].map((item) => (
+                      <div key={item} className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label>{item}</Label>
+                          <p className="text-sm text-muted-foreground">Receive notifications about {item.toLowerCase()}</p>
+                        </div>
+                        <Switch defaultChecked />
+                      </div>
+                    ))}
+                  </>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
@@ -176,6 +316,38 @@ export default function SettingsPage() {
                 <Button className="h-12">Update Password</Button>
               </CardContent>
             </Card>
+
+            {isCompanyUser && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Company Security</CardTitle>
+                  <CardDescription>Additional security options for company accounts</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Two-Factor Authentication</Label>
+                      <p className="text-sm text-muted-foreground">Add an extra layer of security to your account</p>
+                    </div>
+                    <Switch />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Login Notifications</Label>
+                      <p className="text-sm text-muted-foreground">Get notified when your account is accessed from a new device</p>
+                    </div>
+                    <Switch defaultChecked />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Session Management</Label>
+                      <p className="text-sm text-muted-foreground">View and manage active sessions</p>
+                    </div>
+                    <Button variant="outline" size="sm">View Sessions</Button>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
           </TabsContent>
 
           <TabsContent value="integrations" className="space-y-4">
@@ -196,6 +368,26 @@ export default function SettingsPage() {
                 ))}
               </CardContent>
             </Card>
+
+            {isCompanyUser && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Platform Integrations</CardTitle>
+                  <CardDescription>Company-managed service connections</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {["Supabase Database", "Anthropic API", "Federation Network", "Internal MYCA API"].map((service) => (
+                    <div key={service} className="flex items-center justify-between">
+                      <div className="space-y-0.5">
+                        <Label>{service}</Label>
+                        <p className="text-sm text-muted-foreground">Managed by your organization</p>
+                      </div>
+                      <Switch defaultChecked />
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            )}
           </TabsContent>
         </Tabs>
 

--- a/lib/access/routes.ts
+++ b/lib/access/routes.ts
@@ -191,6 +191,19 @@ export const ETHICS_TRAINING_ROUTES: RouteAccess[] = [
   { path: '/ethics-training/observations', gate: AccessGate.ADMIN, config: { gate: AccessGate.ADMIN, minimumRole: UserRole.ADMIN, features: ['ethics-training'] }, description: 'Observer Notes' },
 ]
 
+// Platform routes - require login with @mycosoft.org company email
+export const PLATFORM_ROUTES: RouteAccess[] = [
+  { path: '/platform', gate: AccessGate.ADMIN, config: { gate: AccessGate.ADMIN, minimumRole: UserRole.ADMIN, features: ['company-email'] }, description: 'Platform Admin' },
+  { path: '/platform/analytics', gate: AccessGate.ADMIN, config: { gate: AccessGate.ADMIN, minimumRole: UserRole.ADMIN, features: ['company-email'] }, description: 'Platform Analytics' },
+  { path: '/platform/team', gate: AccessGate.ADMIN, config: { gate: AccessGate.ADMIN, minimumRole: UserRole.ADMIN, features: ['company-email'] }, description: 'Team Management' },
+  { path: '/platform/billing', gate: AccessGate.ADMIN, config: { gate: AccessGate.ADMIN, minimumRole: UserRole.ADMIN, features: ['company-email'] }, description: 'Billing & Plans' },
+  { path: '/platform/api-keys', gate: AccessGate.ADMIN, config: { gate: AccessGate.ADMIN, minimumRole: UserRole.ADMIN, features: ['company-email'] }, description: 'API Keys' },
+  { path: '/platform/security', gate: AccessGate.ADMIN, config: { gate: AccessGate.ADMIN, minimumRole: UserRole.ADMIN, features: ['company-email'] }, description: 'Security & Compliance' },
+]
+
+// Company email domain for platform access
+export const PLATFORM_ALLOWED_DOMAIN = 'mycosoft.org'
+
 // Admin routes
 export const ADMIN_ROUTES: RouteAccess[] = [
   { path: '/devices', gate: AccessGate.ADMIN, config: { gate: AccessGate.ADMIN, minimumRole: UserRole.ADMIN }, description: 'Device Manager' },
@@ -226,6 +239,7 @@ export const ALL_ROUTES: RouteAccess[] = [
   ...FREEMIUM_ROUTES,
   ...AUTHENTICATED_ROUTES,
   ...PREMIUM_ROUTES,
+  ...PLATFORM_ROUTES,
   ...ETHICS_TRAINING_ROUTES,
   ...ADMIN_ROUTES,
   ...SUPER_ADMIN_ROUTES,


### PR DESCRIPTION
Add company email (@mycosoft.org) authentication gate to all platform
pages via a shared layout. Create new platform sub-pages for analytics,
team management, billing, API keys, and security/compliance. Update
settings page to show limited preferences for logged-out users and
additional company-specific options (platform access, federation,
2FA, platform integrations) for authenticated company users.

https://claude.ai/code/session_0184pAYgWts6bcweCoqzkBnB

## Summary by Sourcery

Gate new platform admin pages behind company email authentication and expand settings to support both public and company-specific preferences.

New Features:
- Add platform analytics, team management, billing, API keys, and security/compliance pages under a shared platform layout restricted to company email users.
- Provide a logged-out settings view with basic local display preferences and sign-in prompt.
- Expose company-specific settings for platform access, federation, security, and integrations when a company user is authenticated.

Enhancements:
- Display the current user identity in the settings header and extend notifications and security sections with company-focused options.
- Register new platform routes in central access control configuration with a dedicated allowed domain constant.