### PR TITLE
fix: correct AI stack page content — MYCA, AVANI, NLM, and AI overview

### DIFF
--- a/app/ai/avani/page.tsx
+++ b/app/ai/avani/page.tsx
@@ -117,7 +117,7 @@ export default function AVANIPage() {
         <div className="container max-w-4xl mx-auto px-4 md:px-6">
           <h2 className="text-2xl md:text-3xl font-bold mb-6">What AVANI Is</h2>
           <p className="text-muted-foreground text-base md:text-lg leading-relaxed mb-4">
-            AVANI runs on its own dedicated backend next to the MYCA master VM, exposing a stable public
+            AVANI runs on its own dedicated backend next to the MYCA system, exposing a stable public
             interface for live earth queries while keeping its internal data pipelines and optimizations
             private. It is designed to be the planetary memory and sensory cortex for all other systems
             we build.

--- a/app/ai/page.tsx
+++ b/app/ai/page.tsx
@@ -25,7 +25,7 @@ import { ArrowRight, Shield, Sparkles, Brain, Users, Bot, Cpu, Globe, Layers } f
 export const metadata: Metadata = {
   title: "AI | Layered Intelligence Stack | Mycosoft",
   description:
-    "Mycosoft's AI stack is built as a layered ecosystem: MYCA (agentic OS), AVANI (live Earth substrate), and NLM (reasoning backbone) — powered by the NVIDIA platform.",
+    "Mycosoft's AI stack is built as a layered ecosystem: MYCA (environmental super intelligence), AVANI (live Earth substrate), and NLM (Nature Learning Model) — powered by nature and computers.",
 }
 
 export default function AIOverviewPage() {
@@ -39,8 +39,8 @@ export default function AIOverviewPage() {
           </h1>
           <p className="text-lg text-muted-foreground max-w-3xl mx-auto mb-8">
             Our AI stack is built as a layered ecosystem, not a single monolith. Planet-scale sensing,
-            edge-native agents, robust reasoning, and human-readable explanations — powered by the
-            NVIDIA platform.
+            edge-native agents, robust reasoning, and human-readable explanations — powered by nature
+            and computers.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center flex-wrap">
             <Link href="/myca">
@@ -80,11 +80,11 @@ export default function AIOverviewPage() {
                   <Sparkles className="h-5 w-5 text-green-500 shrink-0" />
                   <CardTitle className="text-xl">MYCA</CardTitle>
                 </div>
-                <CardDescription>Agentic operating system at the edge</CardDescription>
+                <CardDescription>Environmental super intelligence at the edge</CardDescription>
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                  Edge-native agentic OS running on distributed hardware platforms and nodes.
+                  Edge-native environmental super intelligence running on distributed hardware platforms and nodes.
                   MYCA pushes intelligence as close as possible to real-world signals, maintaining
                   a coherent worldview across all edge nodes while respecting locality and data sovereignty.
                 </p>
@@ -122,12 +122,12 @@ export default function AIOverviewPage() {
                   <Brain className="h-5 w-5 text-purple-500 shrink-0" />
                   <CardTitle className="text-xl">NLM</CardTitle>
                 </div>
-                <CardDescription>Reasoning backbone</CardDescription>
+                <CardDescription>Nature Learning Model</CardDescription>
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                  The Neural Logic Machine turns MYCA and AVANI&apos;s rich data into structured
-                  inferences, rules, and decisions. Robust by design — operates under partial data,
+                  The Nature Learning Model gives the entire system robust reasoning and structured
+                  ground-truth-based inference. It operates under partial data,
                   conflicting signals, and noisy environments while surfacing uncertainty.
                 </p>
                 <Link href="/myca/nlm">
@@ -146,12 +146,12 @@ export default function AIOverviewPage() {
         <div className="container max-w-4xl mx-auto px-4 md:px-6">
           <div className="flex items-center gap-3 mb-6">
             <Cpu className="h-6 w-6 text-green-500 shrink-0" />
-            <h2 className="text-2xl md:text-3xl font-bold">Powered by NVIDIA</h2>
+            <h2 className="text-2xl md:text-3xl font-bold">Our Platform</h2>
           </div>
           <p className="text-muted-foreground text-base md:text-lg leading-relaxed mb-4">
-            Underneath MYCA, AVANI, and NLM, we rely on the NVIDIA platform: Nemotron foundation
-            models, NeMo for orchestration and fine-tuning, Earth-2-style simulation models, and
-            PersonaPlex for persona and conversational control.
+            Underneath MYCA, AVANI, and NLM, we build on the NVIDIA platform: Nemotron foundation
+            models, a built-from-the-ground-up orchestration system, Earth-2-style simulation models, and
+            PersonaPlex for full-duplex voice-to-voice and conversational control.
           </p>
           <p className="text-muted-foreground text-base md:text-lg leading-relaxed mb-4">
             This allows us to deploy sophisticated, domain-specific agents on Blackwell-generation
@@ -198,9 +198,10 @@ export default function AIOverviewPage() {
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-muted-foreground leading-relaxed">
-                  Humans use MYCA + AVANI to ask complex questions, coordinate teams and workflows,
-                  delegate multi-step tasks, and operate research and infrastructure systems while
-                  maintaining visibility and control.
+                  Humans use MYCA + AVANI to ask complex questions that interact with the world,
+                  the environment, and nature. The system can be used to see live events, locations,
+                  and details of all species on the planet and coordinate correlation between
+                  environmental events, local biomass &amp; natural signaling data.
                 </p>
               </CardContent>
             </Card>
@@ -211,9 +212,10 @@ export default function AIOverviewPage() {
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-muted-foreground leading-relaxed">
-                  Agents use Mycosoft as a coordination and trust layer. MYCA gives them context,
-                  memory, and task routing. AVANI gives them boundaries, policy, and approval logic.
-                  NLM gives them robust reasoning and structured inference.
+                  Agents use Microsoft as a live worldview coordination and nature learning model.
+                  MYCA gives them context, memory, and task routing. AVANI gives MYCA boundaries,
+                  policy, and approval logic. NLM gives the entire system robust reasoning and
+                  structured ground-truth-based inference.
                 </p>
               </CardContent>
             </Card>
@@ -284,10 +286,10 @@ export default function AIOverviewPage() {
             <AccordionItem value="stack">
               <AccordionTrigger className="text-base text-left">What are the layers of Mycosoft&apos;s AI stack?</AccordionTrigger>
               <AccordionContent className="text-muted-foreground">
-                Three core layers: MYCA (agentic operating system at the edge), AVANI (live Earth substrate
-                for continuous environmental context), and NLM (reasoning backbone for structured inference).
-                All are powered by the NVIDIA platform including Nemotron models, NeMo orchestration,
-                and Blackwell-generation edge GPUs.
+                Three core layers: MYCA (environmental super intelligence at the edge), AVANI (live Earth substrate
+                for continuous environmental context), and NLM (Nature Learning Model for structured
+                ground-truth-based inference). We build on the NVIDIA platform including Nemotron models,
+                a built-from-the-ground-up orchestration system, and Blackwell-generation edge GPUs.
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value="myca-avani">
@@ -302,19 +304,19 @@ export default function AIOverviewPage() {
             <AccordionItem value="nlm">
               <AccordionTrigger className="text-base text-left">What does NLM do?</AccordionTrigger>
               <AccordionContent className="text-muted-foreground">
-                The Neural Logic Machine is the reasoning backbone that turns MYCA and AVANI&apos;s data
-                into structured inferences, rules, and decisions. It specializes in connecting dots over
+                The Nature Learning Model (NLM) gives the entire system robust reasoning and structured
+                ground-truth-based inference. It specializes in connecting dots over
                 time and across modalities, explaining not just what is happening but why and what might
                 happen next — while surfacing its own uncertainty.
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value="nvidia">
-              <AccordionTrigger className="text-base text-left">How does the NVIDIA platform fit in?</AccordionTrigger>
+              <AccordionTrigger className="text-base text-left">What platform do you build on?</AccordionTrigger>
               <AccordionContent className="text-muted-foreground">
-                The NVIDIA platform provides the foundation: Nemotron foundation models for
-                language and multimodal reasoning, NeMo for orchestration and fine-tuning, Earth-2-style
-                simulation models for environmental tasks, and PersonaPlex for persona and conversational
-                control. This runs on Blackwell-generation edge GPUs across our hardware platforms.
+                We build on the NVIDIA platform: Nemotron foundation models for
+                language and multimodal reasoning, a built-from-the-ground-up orchestration system, Earth-2-style
+                simulation models for environmental tasks, and PersonaPlex for full-duplex voice-to-voice
+                and conversational control. This runs on Blackwell-generation edge GPUs across our hardware platforms.
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value="models">

--- a/app/myca/nlm/page.tsx
+++ b/app/myca/nlm/page.tsx
@@ -103,7 +103,7 @@ export default function NLMPage() {
                   </Badge>
                 </div>
                 <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold bg-gradient-to-r from-purple-600 via-green-600 to-emerald-600 dark:from-purple-400 dark:via-green-400 dark:to-emerald-400 bg-clip-text text-transparent">
-                  Neural Logic Machine
+                  Nature Learning Model
                 </h1>
                 <p className="text-base md:text-lg text-muted-foreground mt-2 max-w-2xl">
                   The reasoning backbone inside our ecosystem, responsible for turning MYCA and AVANI&apos;s rich data
@@ -151,7 +151,7 @@ export default function NLMPage() {
                   The NLM in the World of Frontier AI
                 </h2>
                 <p className="text-muted-foreground mb-4">
-                  The Neural Logic Machine (NLM) is the reasoning backbone inside our ecosystem, specializing in connecting dots
+                  The Nature Learning Model (NLM) is the reasoning backbone inside our ecosystem, specializing in connecting dots
                   over time and across modalities. It helps the system explain not just what is happening but why and what might
                   happen next. NLM integrates tightly with MYCA&apos;s worldview and AVANI&apos;s live Earth feeds, giving every agent
                   access to a shared, evolving logical substrate.

--- a/app/myca/page.tsx
+++ b/app/myca/page.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 /**
- * MYCA Introduction Page - Edge-Native Agentic Operating System
- * Presents MYCA as the agentic OS for the mycelial edge
+ * MYCA Introduction Page - Environmental Super Intelligence
+ * Presents MYCA as an environmental super intelligence for the mycelial edge
  * Route: /myca (and /MYCA via redirect)
  * Updated: Mar 18, 2026
  */
@@ -37,7 +37,7 @@ export default function MYCAPage() {
               MYCA
             </span>
             <br />
-            <span className="text-foreground">Agentic Operating System</span>
+            <span className="text-foreground">Environmental Super Intelligence</span>
           </h1>
           <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto mb-8">
             Edge-native intelligence for the mycelial edge. MYCA runs in distributed edge data centers
@@ -85,14 +85,14 @@ export default function MYCAPage() {
           </div>
           <div className="space-y-6 text-muted-foreground text-base md:text-lg leading-relaxed">
             <p>
-              MYCA is our agentic operating system for the mycelial edge: instead of living in centralized
+              MYCA is our environmental super intelligence for the mycelial edge: instead of living in centralized
               hyperscale data centers, MYCA runs in distributed edge data centers embedded inside our
               dedicated hardware platforms and nodes. It treats these locations like a planetary nervous
               system, pushing intelligence as close as possible to real-world signals.
             </p>
             <p>
-              Under the hood, MYCA is powered by the full NVIDIA AI stack, including Nemotron foundation
-              models, NeMo-based orchestration, and PersonaPlex-driven persona routing, with support for
+              Under the hood, MYCA is powered by Nemotron foundation models, a built-from-the-ground-up
+              orchestration system, and PersonaPlex for full-duplex voice-to-voice interactions, with support for
               Blackwell-generation edge GPUs so each node can host rich, local agents. MYCA maintains a
               coherent worldview across all these nodes, allowing it to reason about environments, policies,
               and user intent while still respecting locality and data sovereignty.


### PR DESCRIPTION
- MYCA subtitle: "Agentic Operating System" → "Environmental Super Intelligence"
- MYCA page: remove NeMo-based orchestration, fix PersonaPlex to full-duplex voice-to-voice
- AVANI page: replace "master VM" with "the MYCA system"
- AI page hero: "powered by the NVIDIA platform" → "powered by nature and computers"
- AI system section: "we rely on" → "we build on", remove NeMo orchestration, fix PersonaPlex
- AI agents section: updated to reflect correct MYCA/AVANI/NLM roles
- AI humans section: updated to describe environmental/nature interaction capabilities
- NLM page: "Neural Logic Machine" → "Nature Learning Model" (all occurrences)
- FAQ: updated all answers to match corrected terminology

https://claude.ai/code/session_01AweHG3X5uZ1xd9Ng4J67Cb

## Summary by Sourcery

Update AI stack marketing copy to reflect MYCA as an environmental super intelligence, NLM as the Nature Learning Model, and a nature-plus-compute powered platform.

Documentation:
- Refresh AI overview, MYCA, AVANI, and NLM pages to use updated terminology for MYCA, NLM, and platform positioning, including revised descriptions of human/agent interaction capabilities.
- Update FAQ entries to describe the new role definitions for MYCA, AVANI, and NLM and the revised NVIDIA-based platform description.