### PR TITLE
fix: lowercase Docker image tag in sandbox build step

### DIFF
--- a/.github/workflows/deploy-sandbox-production.yml
+++ b/.github/workflows/deploy-sandbox-production.yml
@@ -54,6 +54,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME_LC=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -61,8 +64,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sandbox-${{ github.sha }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sandbox-latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:sandbox-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:sandbox-latest
           build-args: |
             NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
github.repository returns MycosoftLabs/website (mixed case) but Docker tags must be lowercase. The deploy step already lowercased it, but the build-and-push step did not, causing the CI build to fail.

https://claude.ai/code/session_015NQKKYhnuzeZPaeSSNUW8m

## Summary by Sourcery

Bug Fixes:
- Normalize the Docker image name to lowercase in the sandbox build-and-push workflow so generated tags comply with Docker requirements.