### PR TITLE
Fix workflow: move secrets check from if-condition to shell guard

### DIFF
--- a/.github/workflows/deploy-sandbox-production.yml
+++ b/.github/workflows/deploy-sandbox-production.yml
@@ -140,10 +140,14 @@ jobs:
             curl -sf -o /dev/null http://localhost:3000 || exit 1
 
       - name: Purge Cloudflare cache
-        if: ${{ success() && secrets.CLOUDFLARE_ZONE_ID != '' }}
+        if: success()
         run: |
-          curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
-            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+          if [ -z "$CLOUDFLARE_ZONE_ID" ]; then
+            echo "CLOUDFLARE_ZONE_ID not set, skipping cache purge"
+            exit 0
+          fi
+          curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
             --data '{"purge_everything":true}'
         env:


### PR DESCRIPTION
GitHub Actions does not allow `secrets` context in step `if:` expressions. Move the CLOUDFLARE_ZONE_ID check into the shell script instead, using the env var that's already being passed through.

https://claude.ai/code/session_015NQKKYhnuzeZPaeSSNUW8m

## Summary by Sourcery

Bug Fixes:
- Prevent GitHub Actions workflow failures by moving the CLOUDFLARE_ZONE_ID presence check from the step condition into the shell script using environment variables.