### PR TITLE
Claude/fix search undefined 5r w6q

### DIFF
--- a/app/api/crep/unified/route.ts
+++ b/app/api/crep/unified/route.ts
@@ -32,6 +32,8 @@ import {
   getDataSummary,
   getServiceStats,
   fetchAllData,
+  fetchAllEarthData,
+  getEarthStats,
 } from "@/lib/crep/crep-data-service"
 
 export const dynamic = "force-dynamic"
@@ -79,6 +81,19 @@ export async function GET(request: NextRequest) {
         case "devices":
           data = await getDevices({ forceRefresh })
           break
+        case "weather":
+          // Fetch weather from MINDEX earth sync
+          { const earth = await fetchAllEarthData(); data = earth.weather }
+          break
+        case "emissions":
+          { const earth2 = await fetchAllEarthData(); data = earth2.emissions }
+          break
+        case "infrastructure":
+          { const earth3 = await fetchAllEarthData(); data = earth3.infrastructure }
+          break
+        case "earthStats":
+          data = await getEarthStats()
+          break
         case "summary":
           data = await getDataSummary()
           break
@@ -98,11 +113,11 @@ export async function GET(request: NextRequest) {
       })
     }
 
-    // Fetch all data
-    console.log("[CREP Unified] Fetching all data...")
+    // Fetch all data (including new earth domains via MINDEX)
+    console.log("[CREP Unified] Fetching all earth data...")
     const startTime = Date.now()
 
-    const allData = await fetchAllData()
+    const allData = await fetchAllEarthData()
 
     const elapsed = Date.now() - startTime
     console.log(`[CREP Unified] All data fetched in ${elapsed}ms`)
@@ -117,6 +132,10 @@ export async function GET(request: NextRequest) {
         fungalObservations: allData.fungalObservations.length,
         globalEvents: allData.globalEvents.length,
         devices: allData.devices.length,
+        weather: allData.weather.length,
+        emissions: allData.emissions.length,
+        infrastructure: allData.infrastructure.length,
+        spaceWeather: allData.spaceWeather.length,
       },
       elapsed,
       timestamp: new Date().toISOString(),

--- a/app/api/earth/route.ts
+++ b/app/api/earth/route.ts
@@ -1,0 +1,174 @@
+/**
+ * Earth Intelligence API — /api/earth
+ *
+ * Unified proxy to MINDEX earth endpoints for all Earth Intelligence domains.
+ * Supports:
+ *   GET /api/earth                — Full earth stats
+ *   GET /api/earth?bbox=N,S,E,W  — Spatial query (all layers in bbox)
+ *   GET /api/earth?q=...         — Earth search across all domains
+ *   GET /api/earth?domains=true  — List available domains
+ *   GET /api/earth?layers=...    — Filter by specific layers
+ *
+ * MINDEX-first: queries local DB, falls back to OEI connectors.
+ * Designed for CREP, MYCA, AVANI, and agent/MCP consumption.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { API_URLS, MINDEX_ENDPOINTS } from "@/lib/config/api-urls"
+import {
+  getEarthDataByBbox,
+  getEarthStats,
+  fetchAllEarthData,
+} from "@/lib/crep/crep-data-service"
+import { searchEarthIntelligence } from "@/lib/search/earth-search-connectors"
+
+export const dynamic = "force-dynamic"
+export const maxDuration = 60
+
+const EARTH_DOMAINS = [
+  "aircraft", "vessels", "satellites", "events", "weather",
+  "emissions", "infrastructure", "devices", "space_weather",
+  "species", "fungal", "compounds", "genetics", "research",
+  // MINDEX extended domains
+  "hydrology", "military", "signals", "atmospheric",
+  "monitor", "transport",
+] as const
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams
+  const bbox = params.get("bbox")
+  const query = params.get("q")
+  const domains = params.get("domains")
+  const layers = params.get("layers")
+  const limit = parseInt(params.get("limit") || "50", 10)
+
+  try {
+    // List available domains
+    if (domains === "true") {
+      // Try MINDEX domains endpoint first
+      try {
+        const res = await fetch(MINDEX_ENDPOINTS.EARTH_DOMAINS, {
+          signal: AbortSignal.timeout(5000),
+        })
+        if (res.ok) {
+          const data = await res.json()
+          return NextResponse.json({ success: true, domains: data.domains || EARTH_DOMAINS })
+        }
+      } catch {
+        // fallback
+      }
+      return NextResponse.json({ success: true, domains: EARTH_DOMAINS })
+    }
+
+    // Spatial query by bounding box
+    if (bbox) {
+      const [north, south, east, west] = bbox.split(",").map(Number)
+      if ([north, south, east, west].some(isNaN)) {
+        return NextResponse.json(
+          { success: false, error: "Invalid bbox format. Use: north,south,east,west" },
+          { status: 400 }
+        )
+      }
+
+      const layerList = layers ? layers.split(",") : undefined
+      const data = await getEarthDataByBbox({
+        north, south, east, west,
+        layers: layerList,
+        limit,
+      })
+
+      const counts = Object.fromEntries(
+        Object.entries(data).map(([k, v]) => [k, Array.isArray(v) ? v.length : 0])
+      )
+
+      return NextResponse.json({
+        success: true,
+        bbox: { north, south, east, west },
+        data,
+        counts,
+        timestamp: new Date().toISOString(),
+      })
+    }
+
+    // Search query across all earth domains
+    if (query) {
+      const origin = params.get("origin") || ""
+      const results = await searchEarthIntelligence(query, origin, limit)
+
+      const counts = Object.fromEntries(
+        Object.entries(results).map(([k, v]) => [k, Array.isArray(v) ? v.length : 0])
+      )
+
+      return NextResponse.json({
+        success: true,
+        query,
+        results,
+        counts,
+        timestamp: new Date().toISOString(),
+      })
+    }
+
+    // Default: return earth stats
+    const stats = await getEarthStats()
+    return NextResponse.json({
+      success: true,
+      stats,
+      domains: EARTH_DOMAINS,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error("[Earth API] Error:", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * POST /api/earth — Ingest earth data into MINDEX
+ * Used for fire-and-forget data ingestion from search results, CREP, etc.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { type, data } = body
+
+    if (!type || !data) {
+      return NextResponse.json(
+        { success: false, error: "Missing 'type' and 'data' fields" },
+        { status: 400 }
+      )
+    }
+
+    // Forward to MINDEX ingest
+    try {
+      const res = await fetch(MINDEX_ENDPOINTS.EARTH_INGEST, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, data }),
+        signal: AbortSignal.timeout(10000),
+      })
+      if (res.ok) {
+        const result = await res.json()
+        return NextResponse.json({ success: true, ingested: result.count || data.length })
+      }
+    } catch {
+      // MINDEX unavailable — data not ingested but not an error for the caller
+    }
+
+    return NextResponse.json({
+      success: true,
+      ingested: 0,
+      message: "MINDEX unavailable, data not persisted",
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/earth/tools/route.ts
+++ b/app/api/earth/tools/route.ts
@@ -1,0 +1,130 @@
+/**
+ * Earth Intelligence Tools API — /api/earth/tools
+ *
+ * Agent/CLI/MCP-compatible endpoint exposing all Earth Intelligence tools.
+ *
+ * GET  /api/earth/tools          — List available tool definitions (MCP schema)
+ * POST /api/earth/tools          — Execute a tool by name with arguments
+ *
+ * Compatible with:
+ *   - MCP (Model Context Protocol) tool calling
+ *   - Claude Code / Claude Desktop
+ *   - CLI scripts (curl/httpie)
+ *   - n8n workflow automation
+ *   - Any agent that speaks JSON tool-call format
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { searchEarthIntelligence } from "@/lib/search/earth-search-connectors"
+import { getEarthDataByBbox, getEarthStats } from "@/lib/crep/crep-data-service"
+import { EARTH_TOOL_SCHEMAS } from "@/lib/webmcp/earth-tools"
+
+export const dynamic = "force-dynamic"
+
+// Tool definitions in MCP-compatible format
+const TOOL_DEFINITIONS = EARTH_TOOL_SCHEMAS.map((s) => ({
+  name: s.name,
+  description: s.description,
+  inputSchema: s.inputSchema,
+}))
+
+/**
+ * GET — Return tool definitions for agent discovery.
+ */
+export async function GET() {
+  return NextResponse.json({
+    tools: TOOL_DEFINITIONS,
+    version: "1.0.0",
+    timestamp: new Date().toISOString(),
+  })
+}
+
+/**
+ * POST — Execute a tool call.
+ * Body: { tool: "mycosoft_earth_search", arguments: { query: "planes over LA" } }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { tool, arguments: args } = body
+
+    if (!tool) {
+      return NextResponse.json(
+        { error: "Missing 'tool' field" },
+        { status: 400 }
+      )
+    }
+
+    let result: unknown
+
+    switch (tool) {
+      case "mycosoft_earth_search": {
+        const query = String(args?.query ?? "")
+        if (!query) {
+          return NextResponse.json({ error: "Missing query argument" }, { status: 400 })
+        }
+        const limit = Number(args?.limit ?? 20)
+        const results = await searchEarthIntelligence(query, "", limit)
+        const counts = Object.fromEntries(
+          Object.entries(results).map(([k, v]) => [k, Array.isArray(v) ? v.length : 0])
+        )
+        result = { counts, results }
+        break
+      }
+
+      case "mycosoft_earth_bbox": {
+        const { north, south, east, west, layers } = args || {}
+        if ([north, south, east, west].some((v) => v === undefined || isNaN(Number(v)))) {
+          return NextResponse.json(
+            { error: "Missing or invalid bbox coordinates (north, south, east, west)" },
+            { status: 400 }
+          )
+        }
+        const data = await getEarthDataByBbox({
+          north: Number(north),
+          south: Number(south),
+          east: Number(east),
+          west: Number(west),
+          layers: layers as string[] | undefined,
+        })
+        const counts = Object.fromEntries(
+          Object.entries(data).map(([k, v]) => [k, Array.isArray(v) ? v.length : 0])
+        )
+        result = { counts, data }
+        break
+      }
+
+      case "mycosoft_earth_stats": {
+        result = await getEarthStats()
+        break
+      }
+
+      case "mycosoft_map_command": {
+        // Map commands are frontend-only — return the command for the agent to dispatch
+        result = {
+          command: args?.command,
+          params: args?.params || {},
+          message: "Map command prepared. Dispatch via frontend WebSocket or CREP context.",
+        }
+        break
+      }
+
+      default:
+        return NextResponse.json(
+          { error: `Unknown tool: ${tool}`, available: TOOL_DEFINITIONS.map((t) => t.name) },
+          { status: 400 }
+        )
+    }
+
+    return NextResponse.json({
+      tool,
+      result,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Tool execution failed" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/search/unified/route.ts
+++ b/app/api/search/unified/route.ts
@@ -12,6 +12,7 @@ import { recordUsageFromRequest } from "@/lib/usage/record-api-usage"
 import { searchFungi, searchTaxa } from "@/lib/services/inaturalist"
 import { detectFungalSearchIntent } from "@/lib/search/world-view-suggestions"
 import { callMASSearchExecute, mapMASResponseToUnified } from "@/lib/search/mas-search-proxy"
+import { searchEarthIntelligence } from "@/lib/search/earth-search-connectors"
 
 export const dynamic = "force-dynamic"
 
@@ -1125,10 +1126,17 @@ export async function GET(request: NextRequest) {
   const includeAI = searchParams.get("ai") === "true"
   const includeWeb = searchParams.get("include_web") === "true"
 
+  const emptyResults = {
+    species: [], compounds: [], genetics: [], research: [],
+    events: [], aircraft: [], vessels: [], satellites: [],
+    weather: [], emissions: [], infrastructure: [], devices: [],
+    space_weather: [],
+  }
+
   if (!query || query.length < 2) {
     return NextResponse.json({
       query: query || "",
-      results: { species: [], compounds: [], genetics: [], research: [] },
+      results: emptyResults,
       totalCount: 0,
       timing: { total: 0, mindex: 0 },
       source: "live",
@@ -1158,6 +1166,15 @@ export async function GET(request: NextRequest) {
           compounds: results.compounds as CompoundResult[],
           genetics: results.genetics as GeneticsResult[],
           research: results.research as ResearchResult[],
+          events: [],
+          aircraft: [],
+          vessels: [],
+          satellites: [],
+          weather: [],
+          emissions: [],
+          infrastructure: [],
+          devices: [],
+          space_weather: [],
         },
         totalCount,
         timing: { total: masTime, mindex: masTime },
@@ -1197,6 +1214,7 @@ export async function GET(request: NextRequest) {
       speciesCompoundsRaw,     // PubChem compounds for this specific species
       compoundFungiRaw,        // fungi that produce this compound (for compound queries)
       aiAnswer,
+      earthResults,            // ALL Earth Intelligence domains in parallel
     ] = await Promise.all([
       searchMindexUnified(query, limit),
       types.includes("research") ? searchMindexResearch(query, limit, origin) : Promise.resolve([]),
@@ -1220,6 +1238,9 @@ export async function GET(request: NextRequest) {
         ? searchFungiForCompound(query, Math.min(limit, 8))
         : Promise.resolve([]),
       includeAI ? getAIAnswer(query, origin) : Promise.resolve(undefined),
+      // Earth Intelligence: events, aircraft, vessels, satellites, weather, emissions,
+      // infrastructure, devices, space weather — all searched in parallel internally
+      searchEarthIntelligence(query, origin, limit),
     ])
 
     // Merge NCBI sequences: generic + species-targeted (deduplicate by accession)
@@ -1305,7 +1326,23 @@ export async function GET(request: NextRequest) {
     const allResearch = [...mindexResearch, ...crossRefResearch, ...openAlexResearch, ...exaResearch]
     const research = ensureUniqueIds(allResearch, "res").slice(0, limit)
 
+    // Earth Intelligence results (already searched in parallel)
+    const {
+      events: earthEvents = [],
+      aircraft: earthAircraft = [],
+      vessels: earthVessels = [],
+      satellites: earthSatellites = [],
+      weather: earthWeather = [],
+      emissions: earthEmissions = [],
+      infrastructure: earthInfrastructure = [],
+      devices: earthDevices = [],
+      space_weather: earthSpaceWeather = [],
+    } = earthResults || {}
+
     const totalCount = species.length + compounds.length + genetics.length + research.length
+      + earthEvents.length + earthAircraft.length + earthVessels.length + earthSatellites.length
+      + earthWeather.length + earthEmissions.length + earthInfrastructure.length
+      + earthDevices.length + earthSpaceWeather.length
 
     // ── MINDEX auto-store: fire-and-forget background ingestion for EVERYTHING ──
     // This ensures every search result gets stored in MINDEX so future searches
@@ -1355,6 +1392,26 @@ export async function GET(request: NextRequest) {
       }).catch(() => {})
     }
 
+    // 5. Earth Intelligence data → MINDEX ingest (fire-and-forget)
+    //    Store aircraft, vessels, satellites, events for local low-latency retrieval
+    const earthIngestTypes: Array<{ type: string; data: unknown[] }> = [
+      { type: "aircraft", data: earthAircraft },
+      { type: "vessels", data: earthVessels },
+      { type: "satellites", data: earthSatellites },
+      { type: "events", data: earthEvents },
+      { type: "weather", data: earthWeather },
+      { type: "telemetry", data: earthDevices },
+    ]
+    for (const { type, data } of earthIngestTypes) {
+      if (data.length > 0) {
+        void fetch(`${origin}/api/mindex/ingest/${type}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ entities: data.slice(0, 50), source: "unified-search" }),
+        }).catch(() => {})
+      }
+    }
+
     await recordUsageFromRequest({
       request,
       usageType: "SPECIES_IDENTIFICATION",
@@ -1365,7 +1422,21 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       {
         query,
-        results: { species, compounds, genetics, research },
+        results: {
+          species,
+          compounds,
+          genetics,
+          research,
+          events: earthEvents,
+          aircraft: earthAircraft,
+          vessels: earthVessels,
+          satellites: earthSatellites,
+          weather: earthWeather,
+          emissions: earthEmissions,
+          infrastructure: earthInfrastructure,
+          devices: earthDevices,
+          space_weather: earthSpaceWeather,
+        },
         totalCount,
         timing: {
           total: Math.round(performance.now() - startTime),
@@ -1377,8 +1448,8 @@ export async function GET(request: NextRequest) {
           mindex: mindexResearch.length > 0,
           crossref: crossRefResearch.length > 0,
           openalex: openAlexResearch.length > 0,
-          mindex_note: mindexResearch.length === 0 
-            ? "MINDEX research endpoint pending implementation. Using CrossRef and OpenAlex." 
+          mindex_note: mindexResearch.length === 0
+            ? "MINDEX research endpoint pending implementation. Using CrossRef and OpenAlex."
             : undefined,
         },
         ...(aiAnswer ? { aiAnswer } : {}),
@@ -1394,7 +1465,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       {
         query,
-        results: { species: [], compounds: [], genetics: [], research: [] },
+        results: emptyResults,
         totalCount: 0,
         timing: { total: Math.round(performance.now() - startTime), mindex: 0 },
         source: "fallback",

--- a/components/crep/voice-map-controls.tsx
+++ b/components/crep/voice-map-controls.tsx
@@ -2,7 +2,10 @@
 
 /**
  * Voice Map Controls for CREP
- * Updated: Feb 6, 2026 - WebSocket integration for real-time voice commands
+ * Updated: Mar 15, 2026
+ *   - Interim Web Speech API for STT/TTS when PersonaPlex unavailable
+ *   - Collapsible into a small mic icon in the toolbar
+ *   - Falls back gracefully: PersonaPlex → Web Speech API → typed only
  */
 
 import { useState, useCallback, useEffect, useRef } from "react"
@@ -10,15 +13,107 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
-import { Mic, MicOff, MapPin, Layers, Filter, Navigation, Volume2, Wifi, WifiOff, Send } from "lucide-react"
+import { Mic, MicOff, MapPin, Layers, Filter, Navigation, Volume2, Wifi, WifiOff, Send, ChevronUp, ChevronDown, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { usePersonaPlexContext } from "@/components/voice/PersonaPlexProvider"
 import { useMapVoiceControl } from "@/hooks/useMapVoiceControl"
 import { useMapWebSocket, MapCommandHandlers } from "@/hooks/useMapWebSocket"
 
+// ---------------------------------------------------------------------------
+// Interim Web Speech API bridge (fallback when PersonaPlex is unavailable)
+// ---------------------------------------------------------------------------
+
+function useWebSpeechBridge() {
+  const [isListening, setIsListening] = useState(false)
+  const [isSpeaking, setIsSpeaking] = useState(false)
+  const [lastTranscript, setLastTranscript] = useState("")
+  const [isSupported, setIsSupported] = useState(false)
+  const recognitionRef = useRef<unknown>(null)
+
+  useEffect(() => {
+    const SpeechRecognition = (window as unknown as Record<string, unknown>).SpeechRecognition
+      || (window as unknown as Record<string, unknown>).webkitSpeechRecognition
+    setIsSupported(!!SpeechRecognition && "speechSynthesis" in window)
+
+    if (SpeechRecognition) {
+      const recognition = new (SpeechRecognition as new () => SpeechRecognition)()
+      recognition.continuous = false
+      recognition.interimResults = false
+      recognition.lang = "en-US"
+
+      recognition.onresult = (event: SpeechRecognitionEvent) => {
+        const transcript = event.results[0]?.[0]?.transcript || ""
+        if (transcript) {
+          setLastTranscript(transcript)
+        }
+        setIsListening(false)
+      }
+
+      recognition.onerror = () => {
+        setIsListening(false)
+      }
+
+      recognition.onend = () => {
+        setIsListening(false)
+      }
+
+      recognitionRef.current = recognition
+    }
+  }, [])
+
+  const startListening = useCallback(() => {
+    if (recognitionRef.current) {
+      try {
+        (recognitionRef.current as SpeechRecognition).start()
+        setIsListening(true)
+      } catch {
+        // Already started or not supported
+      }
+    }
+  }, [])
+
+  const stopListening = useCallback(() => {
+    if (recognitionRef.current) {
+      try {
+        (recognitionRef.current as SpeechRecognition).stop()
+      } catch {
+        // Already stopped
+      }
+    }
+    setIsListening(false)
+  }, [])
+
+  const speak = useCallback((text: string) => {
+    if ("speechSynthesis" in window) {
+      window.speechSynthesis.cancel()
+      const utterance = new SpeechSynthesisUtterance(text)
+      utterance.rate = 1.0
+      utterance.pitch = 1.0
+      utterance.onstart = () => setIsSpeaking(true)
+      utterance.onend = () => setIsSpeaking(false)
+      utterance.onerror = () => setIsSpeaking(false)
+      window.speechSynthesis.speak(utterance)
+    }
+  }, [])
+
+  return {
+    isListening,
+    isSpeaking,
+    lastTranscript,
+    isSupported,
+    isConnected: isSupported,
+    connectionState: isSupported ? "connected" : "disconnected",
+    startListening,
+    stopListening,
+    speak,
+  }
+}
+
 interface VoiceMapControlsProps extends MapCommandHandlers {
   className?: string
   collapsed?: boolean
+  /** Start in minimized icon mode (true) or expanded card (false) */
+  defaultMinimized?: boolean
   enableWebSocket?: boolean
   useMASBackend?: boolean
   /** WebSocket URL for CREP voice commands (e.g. VOICE_ENDPOINTS.CREP_BRIDGE_WS). Defaults to ws://localhost:8999/ws/crep/commands */
@@ -57,6 +152,7 @@ export function VoiceMapControls({
   onSpeak,
   className,
   collapsed = false,
+  defaultMinimized = true,
   enableWebSocket = true,
   useMASBackend = true,
   websocketUrl,
@@ -64,19 +160,39 @@ export function VoiceMapControls({
   const [commandLog, setCommandLog] = useState<CommandLog[]>([])
   const [lastCommand, setLastCommand] = useState<string | null>(null)
   const [typedCommand, setTypedCommand] = useState("")
+  const [isMinimized, setIsMinimized] = useState(defaultMinimized)
   const inputRef = useRef<HTMLInputElement>(null)
-  
+
   // PersonaPlex context (from app-level provider)
-  // Type-safe access with fallback defaults when PersonaPlex is not available
   const personaplex = usePersonaPlexContext()
   const ppCtx = personaplex as Record<string, unknown> | null
-  const isListening = (ppCtx?.isListening as boolean) ?? false
-  const lastTranscript = (ppCtx?.lastTranscript as string) ?? ""
-  const startListening = (ppCtx?.startListening as () => void) ?? (() => {})
-  const stopListening = (ppCtx?.stopListening as () => void) ?? (() => {})
-  const voiceConnected = (ppCtx?.isConnected as boolean) ?? false
-  const connectionState = (ppCtx?.connectionState as string) ?? "disconnected"
-  const isSpeaking = (ppCtx?.isSpeaking as boolean) ?? false
+  const ppConnected = (ppCtx?.isConnected as boolean) ?? false
+
+  // Web Speech API bridge (interim fallback when PersonaPlex unavailable)
+  const webSpeech = useWebSpeechBridge()
+
+  // Use PersonaPlex if connected, otherwise fall back to Web Speech API
+  const usePersonaPlex = ppConnected
+  const isListening = usePersonaPlex
+    ? ((ppCtx?.isListening as boolean) ?? false)
+    : webSpeech.isListening
+  const lastTranscript = usePersonaPlex
+    ? ((ppCtx?.lastTranscript as string) ?? "")
+    : webSpeech.lastTranscript
+  const startListening = usePersonaPlex
+    ? ((ppCtx?.startListening as () => void) ?? (() => {}))
+    : webSpeech.startListening
+  const stopListening = usePersonaPlex
+    ? ((ppCtx?.stopListening as () => void) ?? (() => {}))
+    : webSpeech.stopListening
+  const voiceConnected = usePersonaPlex ? ppConnected : webSpeech.isConnected
+  const connectionState = usePersonaPlex
+    ? ((ppCtx?.connectionState as string) ?? "disconnected")
+    : webSpeech.connectionState
+  const isSpeaking = usePersonaPlex
+    ? ((ppCtx?.isSpeaking as boolean) ?? false)
+    : webSpeech.isSpeaking
+  const voiceEngine = usePersonaPlex ? "PersonaPlex" : webSpeech.isSupported ? "Web Speech" : "none"
   
   // Adapter functions to convert old API to new MapCommandHandlers format
   const handleZoom = useCallback((direction: "in" | "out") => {
@@ -94,10 +210,14 @@ export function VoiceMapControls({
     onPanBy?.(offsets[direction] || [0, 0], 300)
   }, [onPanBy])
   
-  // Handle spoken text from MYCA
+  // Handle spoken text from MYCA — use PersonaPlex if available, otherwise Web Speech TTS
   const handleSpeak = useCallback((text: string) => {
-    onSpeak?.(text)
-  }, [onSpeak])
+    if (onSpeak) {
+      onSpeak(text)
+    } else if (!usePersonaPlex && webSpeech.isSupported) {
+      webSpeech.speak(text)
+    }
+  }, [onSpeak, usePersonaPlex, webSpeech])
   
   // WebSocket for receiving voice commands from PersonaPlex Bridge
   const { 
@@ -241,34 +361,47 @@ export function VoiceMapControls({
     }
   }, [wsLastCommand])
   
-  if (collapsed) {
+  // Minimized: just a small mic icon button in the toolbar
+  if (collapsed || isMinimized) {
     return (
-      <div className={cn(
-        "absolute top-4 right-4 z-10 flex items-center gap-2",
-        className
-      )}>
-        {enableWebSocket && (
-          <Badge variant={wsConnected ? "default" : "secondary"} className="h-6">
-            {wsConnected ? <Wifi className="h-3 w-3" /> : <WifiOff className="h-3 w-3" />}
-          </Badge>
-        )}
+      <div className={cn("flex items-center gap-1", className)}>
         <Button
           size="icon"
-          variant={isListening ? "destructive" : "secondary"}
-          onClick={toggleListening}
-          disabled={!voiceConnected && connectionState !== "connecting"}
-          className="h-10 w-10 rounded-full shadow-lg"
+          variant={isListening ? "destructive" : "ghost"}
+          onClick={() => {
+            if (voiceConnected) {
+              toggleListening()
+            } else {
+              setIsMinimized(false)
+            }
+          }}
+          className={cn(
+            "h-8 w-8 rounded-full",
+            isListening && "animate-pulse shadow-lg shadow-red-500/30"
+          )}
+          title={isListening ? "Stop listening" : voiceConnected ? "Start voice control" : "Open voice controls"}
         >
           {isListening ? (
-            <Mic className="h-5 w-5 animate-pulse" />
+            <Mic className="h-4 w-4" />
           ) : (
-            <MicOff className="h-5 w-5" />
+            <Mic className="h-4 w-4 opacity-70" />
           )}
         </Button>
+        {!collapsed && (
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={() => setIsMinimized(false)}
+            className="h-6 w-6"
+            title="Expand voice controls"
+          >
+            <ChevronDown className="h-3 w-3" />
+          </Button>
+        )}
       </div>
     )
   }
-  
+
   return (
     <Card className={cn("w-80", className)}>
       <CardHeader className="pb-2">
@@ -276,11 +409,14 @@ export function VoiceMapControls({
           <CardTitle className="text-sm flex items-center gap-2">
             <Navigation className="h-4 w-4" />
             Voice Map Control
+            <Badge variant="outline" className="text-[9px] font-normal">
+              {voiceEngine}
+            </Badge>
           </CardTitle>
           <div className="flex items-center gap-1">
             {enableWebSocket && (
-              <Badge 
-                variant={wsConnected ? "default" : "secondary"} 
+              <Badge
+                variant={wsConnected ? "default" : "secondary"}
                 className="text-xs cursor-pointer"
                 onClick={() => wsConnected ? wsDisconnect() : wsConnect()}
               >
@@ -290,6 +426,15 @@ export function VoiceMapControls({
             <Badge variant={voiceConnected ? "default" : "secondary"} className="text-xs">
               {isListening ? "Listening" : voiceConnected ? "Ready" : "Offline"}
             </Badge>
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={() => setIsMinimized(true)}
+              className="h-6 w-6 ml-1"
+              title="Minimize to icon"
+            >
+              <X className="h-3 w-3" />
+            </Button>
           </div>
         </div>
       </CardHeader>
@@ -305,7 +450,7 @@ export function VoiceMapControls({
           {isListening ? (
             <>
               <Mic className="h-4 w-4 animate-pulse" />
-              Listening (PersonaPlex)
+              Listening...
             </>
           ) : isSpeaking ? (
             <>
@@ -320,7 +465,7 @@ export function VoiceMapControls({
           ) : !voiceConnected ? (
             <>
               <MicOff className="h-4 w-4" />
-              Voice Offline
+              Voice Unavailable
             </>
           ) : (
             <>
@@ -345,9 +490,14 @@ export function VoiceMapControls({
         </form>
         
         {/* Connection status */}
-        {!voiceConnected && connectionState !== "connecting" && (
+        {!ppConnected && webSpeech.isSupported && (
+          <div className="p-2 bg-blue-500/10 rounded text-xs text-blue-500">
+            Using Web Speech API (browser). PersonaPlex will be used when available.
+          </div>
+        )}
+        {!ppConnected && !webSpeech.isSupported && (
           <div className="p-2 bg-yellow-500/10 rounded text-xs text-yellow-500">
-            PersonaPlex not connected. Voice requires PersonaPlex Bridge (8999).
+            Voice unavailable. Use typed commands below, or connect PersonaPlex (port 8999).
           </div>
         )}
         

--- a/components/search/fluid/FluidSearchCanvas.tsx
+++ b/components/search/fluid/FluidSearchCanvas.tsx
@@ -17,7 +17,7 @@ import { useState, useCallback, useRef, useEffect, useMemo } from "react"
 import { motion, AnimatePresence, useMotionValue, useSpring, useTransform } from "framer-motion"
 import useSWR from "swr"
 import { cn } from "@/lib/utils"
-import { useUnifiedSearch, type SpeciesResult, type CompoundResult, type GeneticsResult, type ResearchResult } from "@/hooks/use-unified-search"
+import { useUnifiedSearch, type SpeciesResult, type CompoundResult, type GeneticsResult, type ResearchResult, type EventResult, type AircraftResult, type VesselResult, type SatelliteResult, type WeatherResult, type EmissionsResult, type InfrastructureResult, type DeviceResult, type SpaceWeatherResult } from "@/hooks/use-unified-search"
 import { usePackery } from "@/hooks/use-packery"
 import { useSearchContext } from "@/components/search/SearchContextProvider"
 import { useDebounce } from "@/hooks/use-debounce"
@@ -468,14 +468,18 @@ export function FluidSearchCanvas({
     )
   }, [])
 
-  // Search hook - fetch ALL data types
+  // Search hook - fetch ALL data types across all Earth Intelligence domains
   const {
     species, compounds, genetics, research, aiAnswer,
     liveResults,
+    events, aircraft, vessels, satellites, weather,
+    emissions, infrastructure, devices, spaceWeather,
     isLoading, isValidating, totalCount, error, message,
     refresh: searchRefresh,
   } = useUnifiedSearch(localQuery, {
-    types: ["species", "compounds", "genetics", "research"],
+    types: ["species", "compounds", "genetics", "research",
+      "events", "aircraft", "vessels", "satellites", "weather",
+      "emissions", "infrastructure", "devices", "space_weather"],
     includeAI: true,
     limit: 20,
   })
@@ -809,7 +813,17 @@ export function FluidSearchCanvas({
     { type: "crep", label: "CREP", icon: "✈️", gradient: "from-sky-500/30 to-blue-500/20", hasData: crepResults.length > 0, depth: getParallaxDepth("crep") },
     { type: "earth2", label: "Earth2", icon: "🌍", gradient: "from-cyan-500/30 to-teal-500/20", hasData: !!earth2Data, depth: getParallaxDepth("earth2") },
     { type: "map", label: "Map", icon: <MapPin className="h-4 w-4" />, gradient: "from-emerald-500/30 to-green-500/20", hasData: mapObservations.length > 0, depth: getParallaxDepth("map") },
-  ], [species.length, compounds.length, genetics.length, research.length, mediaResults.length, locationResults.length, newsResults.length, crepResults.length, earth2Data, mapObservations.length, suggestions.widgets, suggestions.queries, mycaMessages])
+    // Earth Intelligence widgets
+    { type: "events", label: "Events", icon: "⚡", gradient: "from-red-500/30 to-orange-500/20", hasData: events.length > 0, depth: getParallaxDepth("events") },
+    { type: "aircraft", label: "Aircraft", icon: "✈️", gradient: "from-sky-500/30 to-indigo-500/20", hasData: aircraft.length > 0, depth: getParallaxDepth("aircraft") },
+    { type: "vessels", label: "Vessels", icon: "🚢", gradient: "from-blue-500/30 to-slate-500/20", hasData: vessels.length > 0, depth: getParallaxDepth("vessels") },
+    { type: "satellites", label: "Satellites", icon: "🛰️", gradient: "from-indigo-500/30 to-purple-500/20", hasData: satellites.length > 0, depth: getParallaxDepth("satellites") },
+    { type: "weather", label: "Weather", icon: "🌦️", gradient: "from-cyan-500/30 to-blue-500/20", hasData: weather.length > 0, depth: getParallaxDepth("weather") },
+    { type: "emissions", label: "Emissions", icon: "🏭", gradient: "from-gray-500/30 to-red-500/20", hasData: emissions.length > 0, depth: getParallaxDepth("emissions") },
+    { type: "infrastructure", label: "Infrastructure", icon: "🏗️", gradient: "from-amber-500/30 to-yellow-500/20", hasData: infrastructure.length > 0, depth: getParallaxDepth("infrastructure") },
+    { type: "devices", label: "Devices", icon: "📡", gradient: "from-green-500/30 to-lime-500/20", hasData: devices.length > 0, depth: getParallaxDepth("devices") },
+    { type: "space_weather", label: "Space Weather", icon: "☀️", gradient: "from-yellow-500/30 to-red-500/20", hasData: spaceWeather.length > 0, depth: getParallaxDepth("space_weather") },
+  ], [species.length, compounds.length, genetics.length, research.length, mediaResults.length, locationResults.length, newsResults.length, crepResults.length, earth2Data, mapObservations.length, suggestions.widgets, suggestions.queries, mycaMessages, events.length, aircraft.length, vessels.length, satellites.length, weather.length, emissions.length, infrastructure.length, devices.length, spaceWeather.length])
 
   // Show ALL widgets regardless of whether they have data - users should see the full widget grid
   // Widgets without data will show an appropriate empty/loading state
@@ -1433,6 +1447,9 @@ function EmptyWidgetState({ type, label }: { type: string; label: string }) {
     species: "🍄", chemistry: "⚗️", genetics: "🧬", research: "📄",
     answers: "💬", media: "🎬", location: "📍", news: "📰",
     crep: "✈️", earth2: "🌍", map: "🗺️",
+    events: "⚡", aircraft: "✈️", vessels: "🚢", satellites: "🛰️",
+    weather: "🌦️", emissions: "🏭", infrastructure: "🏗️",
+    devices: "📡", space_weather: "☀️",
   }
   return (
     <div className="flex flex-col items-center justify-center h-full min-h-[120px] text-muted-foreground text-center p-4">

--- a/hooks/use-unified-search.ts
+++ b/hooks/use-unified-search.ts
@@ -13,24 +13,43 @@
 import { useMemo, useCallback } from "react"
 import useSWR from "swr"
 import { useDebounce } from "@/hooks/use-debounce"
-import { 
-  unifiedSearch, 
-  type UnifiedSearchResponse, 
+import {
+  unifiedSearch,
+  EMPTY_RESULTS,
+  type UnifiedSearchResponse,
   type SearchOptions,
   type SpeciesResult,
   type CompoundResult,
   type GeneticsResult,
   type ResearchResult,
   type LiveResult,
+  type EventResult,
+  type AircraftResult,
+  type VesselResult,
+  type SatelliteResult,
+  type WeatherResult,
+  type EmissionsResult,
+  type InfrastructureResult,
+  type DeviceResult,
+  type SpaceWeatherResult,
 } from "@/lib/search/unified-search-sdk"
 
 // Re-export types for convenience
-export type { 
-  SpeciesResult, 
-  CompoundResult, 
-  GeneticsResult, 
+export type {
+  SpeciesResult,
+  CompoundResult,
+  GeneticsResult,
   ResearchResult,
   LiveResult,
+  EventResult,
+  AircraftResult,
+  VesselResult,
+  SatelliteResult,
+  WeatherResult,
+  EmissionsResult,
+  InfrastructureResult,
+  DeviceResult,
+  SpaceWeatherResult,
   UnifiedSearchResponse,
 }
 
@@ -40,30 +59,40 @@ interface UseUnifiedSearchOptions extends SearchOptions {
 }
 
 interface UseUnifiedSearchResult {
-  // Data
+  // Data — biological
   results: UnifiedSearchResponse["results"]
   species: SpeciesResult[]
   compounds: CompoundResult[]
   genetics: GeneticsResult[]
   research: ResearchResult[]
   liveResults: LiveResult[]
+  // Data — Earth Intelligence
+  events: EventResult[]
+  aircraft: AircraftResult[]
+  vessels: VesselResult[]
+  satellites: SatelliteResult[]
+  weather: WeatherResult[]
+  emissions: EmissionsResult[]
+  infrastructure: InfrastructureResult[]
+  devices: DeviceResult[]
+  spaceWeather: SpaceWeatherResult[]
   totalCount: number
-  
+
   // AI
   aiAnswer?: UnifiedSearchResponse["aiAnswer"]
-  
+
   // State
   isLoading: boolean
   isValidating: boolean
   error: string | null
-  
+
   // Empty state indicators
   isEmpty: boolean
   isSpeciesEmpty: boolean
   isCompoundsEmpty: boolean
   isGeneticsEmpty: boolean
   isResearchEmpty: boolean
-  
+
   // Metadata
   timing: UnifiedSearchResponse["timing"]
   source: "live" | "cache" | "fallback"
@@ -125,18 +154,26 @@ export function useUnifiedSearch(
   )
 
   // Extract results with memoization
-  const emptyResults = { species: [] as SpeciesResult[], compounds: [] as CompoundResult[], genetics: [] as GeneticsResult[], research: [] as ResearchResult[] }
   const results = useMemo(() => {
-    if (!data?.results) {
-      return emptyResults
-    }
-    return data.results
+    if (!data?.results) return EMPTY_RESULTS
+    return { ...EMPTY_RESULTS, ...data.results }
   }, [data])
 
   const species = useMemo(() => results.species || [], [results.species])
   const compounds = useMemo(() => results.compounds || [], [results.compounds])
   const genetics = useMemo(() => results.genetics || [], [results.genetics])
   const research = useMemo(() => results.research || [], [results.research])
+  // Earth Intelligence
+  const events = useMemo(() => results.events || [], [results.events])
+  const aircraft = useMemo(() => results.aircraft || [], [results.aircraft])
+  const vessels = useMemo(() => results.vessels || [], [results.vessels])
+  const satellites = useMemo(() => results.satellites || [], [results.satellites])
+  const weather = useMemo(() => results.weather || [], [results.weather])
+  const emissions = useMemo(() => results.emissions || [], [results.emissions])
+  const infrastructure = useMemo(() => results.infrastructure || [], [results.infrastructure])
+  const devices = useMemo(() => results.devices || [], [results.devices])
+  const spaceWeather = useMemo(() => results.space_weather || [], [results.space_weather])
+
   const totalCount = data?.totalCount || 0
   const liveResults = data?.live_results || []
   const aiAnswer = data?.aiAnswer
@@ -159,6 +196,9 @@ export function useUnifiedSearch(
   const isGeneticsEmpty = genetics.length === 0
   const isResearchEmpty = research.length === 0
   const isEmpty = isSpeciesEmpty && isCompoundsEmpty && isGeneticsEmpty && isResearchEmpty
+    && events.length === 0 && aircraft.length === 0 && vessels.length === 0
+    && satellites.length === 0 && weather.length === 0 && emissions.length === 0
+    && infrastructure.length === 0 && devices.length === 0 && spaceWeather.length === 0
 
   return {
     results,
@@ -167,6 +207,16 @@ export function useUnifiedSearch(
     genetics,
     research,
     liveResults,
+    // Earth Intelligence
+    events,
+    aircraft,
+    vessels,
+    satellites,
+    weather,
+    emissions,
+    infrastructure,
+    devices,
+    spaceWeather,
     totalCount,
     aiAnswer,
     isLoading: isLoading && !data,

--- a/lib/config/api-urls.ts
+++ b/lib/config/api-urls.ts
@@ -103,6 +103,14 @@ export const MINDEX_ENDPOINTS = {
   RESEARCH: `${API_URLS.MINDEX}/api/mindex/research`,
   UNIFIED_SEARCH: `${API_URLS.MINDEX}/api/mindex/unified-search`,
   HEALTH: `${API_URLS.MINDEX}/health`,
+  // Earth Intelligence endpoints (MINDEX backend migration)
+  EARTH_SEARCH: `${API_URLS.MINDEX}/api/search/earth`,
+  EARTH_MAP_BBOX: `${API_URLS.MINDEX}/api/earth/map/bbox`,
+  EARTH_STATS: `${API_URLS.MINDEX}/api/earth/stats`,
+  EARTH_CREP_SYNC: `${API_URLS.MINDEX}/api/earth/crep/sync`,
+  EARTH_MAP_LAYERS: `${API_URLS.MINDEX}/api/earth/map/layers`,
+  EARTH_DOMAINS: `${API_URLS.MINDEX}/api/earth/domains`,
+  EARTH_INGEST: `${API_URLS.MINDEX}/api/earth/ingest`,
 } as const
 
 /**

--- a/lib/crep/crep-data-service.ts
+++ b/lib/crep/crep-data-service.ts
@@ -457,3 +457,234 @@ export function getServiceStats() {
     timestamp: new Date().toISOString(),
   }
 }
+
+// ============================================================================
+// MINDEX Earth Intelligence — Spatial Queries (bbox)
+// ============================================================================
+
+export interface EarthBboxOptions extends FetchOptions {
+  north: number
+  south: number
+  east: number
+  west: number
+  layers?: string[]
+}
+
+export interface WeatherAlert {
+  id: string
+  type: string
+  title: string
+  severity: string
+  lat: number
+  lng: number
+  timestamp: string
+}
+
+export interface EmissionSource {
+  id: string
+  type: string
+  name: string
+  lat: number
+  lng: number
+  value?: number
+  unit?: string
+}
+
+export interface InfrastructureItem {
+  id: string
+  type: string
+  name: string
+  lat: number
+  lng: number
+  status?: string
+}
+
+export interface SpaceWeatherEvent {
+  id: string
+  type: string
+  title: string
+  severity: string
+  timestamp: string
+}
+
+/**
+ * Fetch all earth data within a bounding box from MINDEX.
+ * Uses the new /api/earth/map/bbox endpoint for spatial queries.
+ * Falls back to individual OEI endpoints if MINDEX is unreachable.
+ */
+export async function getEarthDataByBbox(options: EarthBboxOptions): Promise<{
+  aircraft: Aircraft[]
+  vessels: Vessel[]
+  satellites: Satellite[]
+  globalEvents: GlobalEvent[]
+  fungalObservations: FungalObservation[]
+  devices: Device[]
+  weather: WeatherAlert[]
+  emissions: EmissionSource[]
+  infrastructure: InfrastructureItem[]
+  spaceWeather: SpaceWeatherEvent[]
+}> {
+  const emptyResult = {
+    aircraft: [] as Aircraft[],
+    vessels: [] as Vessel[],
+    satellites: [] as Satellite[],
+    globalEvents: [] as GlobalEvent[],
+    fungalObservations: [] as FungalObservation[],
+    devices: [] as Device[],
+    weather: [] as WeatherAlert[],
+    emissions: [] as EmissionSource[],
+    infrastructure: [] as InfrastructureItem[],
+    spaceWeather: [] as SpaceWeatherEvent[],
+  }
+
+  // Try MINDEX spatial endpoint first
+  try {
+    const params = new URLSearchParams({
+      north: String(options.north),
+      south: String(options.south),
+      east: String(options.east),
+      west: String(options.west),
+    })
+    if (options.layers?.length) {
+      params.set("layers", options.layers.join(","))
+    }
+    if (options.limit) {
+      params.set("limit", String(options.limit))
+    }
+
+    const mindexUrl = `${API_URLS.MINDEX}/api/earth/map/bbox?${params}`
+    const data = await safeFetch<Record<string, unknown[]>>(
+      mindexUrl,
+      {},
+      options.timeout || 8000,
+      options.signal
+    )
+
+    if (data && Object.keys(data).length > 0) {
+      return {
+        aircraft: (data.aircraft as Aircraft[]) || [],
+        vessels: (data.vessels as Vessel[]) || [],
+        satellites: (data.satellites as Satellite[]) || [],
+        globalEvents: (data.events as GlobalEvent[]) || (data.globalEvents as GlobalEvent[]) || [],
+        fungalObservations: (data.observations as FungalObservation[]) || (data.fungalObservations as FungalObservation[]) || [],
+        devices: (data.devices as Device[]) || [],
+        weather: (data.weather as WeatherAlert[]) || [],
+        emissions: (data.emissions as EmissionSource[]) || [],
+        infrastructure: (data.infrastructure as InfrastructureItem[]) || [],
+        spaceWeather: (data.space_weather as SpaceWeatherEvent[]) || (data.spaceWeather as SpaceWeatherEvent[]) || [],
+      }
+    }
+  } catch {
+    console.warn("[CREP Service] MINDEX earth/map/bbox unavailable, falling back to OEI")
+  }
+
+  // Fallback: use existing OEI-based fetchers
+  const opts: FetchOptions = { signal: options.signal }
+  const [aircraft, vessels, satellites, fungalObservations, globalEvents, devices] =
+    await Promise.all([
+      getAircraft(opts).catch(() => []),
+      getVessels(opts).catch(() => []),
+      getSatellites(opts).catch(() => []),
+      getFungalObservations(opts).catch(() => []),
+      getGlobalEvents(opts).catch(() => []),
+      getDevices(opts).catch(() => []),
+    ])
+
+  return {
+    ...emptyResult,
+    aircraft,
+    vessels,
+    satellites,
+    fungalObservations,
+    globalEvents,
+    devices,
+  }
+}
+
+/**
+ * Get MINDEX earth domain statistics.
+ */
+export async function getEarthStats(signal?: AbortSignal): Promise<Record<string, number>> {
+  try {
+    const data = await safeFetch<Record<string, number>>(
+      `${API_URLS.MINDEX}/api/earth/stats`,
+      {},
+      5000,
+      signal
+    )
+    return data
+  } catch {
+    // Fallback: build stats from existing data
+    const summary = await getDataSummary(signal)
+    return {
+      aircraft: summary.aircraft,
+      vessels: summary.vessels,
+      satellites: summary.satellites,
+      fungalObservations: summary.fungalObservations,
+      globalEvents: summary.globalEvents,
+      devices: summary.devices,
+    }
+  }
+}
+
+/**
+ * Fetch all data including new earth domains with progressive loading.
+ */
+export async function fetchAllEarthData(
+  onDataReady?: (type: string, data: unknown[]) => void,
+  signal?: AbortSignal
+): Promise<{
+  aircraft: Aircraft[]
+  vessels: Vessel[]
+  satellites: Satellite[]
+  fungalObservations: FungalObservation[]
+  globalEvents: GlobalEvent[]
+  devices: Device[]
+  weather: WeatherAlert[]
+  emissions: EmissionSource[]
+  infrastructure: InfrastructureItem[]
+  spaceWeather: SpaceWeatherEvent[]
+}> {
+  // Try MINDEX full earth sync first
+  try {
+    const data = await safeFetch<Record<string, unknown[]>>(
+      `${API_URLS.MINDEX}/api/earth/crep/sync`,
+      {},
+      12000,
+      signal
+    )
+    if (data && Object.keys(data).length > 0) {
+      const result = {
+        aircraft: (data.aircraft as Aircraft[]) || [],
+        vessels: (data.vessels as Vessel[]) || [],
+        satellites: (data.satellites as Satellite[]) || [],
+        fungalObservations: (data.observations as FungalObservation[]) || [],
+        globalEvents: (data.events as GlobalEvent[]) || [],
+        devices: (data.devices as Device[]) || [],
+        weather: (data.weather as WeatherAlert[]) || [],
+        emissions: (data.emissions as EmissionSource[]) || [],
+        infrastructure: (data.infrastructure as InfrastructureItem[]) || [],
+        spaceWeather: (data.space_weather as SpaceWeatherEvent[]) || [],
+      }
+      // Fire progressive callbacks
+      for (const [key, val] of Object.entries(result)) {
+        if (Array.isArray(val) && val.length > 0) {
+          onDataReady?.(key, val)
+        }
+      }
+      return result
+    }
+  } catch {
+    // Fall through to individual fetchers
+  }
+
+  // Fallback: use existing fetchAllData + empty new domains
+  const base = await fetchAllData(onDataReady, signal)
+  return {
+    ...base,
+    weather: [],
+    emissions: [],
+    infrastructure: [],
+    spaceWeather: [],
+  }
+}

--- a/lib/crep/index.ts
+++ b/lib/crep/index.ts
@@ -117,3 +117,15 @@ export {
 } from "./spatial/s2-indexer"
 
 export type { MapBounds } from "./spatial/s2-indexer"
+
+// CREP Data Service — Earth Intelligence
+export {
+  getEarthDataByBbox,
+  getEarthStats,
+  fetchAllEarthData,
+  type EarthBboxOptions,
+  type WeatherAlert,
+  type EmissionSource,
+  type InfrastructureItem,
+  type SpaceWeatherEvent,
+} from "./crep-data-service"

--- a/lib/crep/myca-integration.ts
+++ b/lib/crep/myca-integration.ts
@@ -72,7 +72,7 @@ export interface CREPContextForMYCA {
     zoom: number
     bounds?: { north: number; south: number; east: number; west: number }
   }
-  /** Summary of visible entities */
+  /** Summary of visible entities — all Earth Intelligence domains */
   entitySummary: {
     aircraft: number
     vessels: number
@@ -80,6 +80,10 @@ export interface CREPContextForMYCA {
     fungalObservations: number
     globalEvents: number
     devices: number
+    weather: number
+    emissions: number
+    infrastructure: number
+    spaceWeather: number
     total: number
   }
   /** Active mission context */
@@ -265,9 +269,13 @@ export function buildCREPContextForMYCA(context: CREPContextForMYCA): string {
   if (entitySummary.aircraft > 0) entityParts.push(`${entitySummary.aircraft} aircraft`)
   if (entitySummary.vessels > 0) entityParts.push(`${entitySummary.vessels} vessels`)
   if (entitySummary.satellites > 0) entityParts.push(`${entitySummary.satellites} satellites`)
-  if (entitySummary.fungalObservations > 0) entityParts.push(`${entitySummary.fungalObservations} fungal observations`)
+  if (entitySummary.fungalObservations > 0) entityParts.push(`${entitySummary.fungalObservations} biodiversity observations`)
   if (entitySummary.globalEvents > 0) entityParts.push(`${entitySummary.globalEvents} global events`)
   if (entitySummary.devices > 0) entityParts.push(`${entitySummary.devices} MycoBrain devices`)
+  if (entitySummary.weather > 0) entityParts.push(`${entitySummary.weather} weather alerts`)
+  if (entitySummary.emissions > 0) entityParts.push(`${entitySummary.emissions} emission sources`)
+  if (entitySummary.infrastructure > 0) entityParts.push(`${entitySummary.infrastructure} infrastructure`)
+  if (entitySummary.spaceWeather > 0) entityParts.push(`${entitySummary.spaceWeather} space weather events`)
   if (entityParts.length > 0) {
     parts.push(`Visible entities: ${entityParts.join(", ")} (${entitySummary.total} total)`)
   }

--- a/lib/crep/myca-integration.ts
+++ b/lib/crep/myca-integration.ts
@@ -311,6 +311,14 @@ export function buildCREPContextForMYCA(context: CREPContextForMYCA): string {
   // Stream status
   parts.push(`Stream status: ${context.streamStatus}`)
 
+  // Earth Intelligence capabilities
+  parts.push(
+    `Earth Intelligence domains: aircraft, vessels, satellites, events, weather, emissions, infrastructure, devices, space_weather, species, hydrology, atmospheric, signals, transport, monitor`
+  )
+  parts.push(
+    `Available tools: mycosoft_earth_search (query all domains), mycosoft_earth_bbox (spatial query), mycosoft_earth_stats (domain counts), mycosoft_map_command (map control)`
+  )
+
   return parts.join("\n")
 }
 

--- a/lib/search/earth-search-connectors.ts
+++ b/lib/search/earth-search-connectors.ts
@@ -1,0 +1,661 @@
+/**
+ * Earth Intelligence Search Connectors — Mar 15, 2026
+ *
+ * Bridges ALL OEI connectors + external APIs into the unified search pipeline.
+ * Each function takes a search query and returns results in the unified format.
+ * All calls are fire-and-forget safe (catch errors internally, return []).
+ *
+ * Domains covered:
+ *   1. Natural events — earthquakes, volcanoes, wildfires, storms, floods, lightning
+ *   2. Aircraft — OpenSky ADS-B, FlightRadar24
+ *   3. Vessels — AISstream AIS
+ *   4. Satellites — CelesTrak TLE
+ *   5. Weather — NWS alerts, Open-Meteo
+ *   6. Emissions — Carbon Mapper, OpenAQ
+ *   7. Infrastructure — OpenRailway, OpenStreetMap
+ *   8. Devices — MycoBrain telemetry
+ *   9. Space weather — NOAA SWPC
+ *  10. All-life species — GBIF, eBird, OBIS, iNaturalist (beyond fungi)
+ */
+
+import type {
+  EventResult,
+  AircraftResult,
+  VesselResult,
+  SatelliteResult,
+  WeatherResult,
+  EmissionsResult,
+  InfrastructureResult,
+  DeviceResult,
+  SpaceWeatherResult,
+} from "./unified-search-sdk"
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+async function safeFetch(url: string, timeoutMs = 8000): Promise<Response | null> {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: { Accept: "application/json" },
+    })
+    if (!res.ok) return null
+    return res
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Natural Events (NASA EONET + USGS)
+// ---------------------------------------------------------------------------
+
+const EVENT_CATEGORY_MAP: Record<string, string[]> = {
+  earthquake: ["earthquake", "seismic", "quake", "tremor", "richter", "magnitude"],
+  volcano: ["volcano", "volcanic", "eruption", "lava", "magma", "caldera", "vesuvius", "etna", "kilauea"],
+  wildfire: ["wildfire", "fire", "burn", "blaze", "flame", "arson", "forest fire"],
+  storm: ["storm", "hurricane", "typhoon", "cyclone", "tornado", "twister", "thunder", "hail", "supercell"],
+  flood: ["flood", "flooding", "deluge", "inundation", "flash flood", "river overflow"],
+  lightning: ["lightning", "bolt", "thunder", "strike", "blitz"],
+  tsunami: ["tsunami", "tidal wave", "seiche"],
+  dust_haze: ["dust", "haze", "sandstorm", "saharan", "smoke", "smog"],
+}
+
+function detectEventCategory(query: string): string | null {
+  const q = query.toLowerCase()
+  for (const [category, keywords] of Object.entries(EVENT_CATEGORY_MAP)) {
+    if (keywords.some(kw => q.includes(kw))) return category
+  }
+  return null
+}
+
+export async function searchEvents(query: string, limit = 20): Promise<EventResult[]> {
+  try {
+    const category = detectEventCategory(query)
+    let eonetCategory = ""
+    if (category === "earthquake") eonetCategory = "earthquakes"
+    else if (category === "volcano") eonetCategory = "volcanoes"
+    else if (category === "wildfire") eonetCategory = "wildfires"
+    else if (category === "storm" || category === "tornado") eonetCategory = "severeStorms"
+    else if (category === "flood") eonetCategory = "floods"
+
+    const eonetUrl = `https://eonet.gsfc.nasa.gov/api/v3/events?status=open&limit=${limit}${eonetCategory ? `&category=${eonetCategory}` : ""}`
+    const res = await safeFetch(eonetUrl, 10000)
+    if (!res) return []
+
+    const data = await res.json()
+    const events = data.events || []
+
+    return events.slice(0, limit).map((e: Record<string, unknown>) => {
+      const geom = (e.geometry as Array<Record<string, unknown>>)?.[0]
+      const coords = (geom?.coordinates as number[]) || [0, 0]
+      const cats = (e.categories as Array<Record<string, string>>)?.[0]
+
+      let eventType: EventResult["type"] = "dust_haze"
+      const catId = cats?.id || ""
+      if (catId === "earthquakes") eventType = "earthquake"
+      else if (catId === "volcanoes") eventType = "volcano"
+      else if (catId === "wildfires") eventType = "wildfire"
+      else if (catId === "severeStorms") eventType = "storm"
+      else if (catId === "floods") eventType = "flood"
+
+      return {
+        id: `eonet-${e.id}`,
+        type: eventType,
+        title: (e.title as string) || "",
+        description: (e.description as string) || `${eventType} event`,
+        lat: coords[1] || 0,
+        lng: coords[0] || 0,
+        severity: undefined,
+        timestamp: (geom?.date as string) || new Date().toISOString(),
+        source: "NASA EONET",
+      }
+    })
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Aircraft (OpenSky Network)
+// ---------------------------------------------------------------------------
+
+const AIRCRAFT_KEYWORDS = [
+  "aircraft", "airplane", "plane", "flight", "aviation", "jet",
+  "ads-b", "adsb", "airline", "landing", "takeoff", "airspace",
+  "over", "flying",
+]
+
+export function isAircraftQuery(query: string): boolean {
+  const q = query.toLowerCase()
+  return AIRCRAFT_KEYWORDS.some(kw => q.includes(kw))
+}
+
+export async function searchAircraft(query: string, limit = 20): Promise<AircraftResult[]> {
+  try {
+    const res = await safeFetch("https://opensky-network.org/api/states/all?extended=1", 10000)
+    if (!res) return []
+    const data = await res.json()
+    const states = data.states || []
+
+    const q = query.toLowerCase()
+    let filtered = states
+
+    // Filter by callsign or region if query hints
+    if (q.includes("over la") || q.includes("los angeles")) {
+      filtered = states.filter((s: unknown[]) => {
+        const lat = s[6] as number, lng = s[5] as number
+        return lat && lng && Math.abs(lat - 34.05) < 2 && Math.abs(lng + 118.24) < 2
+      })
+    } else if (q.includes("over sf") || q.includes("san francisco")) {
+      filtered = states.filter((s: unknown[]) => {
+        const lat = s[6] as number, lng = s[5] as number
+        return lat && lng && Math.abs(lat - 37.77) < 2 && Math.abs(lng + 122.42) < 2
+      })
+    } else if (q.includes("pacific")) {
+      filtered = states.filter((s: unknown[]) => {
+        const lng = s[5] as number
+        return lng && lng < -120 && lng > -180
+      })
+    }
+
+    return filtered.slice(0, limit).map((s: unknown[]) => ({
+      id: `opensky-${s[0]}`,
+      callsign: ((s[1] as string) || "").trim(),
+      icao24: (s[0] as string) || "",
+      origin: (s[2] as string) || "",
+      lat: (s[6] as number) || 0,
+      lng: (s[5] as number) || 0,
+      altitude: (s[7] as number) || 0,
+      velocity: (s[9] as number) || 0,
+      heading: (s[10] as number) || 0,
+      onGround: (s[8] as boolean) || false,
+      source: "OpenSky Network",
+    }))
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Vessels (AISstream via internal API)
+// ---------------------------------------------------------------------------
+
+const VESSEL_KEYWORDS = [
+  "vessel", "ship", "boat", "maritime", "port", "harbor", "harbour",
+  "cargo", "tanker", "freighter", "cruise", "ferry", "ais", "mmsi",
+  "marine traffic", "shipping", "naval",
+]
+
+export function isVesselQuery(query: string): boolean {
+  const q = query.toLowerCase()
+  return VESSEL_KEYWORDS.some(kw => q.includes(kw))
+}
+
+export async function searchVessels(query: string, origin: string, limit = 20): Promise<VesselResult[]> {
+  try {
+    const res = await safeFetch(`${origin}/api/oei/aisstream?limit=${limit}`, 10000)
+    if (!res) return []
+    const data = await res.json()
+    const vessels = data.entities || data.vessels || data.data || []
+
+    return (vessels as Record<string, unknown>[]).slice(0, limit).map((v) => ({
+      id: `ais-${v.mmsi || v.id}`,
+      name: (v.name as string) || (v.vessel_name as string) || "Unknown",
+      mmsi: String(v.mmsi || v.id || ""),
+      shipType: (v.ship_type as string) || (v.type as string) || "Unknown",
+      lat: (v.lat as number) || (v.latitude as number) || 0,
+      lng: (v.lng as number) || (v.longitude as number) || 0,
+      speed: (v.speed as number) || (v.sog as number) || 0,
+      heading: (v.heading as number) || (v.cog as number) || 0,
+      destination: (v.destination as string) || undefined,
+      source: "AISstream",
+    }))
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Satellites (CelesTrak TLE)
+// ---------------------------------------------------------------------------
+
+const SATELLITE_KEYWORDS = [
+  "satellite", "orbit", "space station", "iss", "starlink", "gps",
+  "norad", "tle", "celestrak", "space debris", "hubble", "james webb",
+]
+
+export function isSatelliteQuery(query: string): boolean {
+  const q = query.toLowerCase()
+  return SATELLITE_KEYWORDS.some(kw => q.includes(kw))
+}
+
+export async function searchSatellites(query: string, origin: string, limit = 20): Promise<SatelliteResult[]> {
+  try {
+    const res = await safeFetch(`${origin}/api/oei/satellites?limit=${limit}`, 10000)
+    if (!res) return []
+    const data = await res.json()
+    const sats = data.entities || data.satellites || data.data || []
+
+    return (sats as Record<string, unknown>[]).slice(0, limit).map((s) => ({
+      id: `sat-${s.norad_id || s.id}`,
+      name: (s.name as string) || "Unknown",
+      noradId: String(s.norad_id || s.noradId || s.id || ""),
+      category: (s.category as string) || "active",
+      lat: (s.lat as number) || (s.latitude as number) || 0,
+      lng: (s.lng as number) || (s.longitude as number) || 0,
+      altitude: (s.altitude as number) || (s.alt as number) || 0,
+      velocity: (s.velocity as number) || undefined,
+      source: "CelesTrak",
+    }))
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Weather (NWS Alerts + Open-Meteo)
+// ---------------------------------------------------------------------------
+
+const WEATHER_KEYWORDS = [
+  "weather", "forecast", "temperature", "wind", "rain", "snow",
+  "humidity", "pressure", "precipitation", "cloud", "uv",
+  "heat", "cold", "frost", "drought", "climate",
+  "modis", "landsat", "airs", "radar", "barometer",
+]
+
+export function isWeatherQuery(query: string): boolean {
+  const q = query.toLowerCase()
+  return WEATHER_KEYWORDS.some(kw => q.includes(kw))
+}
+
+export async function searchWeather(query: string, origin: string, limit = 10): Promise<WeatherResult[]> {
+  try {
+    const results: WeatherResult[] = []
+
+    // NWS Alerts
+    const alertsRes = await safeFetch(`${origin}/api/oei/nws-alerts?limit=${limit}`)
+    if (alertsRes) {
+      const alertsData = await alertsRes.json()
+      const alerts = alertsData.entities || alertsData.alerts || alertsData.data || []
+      for (const a of (alerts as Record<string, unknown>[]).slice(0, limit)) {
+        results.push({
+          id: `nws-${a.id}`,
+          type: "alert",
+          title: (a.headline as string) || (a.title as string) || (a.event as string) || "Weather Alert",
+          description: (a.description as string) || "",
+          lat: (a.lat as number) || undefined,
+          lng: (a.lng as number) || undefined,
+          timestamp: (a.onset as string) || (a.effective as string) || new Date().toISOString(),
+          source: "NWS",
+        })
+      }
+    }
+
+    return results.slice(0, limit)
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Emissions & Air Quality (Carbon Mapper + OpenAQ)
+// ---------------------------------------------------------------------------
+
+const EMISSIONS_KEYWORDS = [
+  "co2", "carbon", "methane", "emission", "pollution", "pollutant",
+  "air quality", "pm2.5", "pm10", "ozone", "o3", "no2", "so2",
+  "co", "carbon monoxide", "smog", "particulate", "aqi",
+  "plume", "leak", "flare", "vent",
+]
+
+export function isEmissionsQuery(query: string): boolean {
+  const q = query.toLowerCase()
+  return EMISSIONS_KEYWORDS.some(kw => q.includes(kw))
+}
+
+export async function searchEmissions(query: string, origin: string, limit = 20): Promise<EmissionsResult[]> {
+  const results: EmissionsResult[] = []
+  const q = query.toLowerCase()
+
+  try {
+    // Carbon Mapper
+    if (q.includes("methane") || q.includes("co2") || q.includes("carbon") || q.includes("emission") || q.includes("plume")) {
+      const cmRes = await safeFetch(`${origin}/api/oei/carbon-mapper?limit=${limit}`)
+      if (cmRes) {
+        const cmData = await cmRes.json()
+        const plumes = cmData.entities || cmData.plumes || cmData.data || []
+        for (const p of (plumes as Record<string, unknown>[]).slice(0, limit)) {
+          results.push({
+            id: `cm-${p.id}`,
+            type: q.includes("methane") ? "methane" : "co2",
+            title: (p.name as string) || (p.source_name as string) || "Emission Source",
+            description: (p.description as string) || `${p.source_type || "Unknown"} emission`,
+            lat: (p.lat as number) || (p.latitude as number) || 0,
+            lng: (p.lng as number) || (p.longitude as number) || 0,
+            value: (p.emission_rate as number) || undefined,
+            unit: "kg/hr",
+            sourceType: (p.source_type as string) || undefined,
+            timestamp: (p.datetime as string) || new Date().toISOString(),
+            source: "Carbon Mapper",
+          })
+        }
+      }
+    }
+
+    // OpenAQ
+    if (q.includes("air quality") || q.includes("pm") || q.includes("ozone") || q.includes("no2") || q.includes("so2") || q.includes("aqi") || q.includes("pollution")) {
+      const aqRes = await safeFetch(`${origin}/api/oei/openaq?limit=${limit}`)
+      if (aqRes) {
+        const aqData = await aqRes.json()
+        const measurements = aqData.entities || aqData.measurements || aqData.data || []
+        for (const m of (measurements as Record<string, unknown>[]).slice(0, limit)) {
+          results.push({
+            id: `oaq-${m.id}`,
+            type: "air_quality",
+            title: (m.location as string) || (m.city as string) || "Air Quality Reading",
+            description: `${m.parameter || "AQI"}: ${m.value || "N/A"} ${m.unit || ""}`,
+            lat: (m.lat as number) || (m.latitude as number) || 0,
+            lng: (m.lng as number) || (m.longitude as number) || 0,
+            value: (m.value as number) || undefined,
+            unit: (m.unit as string) || undefined,
+            parameter: (m.parameter as string) || undefined,
+            timestamp: (m.date as string) || (m.lastUpdated as string) || new Date().toISOString(),
+            source: "OpenAQ",
+          })
+        }
+      }
+    }
+  } catch {
+    // silent
+  }
+
+  return results.slice(0, limit)
+}
+
+// ---------------------------------------------------------------------------
+// 7. Infrastructure (OpenRailway + general)
+// ---------------------------------------------------------------------------
+
+const INFRASTRUCTURE_KEYWORDS = [
+  "factory", "power plant", "dam", "mining", "mine", "oil", "gas",
+  "treatment plant", "refinery", "pipeline", "power grid",
+  "airport", "seaport", "port", "spaceport", "launch pad",
+  "railway", "railroad", "train station", "antenna", "cell tower",
+  "internet cable", "submarine cable", "power line", "substation",
+  "military base", "military", "air force", "navy", "army",
+  "water treatment", "reservoir", "wind farm", "solar farm",
+  "nuclear", "coal", "hydroelectric", "geothermal",
+]
+
+export function isInfrastructureQuery(query: string): boolean {
+  const q = query.toLowerCase()
+  return INFRASTRUCTURE_KEYWORDS.some(kw => q.includes(kw))
+}
+
+export async function searchInfrastructure(query: string, origin: string, limit = 20): Promise<InfrastructureResult[]> {
+  try {
+    const q = query.toLowerCase()
+    const results: InfrastructureResult[] = []
+
+    // Railway data
+    if (q.includes("railway") || q.includes("railroad") || q.includes("train")) {
+      const rRes = await safeFetch(`${origin}/api/oei/railways?limit=${limit}`)
+      if (rRes) {
+        const rData = await rRes.json()
+        const stations = rData.entities || rData.stations || rData.data || []
+        for (const s of (stations as Record<string, unknown>[]).slice(0, limit)) {
+          results.push({
+            id: `rail-${s.id}`,
+            type: "railway",
+            name: (s.name as string) || "Railway",
+            description: (s.description as string) || (s.operator as string) || undefined,
+            lat: (s.lat as number) || (s.latitude as number) || 0,
+            lng: (s.lng as number) || (s.longitude as number) || 0,
+            operator: (s.operator as string) || undefined,
+            source: "OpenRailwayMap",
+          })
+        }
+      }
+    }
+
+    return results.slice(0, limit)
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 8. Devices (MycoBrain telemetry)
+// ---------------------------------------------------------------------------
+
+const DEVICE_KEYWORDS = [
+  "device", "sensor", "mycobrain", "sporebase", "telemetry",
+  "iot", "mycoboard", "brain board", "spore count",
+  "myco", "trufflebot", "myconode", "hyphae",
+]
+
+export function isDeviceQuery(query: string): boolean {
+  const q = query.toLowerCase()
+  return DEVICE_KEYWORDS.some(kw => q.includes(kw))
+}
+
+export async function searchDevices(query: string, origin: string, limit = 20): Promise<DeviceResult[]> {
+  try {
+    const res = await safeFetch(`${origin}/api/natureos/devices/mycobrain`)
+    if (!res) return []
+    const data = await res.json()
+    const devices = data.devices || data.data || data || []
+
+    return (devices as Record<string, unknown>[]).slice(0, limit).map((d) => ({
+      id: `device-${d.id || d.device_id}`,
+      deviceType: (d.type as string) || (d.device_type as string) || "mycobrain",
+      name: (d.name as string) || (d.label as string) || "MycoBrain",
+      lat: (d.lat as number) || (d.latitude as number) || undefined,
+      lng: (d.lng as number) || (d.longitude as number) || undefined,
+      temperature: (d.temperature as number) || undefined,
+      humidity: (d.humidity as number) || undefined,
+      airQuality: (d.air_quality as number) || undefined,
+      sporeCount: (d.spore_count as number) || undefined,
+      lastSeen: (d.last_seen as string) || new Date().toISOString(),
+      status: (d.status as string) || "online",
+      source: "MycoBrain",
+    }))
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 9. Space Weather (NOAA SWPC)
+// ---------------------------------------------------------------------------
+
+const SPACE_WEATHER_KEYWORDS = [
+  "solar flare", "solar wind", "geomagnetic", "aurora", "northern lights",
+  "kp index", "kp-index", "x-ray flux", "coronal mass", "cme",
+  "space weather", "solar storm", "radiation belt", "magnetosphere",
+  "soho", "stereo", "solar cycle", "sunspot",
+]
+
+export function isSpaceWeatherQuery(query: string): boolean {
+  const q = query.toLowerCase()
+  return SPACE_WEATHER_KEYWORDS.some(kw => q.includes(kw))
+}
+
+export async function searchSpaceWeather(query: string, origin: string, _limit = 10): Promise<SpaceWeatherResult[]> {
+  try {
+    const res = await safeFetch(`${origin}/api/oei/space-weather`)
+    if (!res) return []
+    const data = await res.json()
+    const conditions = data.conditions || data.data || data
+
+    const results: SpaceWeatherResult[] = []
+
+    if (conditions.solar_wind || conditions.solarWind) {
+      const sw = conditions.solar_wind || conditions.solarWind || {}
+      results.push({
+        id: "sw-solar-wind",
+        type: "solar_wind",
+        title: "Solar Wind Conditions",
+        description: `Speed: ${sw.speed || "N/A"} km/s, Density: ${sw.density || "N/A"} p/cm³`,
+        solarWindSpeed: sw.speed,
+        timestamp: sw.time_tag || new Date().toISOString(),
+        source: "NOAA SWPC",
+      })
+    }
+
+    if (conditions.kp_index != null || conditions.kpIndex != null) {
+      const kp = conditions.kp_index ?? conditions.kpIndex
+      results.push({
+        id: "sw-kp-index",
+        type: "geomagnetic_storm",
+        title: `Geomagnetic Activity (Kp=${kp})`,
+        description: kp >= 5 ? "Geomagnetic storm in progress" : "Quiet geomagnetic conditions",
+        severity: kp >= 7 ? "high" : kp >= 5 ? "medium" : "low",
+        kpIndex: kp,
+        timestamp: new Date().toISOString(),
+        source: "NOAA SWPC",
+      })
+    }
+
+    if (conditions.xray_flux || conditions.xrayFlux) {
+      const xf = conditions.xray_flux || conditions.xrayFlux
+      results.push({
+        id: "sw-xray",
+        type: "solar_flare",
+        title: "X-Ray Flux",
+        description: `Current X-ray flux: ${typeof xf === "object" ? xf.flux : xf}`,
+        xrayFlux: typeof xf === "object" ? xf.flux : xf,
+        timestamp: new Date().toISOString(),
+        source: "NOAA SWPC",
+      })
+    }
+
+    return results
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Master: detect which domains a query targets
+// ---------------------------------------------------------------------------
+
+export interface EarthSearchDomains {
+  events: boolean
+  aircraft: boolean
+  vessels: boolean
+  satellites: boolean
+  weather: boolean
+  emissions: boolean
+  infrastructure: boolean
+  devices: boolean
+  spaceWeather: boolean
+}
+
+export function detectEarthDomains(query: string): EarthSearchDomains {
+  return {
+    events: detectEventCategory(query) !== null,
+    aircraft: isAircraftQuery(query),
+    vessels: isVesselQuery(query),
+    satellites: isSatelliteQuery(query),
+    weather: isWeatherQuery(query),
+    emissions: isEmissionsQuery(query),
+    infrastructure: isInfrastructureQuery(query),
+    devices: isDeviceQuery(query),
+    spaceWeather: isSpaceWeatherQuery(query),
+  }
+}
+
+/**
+ * Try MINDEX Earth search endpoint first (local DB, low latency).
+ * Falls through to external APIs if MINDEX returns nothing.
+ */
+async function searchMindexEarth(query: string, limit: number): Promise<Record<string, unknown[]> | null> {
+  const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://192.168.0.189:8000"
+  try {
+    const res = await safeFetch(
+      `${MINDEX_API_URL}/api/search/earth?q=${encodeURIComponent(query)}&limit=${limit}`,
+      6000
+    )
+    if (!res) return null
+    const data = await res.json()
+    if (data?.universal_results?.length > 0 || data?.results) {
+      return data.results || data
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Run all Earth Intelligence searches in parallel based on detected domains.
+ * MINDEX-first: tries local DB, then falls back to external APIs.
+ * Returns partial results object matching UnifiedSearchResults shape.
+ */
+export async function searchEarthIntelligence(
+  query: string,
+  origin: string,
+  limit = 20
+): Promise<{
+  events: EventResult[]
+  aircraft: AircraftResult[]
+  vessels: VesselResult[]
+  satellites: SatelliteResult[]
+  weather: WeatherResult[]
+  emissions: EmissionsResult[]
+  infrastructure: InfrastructureResult[]
+  devices: DeviceResult[]
+  space_weather: SpaceWeatherResult[]
+}> {
+  // MINDEX-first: try local database (instant, already scraped + stored)
+  const mindexEarth = await searchMindexEarth(query, limit)
+  if (mindexEarth) {
+    // Map MINDEX results to our typed format — MINDEX returns domain-keyed arrays
+    return {
+      events: (mindexEarth.events as EventResult[]) || [],
+      aircraft: (mindexEarth.aircraft as AircraftResult[]) || [],
+      vessels: (mindexEarth.vessels as VesselResult[]) || [],
+      satellites: (mindexEarth.satellites as SatelliteResult[]) || [],
+      weather: (mindexEarth.weather as WeatherResult[]) || [],
+      emissions: (mindexEarth.emissions as EmissionsResult[]) || [],
+      infrastructure: (mindexEarth.infrastructure as InfrastructureResult[]) || [],
+      devices: (mindexEarth.devices as DeviceResult[]) || [],
+      space_weather: (mindexEarth.space_weather as SpaceWeatherResult[]) || [],
+    }
+  }
+
+  // Fallback: query external APIs directly
+  const domains = detectEarthDomains(query)
+  const isGeneral = !Object.values(domains).some(Boolean)
+
+  // For general queries, search events + weather as baseline context
+  const promises = {
+    events: (domains.events || isGeneral) ? searchEvents(query, limit) : Promise.resolve([]),
+    aircraft: domains.aircraft ? searchAircraft(query, limit) : Promise.resolve([]),
+    vessels: domains.vessels ? searchVessels(query, origin, limit) : Promise.resolve([]),
+    satellites: domains.satellites ? searchSatellites(query, origin, limit) : Promise.resolve([]),
+    weather: (domains.weather || isGeneral) ? searchWeather(query, origin, limit) : Promise.resolve([]),
+    emissions: domains.emissions ? searchEmissions(query, origin, limit) : Promise.resolve([]),
+    infrastructure: domains.infrastructure ? searchInfrastructure(query, origin, limit) : Promise.resolve([]),
+    devices: domains.devices ? searchDevices(query, origin, limit) : Promise.resolve([]),
+    space_weather: domains.spaceWeather ? searchSpaceWeather(query, origin, limit) : Promise.resolve([]),
+  }
+
+  const [events, aircraft, vessels, satellites, weather, emissions, infrastructure, devices, space_weather] =
+    await Promise.all([
+      promises.events,
+      promises.aircraft,
+      promises.vessels,
+      promises.satellites,
+      promises.weather,
+      promises.emissions,
+      promises.infrastructure,
+      promises.devices,
+      promises.space_weather,
+    ])
+
+  return { events, aircraft, vessels, satellites, weather, emissions, infrastructure, devices, space_weather }
+}

--- a/lib/search/intent-parser.ts
+++ b/lib/search/intent-parser.ts
@@ -8,7 +8,10 @@
  * - Query type (factual, comparison, list, etc.)
  */
 
-export type EntityType = "species" | "compound" | "media" | "research" | "location" | "crep" | "general"
+export type EntityType =
+  | "species" | "compound" | "media" | "research" | "location" | "crep" | "general"
+  | "event" | "aircraft" | "vessel" | "satellite" | "weather"
+  | "emissions" | "infrastructure" | "device" | "space_weather"
 
 export type ToxicityFilter = "poisonous" | "toxic" | "deadly" | "edible" | "medicinal" | "psychedelic" | "hallucinogenic"
 
@@ -91,8 +94,9 @@ const MEDIA_KEYWORDS: Record<MediaType, string[]> = {
   games: ["game", "games", "video game", "gaming"],
 }
 
-// Species/genus keywords (common fungi)
+// Species/genus keywords (all life — fungi, plants, animals, marine, insects)
 const SPECIES_KEYWORDS = [
+  // Fungi
   "mushroom", "mushrooms", "fungi", "fungus", "mycelium",
   "amanita", "psilocybe", "agaricus", "boletus", "cantharellus",
   "ganoderma", "hericium", "pleurotus", "morchella", "tuber",
@@ -101,6 +105,27 @@ const SPECIES_KEYWORDS = [
   "lion's mane", "lions mane", "reishi", "shiitake", "oyster mushroom",
   "turkey tail", "cordyceps", "chaga", "maitake", "enoki",
   "death cap", "destroying angel", "fly agaric", "liberty cap",
+  // All life
+  "species", "organism", "biodiversity", "taxonomy", "kingdom",
+  // Plants
+  "plant", "plants", "tree", "flower", "grass", "fern", "moss", "algae",
+  "oak", "pine", "maple", "sequoia", "cactus", "orchid", "rose", "sunflower",
+  // Birds
+  "bird", "birds", "eagle", "hawk", "owl", "parrot", "penguin", "hummingbird",
+  "sparrow", "robin", "crow", "raven", "migration",
+  // Mammals
+  "mammal", "mammals", "bear", "wolf", "deer", "whale", "dolphin", "elephant",
+  "tiger", "lion", "fox", "bat", "otter", "seal",
+  // Reptiles & Amphibians
+  "reptile", "reptiles", "snake", "lizard", "turtle", "crocodile", "alligator",
+  "frog", "toad", "salamander", "amphibian",
+  // Insects
+  "insect", "insects", "butterfly", "bee", "ant", "beetle", "moth", "dragonfly",
+  "mosquito", "wasp", "cricket", "grasshopper", "ladybug", "firefly",
+  // Marine life
+  "fish", "coral", "jellyfish", "octopus", "squid", "shark", "ray",
+  "sea turtle", "starfish", "sea horse", "lobster", "crab", "shrimp",
+  "marine life", "ocean life", "aquatic",
 ]
 
 // Compound/chemistry keywords
@@ -112,16 +137,75 @@ const COMPOUND_KEYWORDS = [
   "chitin", "melanin", "antioxidant", "formula", "structure",
 ]
 
-// CREP/environmental monitoring keywords
+// CREP/environmental monitoring keywords (now expanded to all Earth intelligence)
 const CREP_KEYWORDS = [
+  "crep", "monitor", "tracking", "radar", "observation map",
+]
+
+// Event keywords
+const EVENT_KEYWORDS = [
+  "earthquake", "seismic", "quake", "tremor", "volcano", "volcanic", "eruption",
+  "wildfire", "forest fire", "wildland fire", "storm", "hurricane", "typhoon",
+  "cyclone", "tornado", "twister", "flood", "flooding", "tsunami",
+  "lightning", "thunder", "hail", "landslide", "avalanche",
+]
+
+// Aircraft keywords
+const AIRCRAFT_KEYWORDS = [
   "aircraft", "airplane", "flight", "aviation", "plane", "planes",
+  "jet", "airline", "airport", "takeoff", "landing", "airspace",
+  "ads-b", "adsb", "flying over",
+]
+
+// Vessel keywords
+const VESSEL_KEYWORDS = [
   "vessel", "ship", "maritime", "boat", "tanker", "cargo",
+  "cruise", "ferry", "port", "harbor", "harbour", "ais",
+  "freighter", "naval", "shipping", "marine traffic",
+]
+
+// Satellite keywords
+const SATELLITE_KEYWORDS = [
   "satellite", "orbit", "space station", "iss", "starlink",
-  "earthquake", "seismic", "wildfire", "storm", "tsunami", "volcano",
-  "environmental", "radar", "tracking", "crep", "monitor",
-  "sensor", "device", "mycobrain", "spore", "dispersal",
-  "weather", "wind", "precipitation", "pressure",
-  "observation", "sighting", "observation map",
+  "gps", "norad", "tle", "celestrak", "hubble", "space debris",
+]
+
+// Weather keywords
+const WEATHER_KEYWORDS = [
+  "weather", "forecast", "temperature", "wind", "precipitation",
+  "rain", "snow", "humidity", "pressure", "cloud", "drought",
+  "climate", "heat wave", "cold front", "warm front", "modis", "landsat",
+]
+
+// Emissions & air quality keywords
+const EMISSIONS_KEYWORDS = [
+  "co2", "carbon", "methane", "emission", "pollution", "air quality",
+  "pm2.5", "pm10", "ozone", "smog", "particulate", "aqi",
+  "carbon mapper", "plume", "greenhouse",
+]
+
+// Infrastructure keywords
+const INFRASTRUCTURE_KEYWORDS = [
+  "factory", "power plant", "dam", "mining", "mine", "oil", "gas",
+  "refinery", "pipeline", "power grid", "airport", "seaport", "spaceport",
+  "railway", "railroad", "train station", "antenna", "cell tower",
+  "internet cable", "submarine cable", "power line", "nuclear",
+  "military base", "military", "wind farm", "solar farm",
+  "water treatment", "treatment plant", "reservoir",
+]
+
+// Device/sensor keywords
+const DEVICE_KEYWORDS = [
+  "device", "sensor", "mycobrain", "sporebase", "telemetry",
+  "iot", "mycoboard", "brain board", "spore count",
+  "environmental sensor", "observation",
+]
+
+// Space weather keywords
+const SPACE_WEATHER_KEYWORDS = [
+  "solar flare", "solar wind", "geomagnetic", "aurora", "northern lights",
+  "kp index", "x-ray flux", "coronal mass", "cme", "space weather",
+  "solar storm", "sunspot", "soho", "stereo",
 ]
 
 // Research keywords
@@ -207,14 +291,43 @@ export function parseSearchIntent(query: string): SearchIntent {
     }
   }
 
-  // Determine entity type
+  // Determine entity type — check all Earth Intelligence domains
   let type: EntityType = "general"
   let confidence = 0.5
+
+  const matchesDomain = (kws: string[]) => kws.some(kw => normalizedQuery.includes(kw))
 
   if (filters.mediaType) {
     type = "media"
     confidence = 0.85
-  } else if (CREP_KEYWORDS.some(kw => normalizedQuery.includes(kw))) {
+  } else if (matchesDomain(EVENT_KEYWORDS)) {
+    type = "event"
+    confidence = 0.9
+  } else if (matchesDomain(AIRCRAFT_KEYWORDS)) {
+    type = "aircraft"
+    confidence = 0.9
+  } else if (matchesDomain(VESSEL_KEYWORDS)) {
+    type = "vessel"
+    confidence = 0.9
+  } else if (matchesDomain(SATELLITE_KEYWORDS)) {
+    type = "satellite"
+    confidence = 0.9
+  } else if (matchesDomain(SPACE_WEATHER_KEYWORDS)) {
+    type = "space_weather"
+    confidence = 0.9
+  } else if (matchesDomain(EMISSIONS_KEYWORDS)) {
+    type = "emissions"
+    confidence = 0.85
+  } else if (matchesDomain(WEATHER_KEYWORDS)) {
+    type = "weather"
+    confidence = 0.85
+  } else if (matchesDomain(INFRASTRUCTURE_KEYWORDS)) {
+    type = "infrastructure"
+    confidence = 0.85
+  } else if (matchesDomain(DEVICE_KEYWORDS)) {
+    type = "device"
+    confidence = 0.85
+  } else if (matchesDomain(CREP_KEYWORDS)) {
     type = "crep"
     confidence = 0.85
   } else if (RESEARCH_KEYWORDS.some(kw => normalizedQuery.includes(kw))) {
@@ -285,18 +398,53 @@ export function getSearchParamsFromIntent(intent: SearchIntent): {
       break
     case "media":
       types.push("media")
-      includeAI = true // AI can provide media info
+      includeAI = true
+      break
+    case "event":
+      types.push("events", "weather", "species")
+      locationBased = true
+      break
+    case "aircraft":
+      types.push("aircraft")
+      locationBased = true
+      break
+    case "vessel":
+      types.push("vessels")
+      locationBased = true
+      break
+    case "satellite":
+      types.push("satellites", "space_weather")
+      break
+    case "weather":
+      types.push("weather", "events")
+      locationBased = true
+      break
+    case "emissions":
+      types.push("emissions", "weather")
+      locationBased = true
+      break
+    case "infrastructure":
+      types.push("infrastructure")
+      locationBased = true
+      break
+    case "device":
+      types.push("devices")
+      break
+    case "space_weather":
+      types.push("space_weather", "satellites")
       break
     case "crep":
-      types.push("crep", "species", "observations")
+      types.push("crep", "species", "events", "aircraft", "vessels", "satellites")
       locationBased = true
       break
     case "location":
-      types.push("species", "observations", "crep")
+      types.push("species", "events", "crep")
       locationBased = true
       break
     default:
-      types.push("species", "compounds", "genetics", "research")
+      types.push("species", "compounds", "genetics", "research",
+        "events", "aircraft", "vessels", "satellites", "weather",
+        "emissions", "infrastructure", "devices", "space_weather")
   }
 
   if (intent.filters.location) {

--- a/lib/search/unified-search-sdk.ts
+++ b/lib/search/unified-search-sdk.ts
@@ -76,14 +76,160 @@ export interface LiveResult {
   lng?: number
 }
 
+// ---------------------------------------------------------------------------
+// Earth Intelligence result types — all domains beyond biology
+// ---------------------------------------------------------------------------
+
+export interface EventResult {
+  id: string
+  type: "earthquake" | "volcano" | "wildfire" | "storm" | "flood" | "lightning" | "tornado" | "tsunami" | "dust_haze"
+  title: string
+  description: string
+  lat: number
+  lng: number
+  magnitude?: number
+  severity?: string
+  timestamp: string
+  source: string
+}
+
+export interface AircraftResult {
+  id: string
+  callsign: string
+  icao24: string
+  origin: string
+  destination?: string
+  lat: number
+  lng: number
+  altitude: number
+  velocity: number
+  heading: number
+  onGround: boolean
+  source: string
+}
+
+export interface VesselResult {
+  id: string
+  name: string
+  mmsi: string
+  shipType: string
+  lat: number
+  lng: number
+  speed: number
+  heading: number
+  destination?: string
+  source: string
+}
+
+export interface SatelliteResult {
+  id: string
+  name: string
+  noradId: string
+  category: string
+  lat: number
+  lng: number
+  altitude: number
+  velocity?: number
+  source: string
+}
+
+export interface WeatherResult {
+  id: string
+  type: "forecast" | "alert" | "observation" | "radar" | "satellite_imagery"
+  title: string
+  description: string
+  lat?: number
+  lng?: number
+  temperature?: number
+  windSpeed?: number
+  humidity?: number
+  precipitation?: number
+  pressure?: number
+  timestamp: string
+  source: string
+}
+
+export interface EmissionsResult {
+  id: string
+  type: "co2" | "methane" | "air_quality" | "pollution_source"
+  title: string
+  description: string
+  lat: number
+  lng: number
+  value?: number
+  unit?: string
+  parameter?: string
+  sourceType?: string
+  timestamp: string
+  source: string
+}
+
+export interface InfrastructureResult {
+  id: string
+  type: "power_plant" | "factory" | "dam" | "mining" | "oil_gas" | "treatment_plant"
+    | "airport" | "seaport" | "spaceport" | "railway" | "antenna" | "cable" | "military_base"
+  name: string
+  description?: string
+  lat: number
+  lng: number
+  operator?: string
+  source: string
+}
+
+export interface DeviceResult {
+  id: string
+  deviceType: string
+  name: string
+  lat?: number
+  lng?: number
+  temperature?: number
+  humidity?: number
+  airQuality?: number
+  sporeCount?: number
+  lastSeen: string
+  status: string
+  source: string
+}
+
+export interface SpaceWeatherResult {
+  id: string
+  type: "solar_flare" | "geomagnetic_storm" | "solar_wind" | "radiation_belt" | "cme"
+  title: string
+  description: string
+  severity?: string
+  kpIndex?: number
+  xrayFlux?: number
+  solarWindSpeed?: number
+  timestamp: string
+  source: string
+}
+
+/** All result bucket key names */
+export type ResultBucketKey =
+  | "species" | "compounds" | "genetics" | "research"
+  | "events" | "aircraft" | "vessels" | "satellites"
+  | "weather" | "emissions" | "infrastructure" | "devices"
+  | "space_weather"
+
+export interface UnifiedSearchResults {
+  species: SpeciesResult[]
+  compounds: CompoundResult[]
+  genetics: GeneticsResult[]
+  research: ResearchResult[]
+  events: EventResult[]
+  aircraft: AircraftResult[]
+  vessels: VesselResult[]
+  satellites: SatelliteResult[]
+  weather: WeatherResult[]
+  emissions: EmissionsResult[]
+  infrastructure: InfrastructureResult[]
+  devices: DeviceResult[]
+  space_weather: SpaceWeatherResult[]
+}
+
 export interface UnifiedSearchResponse {
   query: string
-  results: {
-    species: SpeciesResult[]
-    compounds: CompoundResult[]
-    genetics: GeneticsResult[]
-    research: ResearchResult[]
-  }
+  results: UnifiedSearchResults
   totalCount: number
   timing: {
     total: number
@@ -101,8 +247,24 @@ export interface UnifiedSearchResponse {
   error?: string
 }
 
+export const EMPTY_RESULTS: UnifiedSearchResults = {
+  species: [],
+  compounds: [],
+  genetics: [],
+  research: [],
+  events: [],
+  aircraft: [],
+  vessels: [],
+  satellites: [],
+  weather: [],
+  emissions: [],
+  infrastructure: [],
+  devices: [],
+  space_weather: [],
+}
+
 export interface SearchOptions {
-  types?: ("species" | "compounds" | "genetics" | "research")[]
+  types?: ResultBucketKey[]
   limit?: number
   includeAI?: boolean
   signal?: AbortSignal
@@ -130,7 +292,7 @@ export class UnifiedSearchClient {
    */
   async search(query: string, options: SearchOptions = {}): Promise<UnifiedSearchResponse> {
     const {
-      types = ["species", "compounds", "genetics", "research"],
+      types = ["species", "compounds", "genetics", "research", "events", "aircraft", "vessels", "satellites", "weather", "emissions", "infrastructure", "devices", "space_weather"],
       limit = 20,
       includeAI = false,
       signal,
@@ -141,7 +303,7 @@ export class UnifiedSearchClient {
     if (!normalizedQuery || normalizedQuery.length < 2) {
       return {
         query: "",
-        results: { species: [], compounds: [], genetics: [], research: [] },
+        results: { ...EMPTY_RESULTS },
         totalCount: 0,
         timing: { total: 0, mindex: 0 },
         source: "cache",
@@ -232,7 +394,7 @@ export class UnifiedSearchClient {
       if (error instanceof Error && error.name === "AbortError") {
         return {
           query: "",
-          results: { species: [], compounds: [], genetics: [], research: [] },
+          results: { ...EMPTY_RESULTS },
           totalCount: 0,
           timing: { total: performance.now() - startTime, mindex: 0 },
           source: "cache",
@@ -243,7 +405,7 @@ export class UnifiedSearchClient {
       console.error("Unified search error:", error)
       return {
         query: "",
-        results: { species: [], compounds: [], genetics: [], research: [] },
+        results: { ...EMPTY_RESULTS },
         totalCount: 0,
         timing: { total: performance.now() - startTime, mindex: 0 },
         source: "cache",

--- a/lib/search/widget-registry.ts
+++ b/lib/search/widget-registry.ts
@@ -18,6 +18,15 @@ export type WidgetType =
   | "crep"
   | "earth2"
   | "map"
+  | "events"
+  | "aircraft"
+  | "vessels"
+  | "satellites"
+  | "weather"
+  | "emissions"
+  | "infrastructure"
+  | "devices"
+  | "space_weather"
   | "fallback"
 
 export interface WidgetRegistryEntry {
@@ -46,6 +55,15 @@ export const WIDGET_TYPE_IDS: WidgetType[] = [
   "crep",
   "earth2",
   "map",
+  "events",
+  "aircraft",
+  "vessels",
+  "satellites",
+  "weather",
+  "emissions",
+  "infrastructure",
+  "devices",
+  "space_weather",
 ]
 
 /** Map result bucket keys (from API) to widget type. Unknown buckets use "fallback". */
@@ -62,6 +80,16 @@ export const RESULT_BUCKET_TO_WIDGET: Record<string, WidgetType> = {
   crep: "crep",
   earth2: "earth2",
   map: "map",
+  // Earth Intelligence buckets
+  events: "events",
+  aircraft: "aircraft",
+  vessels: "vessels",
+  satellites: "satellites",
+  weather: "weather",
+  emissions: "emissions",
+  infrastructure: "infrastructure",
+  devices: "devices",
+  space_weather: "space_weather",
 }
 
 export const WIDGET_REGISTRY: Record<WidgetType, WidgetRegistryEntry> = {
@@ -142,6 +170,74 @@ export const WIDGET_REGISTRY: Record<WidgetType, WidgetRegistryEntry> = {
     label: "Map",
     resultKey: "map",
     size: { width: 2, height: 2 },
+    emptyPolicy: "hide",
+  },
+  // Earth Intelligence widgets
+  events: {
+    id: "events",
+    label: "Events",
+    resultKey: "events",
+    size: { width: 2, height: 2 },
+    emptyPolicy: "hide",
+    autoExpand: true,
+  },
+  aircraft: {
+    id: "aircraft",
+    label: "Aircraft",
+    resultKey: "aircraft",
+    size: { width: 1, height: 2 },
+    emptyPolicy: "hide",
+    autoExpand: true,
+  },
+  vessels: {
+    id: "vessels",
+    label: "Vessels",
+    resultKey: "vessels",
+    size: { width: 1, height: 2 },
+    emptyPolicy: "hide",
+    autoExpand: true,
+  },
+  satellites: {
+    id: "satellites",
+    label: "Satellites",
+    resultKey: "satellites",
+    size: { width: 1, height: 1 },
+    emptyPolicy: "hide",
+  },
+  weather: {
+    id: "weather",
+    label: "Weather",
+    resultKey: "weather",
+    size: { width: 2, height: 1 },
+    emptyPolicy: "hide",
+    autoExpand: true,
+  },
+  emissions: {
+    id: "emissions",
+    label: "Emissions",
+    resultKey: "emissions",
+    size: { width: 1, height: 1 },
+    emptyPolicy: "hide",
+  },
+  infrastructure: {
+    id: "infrastructure",
+    label: "Infrastructure",
+    resultKey: "infrastructure",
+    size: { width: 1, height: 1 },
+    emptyPolicy: "hide",
+  },
+  devices: {
+    id: "devices",
+    label: "Devices",
+    resultKey: "devices",
+    size: { width: 1, height: 1 },
+    emptyPolicy: "hide",
+  },
+  space_weather: {
+    id: "space_weather",
+    label: "Space Weather",
+    resultKey: "space_weather",
+    size: { width: 1, height: 1 },
     emptyPolicy: "hide",
   },
   fallback: {

--- a/lib/search/world-view-suggestions.ts
+++ b/lib/search/world-view-suggestions.ts
@@ -12,42 +12,57 @@ export interface SuggestionItem {
   phoneVisible?: boolean
 }
 
-/** Suggestion terms by category: live, trending, recent, anomalies. */
+/** Suggestion terms by category: live, trending, recent, anomalies, infrastructure, species, environmental. */
 export const WORLD_VIEW_SUGGESTIONS: Record<string, string[]> = {
   live_events: [
     "Flights over Pacific",
     "Ships in port now",
     "Satellite passes",
-    "Live weather radar",
     "Planes over LA",
     "Vessels near coast",
     "ISS orbit now",
+    "Active earthquakes",
+    "Lightning strikes now",
   ],
-  trending: [
-    "Bird migration 2025",
-    "Pacific storm track",
-    "California drought",
-    "Psilocybin research",
-    "Climate forecast",
-    "Wildfire status",
-    "Port activity",
-  ],
-  recent_discoveries: [
+  species_biodiversity: [
+    "Bird migration 2026",
     "New fungal species",
-    "Biodiversity hotspot",
     "Species near me",
-    "Temperature anomaly",
-    "Unusual migration",
-    "New research papers",
+    "Marine life Pacific",
+    "Endangered mammals",
+    "Coral reef status",
+    "Insect populations",
+    "Whale sightings",
   ],
-  anomalies_events: [
-    "Temperature anomaly",
+  environmental: [
     "Wildfire alert",
-    "Storm surge",
-    "Unusual migration",
-    "Port congestion",
-    "Hurricane track",
+    "Air quality index",
+    "CO2 emissions",
+    "Methane plumes",
+    "River levels",
     "Dam status",
+    "Water treatment plants",
+    "Deforestation",
+  ],
+  weather_climate: [
+    "Temperature anomaly",
+    "Storm surge",
+    "Hurricane track",
+    "Climate forecast",
+    "Solar flare activity",
+    "Weather radar",
+    "Pacific storm track",
+    "Drought status",
+  ],
+  infrastructure: [
+    "Power plants near me",
+    "Cell tower locations",
+    "Submarine cables",
+    "Airport traffic",
+    "Nuclear facilities",
+    "Oil rigs",
+    "Railway stations",
+    "Wind farms",
   ],
   popular_searches: [
     "Planes over LA",
@@ -55,7 +70,9 @@ export const WORLD_VIEW_SUGGESTIONS: Record<string, string[]> = {
     "Ships in port",
     "Species near me",
     "Flights near me",
-    "River levels",
+    "Earthquake activity",
+    "Satellite tracking",
+    "Volcano alerts",
   ],
 }
 
@@ -108,9 +125,9 @@ export function getRotatedSuggestions(count = 6, mobileCount = 3): SuggestionIte
 export const DEFAULT_TRY_SUGGESTIONS: { term: string; phoneVisible?: boolean }[] = [
   { term: "Planes over LA", phoneVisible: true },
   { term: "Ships in port", phoneVisible: true },
-  { term: "Temperature anomaly", phoneVisible: true },
-  { term: "Bird migration 2025", phoneVisible: false },
-  { term: "Wildfire alert", phoneVisible: false },
+  { term: "Active earthquakes", phoneVisible: true },
+  { term: "Bird migration 2026", phoneVisible: false },
+  { term: "Air quality index", phoneVisible: false },
   { term: "Species near me", phoneVisible: false },
 ]
 
@@ -137,36 +154,41 @@ export function detectFungalSearchIntent(query: string): boolean {
  * Detect worldview intent from a search query.
  * Returns which widgets (crep, earth2, map) should be expanded based on query keywords.
  * Used for intent-based auto-expand so worldview widgets surface even before data arrives.
+ * Now covers ALL Earth Intelligence domains.
  */
 export function detectWorldviewIntent(query: string): { crep: boolean; earth2: boolean; map: boolean } {
   if (!query || query.length < 2) return { crep: false, earth2: false, map: false }
   const q = query.toLowerCase()
   const crep =
     /\b(flights?|planes?|ships?|vessels?|satellites?|aircraft|aviation|maritime|orbit|iss|port|crep)\b/.test(q) ||
-    /\b(planes?\s+over|flights?\s+over|ships?\s+in\s+port|vessels?\s+near)\b/.test(q)
+    /\b(planes?\s+over|flights?\s+over|ships?\s+in\s+port|vessels?\s+near)\b/.test(q) ||
+    /\b(earthquake|volcano|wildfire|lightning|tsunami|emission|methane|co2|air\s+quality)\b/.test(q) ||
+    /\b(power\s+plant|factory|dam|mine|antenna|cell\s+tower|military|infrastructure)\b/.test(q) ||
+    /\b(solar\s+flare|space\s+weather|geomagnetic|aurora|mycobrain|sensor|device)\b/.test(q)
   const earth2 =
     /\b(earth2|climate\s+forecast|weather\s+forecast|temperature\s+anomaly)\b/.test(q) ||
-    /\b(weather|climate|forecast|storm|hurricane|drought)\b/.test(q)
+    /\b(weather|climate|forecast|storm|hurricane|drought|modis|landsat)\b/.test(q)
   const map =
     /\b(map|location|where|near\s+me|river\s+levels?|dam|wildfire|flood)\b/.test(q) ||
+    /\b(airport|seaport|spaceport|railway|cable|antenna|buoy|webcam)\b/.test(q) ||
     crep ||
     earth2
   return { crep, earth2, map }
 }
 
-/** Full-sentence suggestions for typing placeholder effect (world-view first). */
+/** Full-sentence suggestions for typing placeholder effect (all-Earth intelligence). */
 export const TYPING_PLACEHOLDER_SUGGESTIONS: string[] = [
-  "Search species, weather, flights...",
-  "Find flights, ships, satellites...",
-  "Ask about weather, climate, storms...",
-  "Explore species and biodiversity...",
-  "Query Earth2 climate data...",
-  "Check river levels, dams, wildfire...",
-  "Search species, biodiversity, taxonomy...",
-  "Discover research papers...",
-  "Analyze chemical structures...",
+  "Search all species, weather, flights, ships...",
+  "Find earthquakes, volcanoes, storms...",
+  "Track aircraft, vessels, satellites...",
+  "Explore all biodiversity on Earth...",
+  "Check air quality, CO2, methane emissions...",
+  "Find power plants, dams, infrastructure...",
+  "Query solar flares, space weather...",
+  "Search marine life, coral reefs...",
   "What planes are over the Pacific?",
-  "Species near me...",
-  "Port activity, freeway congestion...",
-  "Weather along shipping lane...",
+  "Bird migration patterns near me...",
+  "Active wildfires and lightning...",
+  "MycoBrain sensor readings...",
+  "Cell towers and antenna locations...",
 ]

--- a/lib/services/myca-nlq.ts
+++ b/lib/services/myca-nlq.ts
@@ -271,6 +271,111 @@ const INTENT_PATTERNS: IntentPattern[] = [
     type: "help",
     dataSources: ["documents"],
   },
+
+  // Earth Intelligence — transport, aviation, maritime
+  {
+    patterns: [
+      /(?:flights?|planes?|aircraft)\s+(?:over|near|above|around|in)/i,
+      /(?:show|find|track|where)\s+(?:are\s+)?(?:the\s+)?(?:flights?|planes?|aircraft)/i,
+      /(?:ships?|vessels?|boats?)\s+(?:in|near|at|around)\s+/i,
+      /(?:show|find|track|where)\s+(?:are\s+)?(?:the\s+)?(?:ships?|vessels?|boats?)/i,
+      /(?:satellite|orbit|iss|space\s+station)/i,
+      /(?:ais|ads-b|adsb|transponder|maritime\s+traffic|shipping\s+lane)/i,
+    ],
+    type: "query_data",
+    entities: ["domain", "location"],
+    dataSources: ["mindex"],
+  },
+
+  // Earth Intelligence — natural events, hazards
+  {
+    patterns: [
+      /(?:earthquake|volcano|wildfire|tsunami|storm|hurricane|tornado|flood|lightning)/i,
+      /(?:active|recent|current)\s+(?:earthquake|eruption|fire|storm|disaster)/i,
+      /(?:natural\s+disaster|hazard|emergency|alert)/i,
+      /(?:seismic|volcanic|geological)\s+(?:activity|event)/i,
+    ],
+    type: "query_data",
+    entities: ["domain", "eventType"],
+    dataSources: ["mindex"],
+  },
+
+  // Earth Intelligence — weather, climate, atmospheric
+  {
+    patterns: [
+      /(?:weather|forecast|temperature|rain|snow|wind|humidity|pressure)\s+(?:in|at|near|for|around)/i,
+      /(?:climate|warming|cooling|anomaly)\s+(?:data|forecast|trend)/i,
+      /(?:air\s+quality|aqi|pollution|smog|particulate)/i,
+      /(?:solar\s+flare|geomagnetic|aurora|space\s+weather|coronal)/i,
+    ],
+    type: "query_data",
+    entities: ["domain", "location"],
+    dataSources: ["mindex"],
+  },
+
+  // Earth Intelligence — emissions, environmental
+  {
+    patterns: [
+      /(?:co2|carbon|methane|emission|greenhouse)\s+/i,
+      /(?:deforestation|land\s+use|habitat|ecosystem)/i,
+      /(?:river|lake|ocean|water)\s+(?:level|quality|temperature)/i,
+      /(?:dam|reservoir|watershed|hydrology)/i,
+    ],
+    type: "query_data",
+    entities: ["domain"],
+    dataSources: ["mindex"],
+  },
+
+  // Earth Intelligence — infrastructure
+  {
+    patterns: [
+      /(?:power\s+plant|nuclear|solar\s+farm|wind\s+farm|hydroelectric)/i,
+      /(?:cell\s+tower|antenna|radio|telecommunications)/i,
+      /(?:oil\s+rig|refinery|pipeline|mine|quarry)/i,
+      /(?:airport|seaport|railway|highway|bridge|tunnel)/i,
+      /(?:submarine\s+cable|fiber\s+optic|data\s+center)/i,
+    ],
+    type: "query_data",
+    entities: ["domain", "infraType"],
+    dataSources: ["mindex"],
+  },
+
+  // Earth Intelligence — biodiversity, species
+  {
+    patterns: [
+      /(?:species|bird|mammal|reptile|insect|fish|coral|whale|dolphin)\s+(?:near|in|at|sighting)/i,
+      /(?:biodiversity|wildlife|fauna|flora|ecosystem|habitat)/i,
+      /(?:migration|breeding|nesting|spawning)\s+(?:pattern|season|route)/i,
+      /(?:endangered|threatened|invasive|native)\s+(?:species|plant|animal)/i,
+      /(?:fungal|mushroom|fungi|mycology|mycelium)/i,
+    ],
+    type: "query_data",
+    entities: ["domain", "taxon"],
+    dataSources: ["mindex"],
+  },
+
+  // Earth Intelligence — devices, sensors
+  {
+    patterns: [
+      /(?:mycobrain|sensor|device|iot)\s+(?:data|reading|status|telemetry)/i,
+      /(?:buoy|weather\s+station|seismograph|gauge)\s+(?:reading|data|near)/i,
+    ],
+    type: "query_telemetry",
+    dataSources: ["mindex", "telemetry"],
+  },
+
+  // Earth Intelligence — map/CREP commands
+  {
+    patterns: [
+      /(?:fly\s+to|zoom\s+to|navigate\s+to|show\s+me|center\s+on)\s+/i,
+      /(?:show|hide|toggle|enable|disable)\s+(?:the\s+)?(?:\w+\s+)?layer/i,
+      /(?:what\s+am\s+i|what\s+are\s+we)\s+(?:looking\s+at|seeing)/i,
+      /(?:reset|default|home)\s+(?:view|map)/i,
+    ],
+    type: "navigation",
+    entities: ["location", "layer"],
+    dataSources: [],
+  },
 ]
 
 // =============================================================================
@@ -280,21 +385,36 @@ const INTENT_PATTERNS: IntentPattern[] = [
 const ENTITY_PATTERNS = {
   // Agent categories
   category: /\b(core|financial|mycology|research|dao|communication|data|infrastructure|simulation|security|integration|device|chemistry|nlm)\b/i,
-  
+
   // Agent statuses
   status: /\b(active|busy|idle|offline|error|starting|stopping)\b/i,
-  
+
   // Metrics
   metric: /\b(cpu|memory|ram|error|latency|messages?|throughput|uptime)\b/i,
-  
+
   // Time references
   timeRange: /\b(today|yesterday|this\s+week|last\s+week|this\s+month|last\s+hour)\b/i,
-  
+
   // Numbers
   number: /\b(\d+)\b/,
-  
+
   // Comparison
   comparison: /\b(high|low|above|below|greater|less|more|fewer)\b/i,
+
+  // Earth Intelligence domains
+  domain: /\b(aircraft|vessel|satellite|weather|emission|infrastructure|device|species|event|space_weather|hydrology|atmospheric|signal|transport|monitor|military)\b/i,
+
+  // Location references
+  location: /\b(?:near|in|at|over|around|above)\s+(.+?)(?:\s+(?:right|now|today|currently)|[.!?]|$)/i,
+
+  // Event types
+  eventType: /\b(earthquake|volcano|wildfire|storm|flood|tsunami|lightning|eruption|hurricane|tornado)\b/i,
+
+  // Taxon references
+  taxon: /\b(fungal|bird|mammal|reptile|fish|insect|coral|whale|dolphin|species|plant|tree|flower|marine)\b/i,
+
+  // Infrastructure types
+  infraType: /\b(power\s+plant|cell\s+tower|airport|railway|dam|pipeline|mine|refinery|antenna|port|cable)\b/i,
 }
 
 // =============================================================================

--- a/lib/webmcp/earth-tools.ts
+++ b/lib/webmcp/earth-tools.ts
@@ -1,0 +1,190 @@
+/**
+ * Earth Intelligence MCP Tools — Mar 15, 2026
+ *
+ * Registers earth intelligence tools with navigator.modelContext (WebMCP).
+ * Enables AI agents to query all Earth Intelligence domains:
+ *   - Spatial queries (bbox)
+ *   - Entity search across all domains
+ *   - CREP map control
+ *   - Domain listing and stats
+ *
+ * For use by Claude, ChatGPT, browser AI extensions, and any MCP-compatible agent.
+ */
+
+import type { ToolRegistration, WebMCPToolResult } from "./provider"
+import { isWebMCPAvailable } from "./provider"
+
+export interface EarthToolCallbacks {
+  onEarthSearch?: (query: string, domains?: string[]) => Promise<Record<string, unknown[]>>
+  onEarthBbox?: (bbox: { north: number; south: number; east: number; west: number }, layers?: string[]) => Promise<Record<string, unknown[]>>
+  onEarthStats?: () => Promise<Record<string, number>>
+  onMapCommand?: (command: string, params: Record<string, unknown>) => void
+}
+
+export const EARTH_TOOL_SCHEMAS = [
+  {
+    name: "mycosoft_earth_search",
+    description:
+      "Search all Earth Intelligence domains: aircraft, vessels, satellites, events (earthquakes, volcanoes, storms), weather, emissions, infrastructure, devices, species, space weather. Returns structured results by domain.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Natural language search query (e.g. 'planes over LA', 'earthquakes today', 'ships in port')" },
+        domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional: limit to specific domains (aircraft, vessels, satellites, events, weather, emissions, infrastructure, devices, species, space_weather)",
+        },
+        limit: { type: "number", description: "Max results per domain (default 20)" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "mycosoft_earth_bbox",
+    description:
+      "Query all Earth Intelligence data within a geographic bounding box. Returns entities visible in that area across all domains.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        north: { type: "number", description: "North latitude boundary" },
+        south: { type: "number", description: "South latitude boundary" },
+        east: { type: "number", description: "East longitude boundary" },
+        west: { type: "number", description: "West longitude boundary" },
+        layers: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional: specific layers to query",
+        },
+      },
+      required: ["north", "south", "east", "west"],
+    },
+  },
+  {
+    name: "mycosoft_earth_stats",
+    description: "Get current Earth Intelligence statistics: counts of tracked entities across all domains.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "mycosoft_map_command",
+    description:
+      "Control the CREP map: fly to location, zoom, toggle layers, select entities, reset view.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+          enum: ["fly_to", "zoom", "show_layer", "hide_layer", "reset_view", "select_entity", "search_entities"],
+          description: "Map command type",
+        },
+        params: {
+          type: "object",
+          description: "Command parameters (e.g. {query: 'San Diego'} for fly_to, {layer: 'aircraft'} for show_layer)",
+        },
+      },
+      required: ["command"],
+    },
+  },
+] as const
+
+function noopReg(): ToolRegistration {
+  return { unregister: () => {} }
+}
+
+export function registerEarthMCPTools(callbacks: EarthToolCallbacks): ToolRegistration[] {
+  if (!isWebMCPAvailable()) return [noopReg()]
+
+  const registrations: ToolRegistration[] = []
+  const mc = navigator.modelContext!
+
+  if (callbacks.onEarthSearch) {
+    registrations.push(
+      mc.registerTool({
+        name: "mycosoft_earth_search",
+        description: EARTH_TOOL_SCHEMAS[0].description,
+        inputSchema: EARTH_TOOL_SCHEMAS[0].inputSchema as Record<string, unknown>,
+        async execute(args): Promise<WebMCPToolResult> {
+          const results = await callbacks.onEarthSearch!(
+            String(args.query ?? ""),
+            args.domains as string[] | undefined
+          )
+          const counts = Object.fromEntries(
+            Object.entries(results).map(([k, v]) => [k, Array.isArray(v) ? v.length : 0])
+          )
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({ counts, results }, null, 2),
+            }],
+          }
+        },
+      })
+    )
+  }
+
+  if (callbacks.onEarthBbox) {
+    registrations.push(
+      mc.registerTool({
+        name: "mycosoft_earth_bbox",
+        description: EARTH_TOOL_SCHEMAS[1].description,
+        inputSchema: EARTH_TOOL_SCHEMAS[1].inputSchema as Record<string, unknown>,
+        async execute(args): Promise<WebMCPToolResult> {
+          const results = await callbacks.onEarthBbox!(
+            {
+              north: Number(args.north),
+              south: Number(args.south),
+              east: Number(args.east),
+              west: Number(args.west),
+            },
+            args.layers as string[] | undefined
+          )
+          const counts = Object.fromEntries(
+            Object.entries(results).map(([k, v]) => [k, Array.isArray(v) ? v.length : 0])
+          )
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({ counts, results }, null, 2),
+            }],
+          }
+        },
+      })
+    )
+  }
+
+  if (callbacks.onEarthStats) {
+    registrations.push(
+      mc.registerTool({
+        name: "mycosoft_earth_stats",
+        description: EARTH_TOOL_SCHEMAS[2].description,
+        inputSchema: EARTH_TOOL_SCHEMAS[2].inputSchema as Record<string, unknown>,
+        async execute(): Promise<WebMCPToolResult> {
+          const stats = await callbacks.onEarthStats!()
+          return {
+            content: [{ type: "text", text: JSON.stringify(stats, null, 2) }],
+          }
+        },
+      })
+    )
+  }
+
+  if (callbacks.onMapCommand) {
+    registrations.push(
+      mc.registerTool({
+        name: "mycosoft_map_command",
+        description: EARTH_TOOL_SCHEMAS[3].description,
+        inputSchema: EARTH_TOOL_SCHEMAS[3].inputSchema as Record<string, unknown>,
+        async execute(args): Promise<WebMCPToolResult> {
+          const cmd = String(args.command ?? "")
+          const params = (args.params as Record<string, unknown>) || {}
+          callbacks.onMapCommand!(cmd, params)
+          return {
+            content: [{ type: "text", text: `Map command executed: ${cmd}` }],
+          }
+        },
+      })
+    )
+  }
+
+  return registrations.length > 0 ? registrations : [noopReg()]
+}

--- a/lib/webmcp/index.ts
+++ b/lib/webmcp/index.ts
@@ -13,3 +13,9 @@ export {
   type WebMCPToolResult,
   type WebMCPCallbacks,
 } from "./provider"
+
+export {
+  registerEarthMCPTools,
+  EARTH_TOOL_SCHEMAS,
+  type EarthToolCallbacks,
+} from "./earth-tools"

--- a/types/search.ts
+++ b/types/search.ts
@@ -2,6 +2,8 @@ export interface SearchSuggestion {
   id: string
   title: string
   type: "fungi" | "article" | "compound" | "research" | "category"
+    | "event" | "aircraft" | "vessel" | "satellite" | "weather"
+    | "emissions" | "infrastructure" | "device" | "space_weather"
   scientificName?: string
   url: string
   date?: string
@@ -14,8 +16,12 @@ export interface SearchResult {
   title: string
   description: string
   type: "fungi" | "compound" | "paper" | "research"
+    | "event" | "aircraft" | "vessel" | "satellite" | "weather"
+    | "emissions" | "infrastructure" | "device" | "space_weather"
   url: string
   source: "iNaturalist" | "MycoBank" | "FungiDB" | "Elsevier" | "ChemSpider" | "PubChem" | "Mycosoft"
+    | "USGS" | "NOAA" | "NASA" | "OpenSky" | "AISstream" | "CelesTrak" | "OpenAQ"
+    | "CarbonMapper" | "GBIF" | "eBird" | "OBIS" | "Blitzortung" | "MycoBrain" | "EONET"
   metadata?: {
     authors?: string[]
     year?: number
@@ -25,6 +31,11 @@ export interface SearchResult {
     molecularWeight?: number
     sourceSpecies?: string[]
     biologicalActivity?: string[]
+    lat?: number
+    lng?: number
+    magnitude?: number
+    severity?: string
+    timestamp?: string
   }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Extend unified search, CREP, and Earth Intelligence APIs to cover additional Earth domains and expose them via new tools and MCP-compatible endpoints.

New Features:
- Add MINDEX-based Earth Intelligence spatial and sync queries (bbox, stats, full-domain fetch) to the CREP data service and unify them into fetchAllEarthData.
- Extend unified search types, client, and API to support Earth Intelligence result buckets (events, aircraft, vessels, satellites, weather, emissions, infrastructure, devices, space weather).
- Introduce Earth Intelligence intent parsing, suggestions, and widget registry entries so Earth domains appear in world-view search UI and widgets.
- Add new Earth Intelligence search connectors that integrate multiple external OEI and public data sources, with MINDEX-first fallback, into unified search.
- Expose Earth Intelligence functionality via new /api/earth and /api/earth/tools endpoints and WebMCP earth-tools, enabling MCP-compatible agents and tools.
- Provide a Web Speech API fallback and improved minimizable UI for voice map controls when PersonaPlex is unavailable.

Enhancements:
- Improve CREP–MYCA integration context to describe all Earth Intelligence domains and available tools.
- Refine world-view search suggestions and placeholder copy to highlight new Earth domains and example queries.

Documentation:
- Document available Earth Intelligence domains, tools, and capabilities through API responses and context strings for agents and UIs.