### PR TITLE
fix(search): prevent crash when search results are undefined

### DIFF
--- a/components/search/fluid/FluidSearchCanvas.tsx
+++ b/components/search/fluid/FluidSearchCanvas.tsx
@@ -1539,9 +1539,9 @@ function WidgetContent({
     case "fallback":
       return (
         <FallbackWidget
-          bucketKey={config.fallbackBucketKey ?? "unknown"}
-          items={config.fallbackItems ?? []}
-          title={config.label}
+          bucketKey={"unknown"}
+          items={[]}
+          title={"Fallback"}
           widgetType="fallback"
         />
       )

--- a/hooks/use-unified-search.ts
+++ b/hooks/use-unified-search.ts
@@ -125,14 +125,10 @@ export function useUnifiedSearch(
   )
 
   // Extract results with memoization
+  const emptyResults = { species: [] as SpeciesResult[], compounds: [] as CompoundResult[], genetics: [] as GeneticsResult[], research: [] as ResearchResult[] }
   const results = useMemo(() => {
-    if (!data) {
-      return {
-        species: [],
-        compounds: [],
-        genetics: [],
-        research: [],
-      }
+    if (!data?.results) {
+      return emptyResults
     }
     return data.results
   }, [data])


### PR DESCRIPTION
Guard against `data.results` being undefined in useUnifiedSearch hook, which caused "Cannot read properties of undefined (reading 'length')" when the API returned data without a results object. Also fix FluidSearchCanvas WidgetContent referencing out-of-scope `config` variable in the fallback widget case.

https://claude.ai/code/session_01NpFFt3iujTdMpJdaSvkFnP

## Summary by Sourcery

Prevent unified search from crashing when API responses omit the results object and adjust fallback widget configuration for the fluid search canvas.

Bug Fixes:
- Guard unified search hook against undefined data.results to avoid runtime errors when accessing result lengths.
- Use static fallback values in FluidSearchCanvas fallback widget to avoid referencing an out-of-scope configuration object.