### PR TITLE
fix(ci): authenticate GHCR on VM before pulling image

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -234,13 +234,17 @@ jobs:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
+          envs: GHCR_TOKEN
           script: |
             IMAGE_NAME_LC=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
             docker pull ${{ env.REGISTRY }}/${IMAGE_NAME_LC}:staging-latest
             cd /opt/mycosoft-staging
-            docker compose up -d --remove-orphans
+            docker compose up -d --no-build --remove-orphans
             docker compose exec -T website npm run db:migrate --if-present
             echo "Deployed ${{ github.sha }} to staging at $(date)"
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ===========================================================================
   # DEPLOY TO PRODUCTION — pull GHCR image + restart (no build on VM)
@@ -250,6 +254,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true')
+    permissions:
+      packages: read
     environment: production
     continue-on-error: false
     timeout-minutes: 10
@@ -298,26 +304,27 @@ jobs:
         run: |
           ssh production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T postgres pg_dump -U mycosoft mycosoft > /backup/db-$(date +%Y%m%d-%H%M%S).sql 2>/dev/null || echo "No existing database to backup (first deploy?) — skipping"'
 
+      - name: Sync compose file
+        run: |
+          ssh production 'cd /opt/mycosoft/website && git fetch origin main && git checkout origin/main -- docker-compose.production.yml'
+
       - name: Pull image and deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IMAGE_NAME_LC=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
-          ssh production bash -s <<SCRIPT
-            set -e
-            IMAGE="${{ env.REGISTRY }}/${IMAGE_NAME_LC}:production-latest"
+          IMAGE="${{ env.REGISTRY }}/${IMAGE_NAME_LC}:production-latest"
 
-            # Authenticate to GHCR if token is available
-            if [ -n "\${GHCR_PULL_TOKEN:-}" ]; then
-              echo "\${GHCR_PULL_TOKEN}" | docker login ghcr.io -u mycosoft --password-stdin
-            fi
+          # Authenticate to GHCR on the VM using the CI token
+          echo "${GH_TOKEN}" | ssh production docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-            # Pull the pre-built image (the only thing that changes per deploy)
-            docker pull "\${IMAGE}"
+          # Pull the pre-built image
+          ssh production docker pull "${IMAGE}"
 
-            # Restart only the website service — other services (postgres, redis,
-            # ollama, cloudflared) don't change and stay running
-            cd /opt/mycosoft/website
-            docker compose -f docker-compose.production.yml up -d --no-build --remove-orphans website
-          SCRIPT
+          # Restart only the website service with the new image
+          # WEBSITE_IMAGE env var overrides the compose default — works even if
+          # the VM's compose file hasn't been updated yet
+          ssh production bash -c "cd /opt/mycosoft/website && WEBSITE_IMAGE=${IMAGE} docker compose -f docker-compose.production.yml up -d --no-build --remove-orphans website"
 
       - name: Run database migrations
         continue-on-error: true

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -62,11 +62,8 @@ services:
   # ==========================================================================
 
   website:
-    image: ghcr.io/mycosoftlabs/website:production-latest
-    # Fallback: uncomment to build locally instead of pulling from GHCR
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile.production
+    image: ${WEBSITE_IMAGE:-ghcr.io/mycosoftlabs/website:production-latest}
+    # To build locally instead: WEBSITE_IMAGE= docker compose -f docker-compose.production.yml build website
     container_name: mycosoft-website
     ports:
       - "3000:3000"


### PR DESCRIPTION
The deploy was failing with "unauthorized" because:
1. GITHUB_TOKEN was never passed to the VM — GHCR auth check looked for a VM-local env var that didn't exist
2. Compose file on VM still had build: instead of image:

Fix:
- Pipe GITHUB_TOKEN from CI to VM via ssh for docker login
- Add packages:read permission to deploy-production job
- Sync compose file from origin/main before deploying
- Use WEBSITE_IMAGE env var override so deploy works even if VM compose file is stale
- Same GHCR auth fix applied to staging deploy

https://claude.ai/code/session_01JdTbrxWnVGJB1LAMz7s6ef

## Summary by Sourcery

Authenticate GHCR from CI on target VMs and make production deploys resilient to stale compose files.

New Features:
- Allow overriding the production website image via a WEBSITE_IMAGE environment variable during deploys.

Bug Fixes:
- Fix staging deploys failing to pull images from GHCR by forwarding the GitHub token over SSH and disabling on-VM builds.
- Fix production deploys failing GHCR authentication by logging into GHCR on the VM using the CI GitHub token before pulling images.

Enhancements:
- Sync the production docker-compose file from origin/main before deployment to keep VM configuration up to date.
- Restrict production docker-compose to use pre-built images by default while documenting how to opt into local builds.

CI:
- Grant the production deployment job packages:read permission required for GHCR image pulls.