### PR TITLE
ci: add swap space to prevent OOM during Docker build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -105,6 +105,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free disk space and add swap
+        run: |
+          sudo swapoff -a || true
+          sudo fallocate -l 4G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          echo "Swap enabled: $(swapon --show)"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
The Next.js build requests 4GB via NODE_OPTIONS but GitHub Actions runners only have 7GB total RAM. Docker/Buildx overhead leaves insufficient memory, causing the build to be OOM-killed after ~325s ("The operation was canceled").

Adding 4GB swap gives the builder enough headroom to complete.

https://claude.ai/code/session_01JdTbrxWnVGJB1LAMz7s6ef

## Summary by Sourcery

CI:
- Allocate and enable a 4GB swapfile in the GitHub Actions runner before setting up Docker Buildx to provide additional virtual memory for builds.