### PR TITLE
Fix invalid workflow: wrap secrets reference in expression syntax

### DIFF
--- a/.github/workflows/deploy-sandbox-production.yml
+++ b/.github/workflows/deploy-sandbox-production.yml
@@ -140,7 +140,7 @@ jobs:
             curl -sf -o /dev/null http://localhost:3000 || exit 1
 
       - name: Purge Cloudflare cache
-        if: success() && secrets.CLOUDFLARE_ZONE_ID != ''
+        if: ${{ success() && secrets.CLOUDFLARE_ZONE_ID != '' }}
         run: |
           curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
             -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \


### PR DESCRIPTION
The `secrets` context is not recognized as a bare named-value in GitHub Actions `if:` conditions. Wrap the entire condition in `${{ }}` syntax.

https://claude.ai/code/session_015NQKKYhnuzeZPaeSSNUW8m

## Summary by Sourcery

Bug Fixes:
- Wrap the Cloudflare cache purge step condition in GitHub Actions expression syntax so the secrets context is correctly evaluated.