### PR TITLE
Update API endpoints: onboarding user_type, worldview search, internal admin tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,11 @@ MINDEX_API_KEY=
 # For production: use same key as MINDEX VM's API_KEYS
 NEXT_PUBLIC_MINDEX_URL=http://192.168.0.189:8000
 NEXT_PUBLIC_MINDEX_API_URL=http://192.168.0.189:8000
+# Internal token for admin/dashboard calls to /api/mindex/internal/... endpoints.
+# Shared secret between website and MINDEX backend — bypasses public rate limits.
+MINDEX_INTERNAL_TOKEN=
+# Feature flag: route /api/search to MINDEX /api/worldview/v1/search (per-user API keys)
+USE_WORLDVIEW_SEARCH=false
 
 # -----------------------------------------------------------------------------
 # MycoBrain IoT

--- a/app/api/admin/api-keys/route.ts
+++ b/app/api/admin/api-keys/route.ts
@@ -16,6 +16,7 @@ const API_KEYS_CONFIG = [
   { key: 'SUPABASE_SERVICE_ROLE_KEY', name: 'Supabase Service Role' },
   { key: 'NEXT_PUBLIC_SUPABASE_ANON_KEY', name: 'Supabase Anon' },
   { key: 'MINDEX_API_KEY', name: 'MINDEX' },
+  { key: 'MINDEX_INTERNAL_TOKEN', name: 'MINDEX Internal' },
   { key: 'GOOGLE_MAPS_API_KEY', name: 'Google Maps' },
   { key: 'INFURA_API_KEY', name: 'Infura' },
   { key: 'NIH_API_KEY', name: 'NIH' },

--- a/app/api/beta/onboard/route.ts
+++ b/app/api/beta/onboard/route.ts
@@ -2,12 +2,20 @@
  * POST /api/beta/onboard
  * Onboard beta user: create MINDEX beta_users record, generate API key.
  * Requires authenticated Supabase session.
+ *
+ * Body: { plan, user_type?, startup_fee_paid? }
+ *   - user_type: "individual" | "developer" | "researcher" | "organization" (default: "individual")
+ *   - startup_fee_paid: boolean — true when the $1 Stripe startup fee has been charged
+ *
  * March 5, 2026 — MYCA Loop Closure (revenue validation)
+ * March 19, 2026 — Added user_type and startup_fee_paid for segregated public/internal APIs
  */
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 
 const MINDEX_BASE = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL
+
+const VALID_USER_TYPES = ['individual', 'developer', 'researcher', 'organization'] as const
 
 export async function POST(request: NextRequest) {
   try {
@@ -30,6 +38,8 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json().catch(() => ({}))
     const plan = typeof body?.plan === 'string' ? body.plan.toLowerCase() : 'free'
+    const userType = VALID_USER_TYPES.includes(body?.user_type) ? body.user_type : 'individual'
+    const startupFeePaid = body?.startup_fee_paid === true
 
     const response = await fetch(`${MINDEX_BASE}/api/mindex/beta/onboard`, {
       method: 'POST',
@@ -38,6 +48,8 @@ export async function POST(request: NextRequest) {
         email: user.email,
         plan,
         supabase_user_id: user.id,
+        user_type: userType,
+        startup_fee_paid: startupFeePaid,
       }),
       cache: 'no-store',
     })

--- a/app/api/billing/mrr/route.ts
+++ b/app/api/billing/mrr/route.ts
@@ -2,13 +2,16 @@
  * GET /api/billing/mrr
  * MRR and beta stats for super admin dashboard.
  * Super admin only (morgan@mycosoft.org).
- * Fetches from MINDEX beta_users; no mock data.
+ * Fetches from MINDEX internal API; no mock data.
+ *
  * March 5, 2026 — MYCA Loop Closure (revenue validation)
+ * March 19, 2026 — Migrated to /api/mindex/internal/beta/stats with internal token
  */
 import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 
 const MINDEX_BASE = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL
+const MINDEX_INTERNAL_TOKEN = process.env.MINDEX_INTERNAL_TOKEN || process.env.INTERNAL_API_SECRET
 
 export async function GET() {
   try {
@@ -42,13 +45,36 @@ export async function GET() {
       })
     }
 
-    const res = await fetch(`${MINDEX_BASE}/api/mindex/beta/stats`, {
+    // Use internal MINDEX endpoint with internal token for admin calls.
+    // Falls back to the old public endpoint if the internal one isn't available yet.
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (MINDEX_INTERNAL_TOKEN) {
+      headers['x-internal-token'] = MINDEX_INTERNAL_TOKEN
+    }
+
+    let stats: Record<string, unknown> = {}
+
+    // Try new internal endpoint first
+    const internalRes = await fetch(`${MINDEX_BASE}/api/mindex/internal/beta/stats`, {
+      headers,
       cache: 'no-store',
-    })
-    const stats = await res.json().catch(() => ({}))
-    const active_users = stats.active_users ?? 0
-    const api_calls = stats.total_api_calls ?? 0
-    const users_by_plan = stats.users_by_plan ?? {}
+      signal: AbortSignal.timeout(5000),
+    }).catch(() => null)
+
+    if (internalRes?.ok) {
+      stats = await internalRes.json().catch(() => ({}))
+    } else {
+      // Fall back to legacy public endpoint
+      const fallbackRes = await fetch(`${MINDEX_BASE}/api/mindex/beta/stats`, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(5000),
+      }).catch(() => null)
+      stats = await fallbackRes?.json().catch(() => ({})) ?? {}
+    }
+
+    const active_users = (stats.active_users as number) ?? 0
+    const api_calls = (stats.total_api_calls as number) ?? 0
+    const users_by_plan = (stats.users_by_plan as Record<string, number>) ?? {}
 
     // MRR: approximate from beta_users plans (free=0, pro=29, enterprise=99, etc.)
     // Real MRR would come from Stripe; for now derive from plan counts

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -8,6 +8,9 @@ import { searchExpandedMushrooms } from "@/lib/data/top-mushrooms-expanded"
 import { searchTracker } from "@/lib/services/search-tracker"
 import { recordUsageFromRequest } from "@/lib/usage/record-api-usage"
 
+const MINDEX_BASE = process.env.MINDEX_API_URL || "http://192.168.0.189:8000"
+const USE_WORLDVIEW_SEARCH = process.env.USE_WORLDVIEW_SEARCH === "true"
+
 interface SpeciesMappingEntry {
   iNaturalistId?: string | number
   scientificName: string
@@ -175,6 +178,47 @@ export async function GET(request: NextRequest) {
 
     // Track this search query
     searchTracker.trackSearch(query)
+
+    // Worldview-first: try MINDEX /api/worldview/v1/search when enabled.
+    // Uses per-user API key forwarding for rate limiting.
+    if (USE_WORLDVIEW_SEARCH) {
+      try {
+        const authHeader = request.headers.get("authorization") || ""
+        const wvHeaders: Record<string, string> = { "Content-Type": "application/json" }
+        if (authHeader) wvHeaders["Authorization"] = authHeader
+        const mindexApiKey = process.env.MINDEX_API_KEY
+        if (mindexApiKey) wvHeaders["X-API-Key"] = mindexApiKey
+
+        const wvRes = await fetch(
+          `${MINDEX_BASE}/api/worldview/v1/search?q=${encodeURIComponent(query)}&limit=20`,
+          { headers: wvHeaders, signal: AbortSignal.timeout(5000), cache: "no-store" }
+        )
+        if (wvRes.ok) {
+          const wvData = await wvRes.json()
+          const wvResults: SearchResult[] = (wvData.results || []).map(
+            (r: { id?: string; title?: string; description?: string; type?: string; url?: string; source?: string }) => ({
+              id: r.id || "",
+              title: r.title || "",
+              description: r.description || "",
+              type: r.type || "fungi",
+              url: r.url || "",
+              source: r.source || "Worldview",
+            })
+          )
+          if (wvResults.length > 0) {
+            await recordUsageFromRequest({
+              request,
+              usageType: "SPECIES_IDENTIFICATION",
+              quantity: 1,
+              metadata: { query, source: "worldview_v1" },
+            })
+            return NextResponse.json({ results: wvResults, query, source: "worldview" }, { status: 200, headers })
+          }
+        }
+      } catch {
+        // Worldview not available — fall through to legacy search
+      }
+    }
 
     // Initialize with local results first
     const results: SearchResult[] = await getLocalSearchResults(query)

--- a/app/api/worldview/v1/search/route.ts
+++ b/app/api/worldview/v1/search/route.ts
@@ -1,0 +1,168 @@
+/**
+ * GET /api/worldview/v1/search
+ *
+ * Public search endpoint backed by MINDEX's worldview search API.
+ * Requires per-user API key (Bearer mk_...) or authenticated Supabase session.
+ *
+ * Query params:
+ *   q       — search query (required)
+ *   types   — comma-separated: species,compounds,genetics,research,earth (default: all)
+ *   limit   — max results per type (default 20, max 100)
+ *
+ * The other Claude Code agent is building /api/worldview/v1/search on the MINDEX
+ * backend (segregated public API). This route proxies to that endpoint and passes
+ * the user's API key for per-user rate limiting and access control.
+ *
+ * March 19, 2026 — Segregated public/internal API migration
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { getAgentProfile } from "@/lib/agent-auth"
+import { createClient } from "@/lib/supabase/server"
+import { recordUsageFromRequest } from "@/lib/usage/record-api-usage"
+
+export const dynamic = "force-dynamic"
+
+const MINDEX_BASE = process.env.MINDEX_API_URL || "http://192.168.0.189:8000"
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization, Content-Type",
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS })
+}
+
+export async function GET(request: NextRequest) {
+  const startTime = performance.now()
+
+  try {
+    // --- Auth: per-user API key (Bearer mk_...) or Supabase session ---
+    let userApiKey: string | null = null
+    let userId: string | null = null
+
+    // Try API key auth first
+    const agent = await getAgentProfile(request)
+    if (agent) {
+      userId = agent.profile_id
+      // Extract the raw Bearer token to forward to MINDEX
+      const authHeader = request.headers.get("authorization") || ""
+      if (authHeader.toLowerCase().startsWith("bearer ")) {
+        userApiKey = authHeader.slice(7)
+      }
+    } else {
+      // Fall back to Supabase session auth
+      const supabase = await createClient()
+      const { data: { user } } = await supabase.auth.getUser()
+      if (user) {
+        userId = user.id
+      }
+    }
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: "API key or authentication required", docs: "/agent" },
+        { status: 401, headers: CORS_HEADERS }
+      )
+    }
+
+    // --- Parse query params ---
+    const { searchParams } = request.nextUrl
+    const query = searchParams.get("q")?.trim()
+
+    if (!query || query.length < 2) {
+      return NextResponse.json(
+        { query: query || "", results: {}, totalCount: 0 },
+        { headers: CORS_HEADERS }
+      )
+    }
+
+    const types = searchParams.get("types") || "species,compounds,genetics,research,earth"
+    const limit = Math.min(parseInt(searchParams.get("limit") || "20", 10), 100)
+
+    // --- Proxy to MINDEX /api/worldview/v1/search ---
+    const proxyUrl = new URL(`${MINDEX_BASE}/api/worldview/v1/search`)
+    proxyUrl.searchParams.set("q", query)
+    proxyUrl.searchParams.set("types", types)
+    proxyUrl.searchParams.set("limit", String(limit))
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    }
+
+    // Forward per-user API key so MINDEX can enforce per-user rate limits
+    if (userApiKey) {
+      headers["Authorization"] = `Bearer ${userApiKey}`
+    }
+
+    // Also send server-side MINDEX API key for backend-to-backend auth
+    const mindexApiKey = process.env.MINDEX_API_KEY
+    if (mindexApiKey) {
+      headers["X-API-Key"] = mindexApiKey
+    }
+
+    const response = await fetch(proxyUrl.toString(), {
+      headers,
+      signal: AbortSignal.timeout(15000),
+      cache: "no-store",
+    })
+
+    const latencyMs = Math.round(performance.now() - startTime)
+
+    if (!response.ok) {
+      // If MINDEX worldview endpoint isn't deployed yet, return a helpful error
+      if (response.status === 404) {
+        return NextResponse.json(
+          {
+            error: "Worldview search API not yet available on MINDEX backend",
+            detail: "The /api/worldview/v1/search endpoint is being deployed. Use /api/search/unified in the meantime.",
+            fallback: "/api/search/unified",
+          },
+          { status: 503, headers: CORS_HEADERS }
+        )
+      }
+
+      const errorData = await response.json().catch(() => ({}))
+      return NextResponse.json(
+        { error: errorData?.detail || "Search failed", status: response.status },
+        { status: response.status >= 500 ? 502 : response.status, headers: CORS_HEADERS }
+      )
+    }
+
+    const data = await response.json()
+
+    // Record usage
+    await recordUsageFromRequest({
+      request,
+      usageType: "SPECIES_IDENTIFICATION",
+      quantity: 1,
+      metadata: { query, source: "worldview_v1", latencyMs },
+    })
+
+    return NextResponse.json(
+      {
+        ...data,
+        meta: {
+          api: "worldview",
+          version: "1.0",
+          timestamp: new Date().toISOString(),
+          latencyMs,
+        },
+      },
+      {
+        headers: {
+          ...CORS_HEADERS,
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        },
+      }
+    )
+  } catch (error) {
+    console.error("[worldview/v1/search] Error:", error)
+    return NextResponse.json(
+      { error: "Search service temporarily unavailable" },
+      { status: 502, headers: CORS_HEADERS }
+    )
+  }
+}

--- a/components/onboarding/api-key-step.tsx
+++ b/components/onboarding/api-key-step.tsx
@@ -6,12 +6,16 @@ import { Copy, Check, AlertCircle, Loader2, ArrowRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SubscriptionTier } from '@/lib/access/types'
 
+type UserType = 'individual' | 'developer' | 'researcher' | 'organization'
+
 interface ApiKeyStepProps {
   plan: SubscriptionTier
+  userType?: UserType
+  startupFeePaid?: boolean
   onComplete: () => void
 }
 
-export function ApiKeyStep({ plan, onComplete }: ApiKeyStepProps) {
+export function ApiKeyStep({ plan, userType = 'individual', startupFeePaid = false, onComplete }: ApiKeyStepProps) {
   const [apiKey, setApiKey] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -25,7 +29,7 @@ export function ApiKeyStep({ plan, onComplete }: ApiKeyStepProps) {
         const res = await fetch('/api/beta/onboard', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ plan }),
+          body: JSON.stringify({ plan, user_type: userType, startup_fee_paid: startupFeePaid }),
           credentials: 'include',
         })
 

--- a/components/onboarding/onboarding-wizard.tsx
+++ b/components/onboarding/onboarding-wizard.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { 
-  Leaf, 
-  Microscope, 
-  Globe2, 
-  Brain, 
+import {
+  Leaf,
+  Microscope,
+  Globe2,
+  Brain,
   Sparkles,
   ChevronRight,
   ChevronLeft,
@@ -17,7 +17,9 @@ import {
   Dna,
   CloudSun,
   Cpu,
-  ArrowRight
+  ArrowRight,
+  AlertCircle,
+  Loader2
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SignupForm } from './signup-form'
@@ -407,17 +409,111 @@ function ParticleBackground() {
   )
 }
 
+// Stripe $1 startup fee step
+function StartupFeeStep({ onSuccess, onSkip }: { onSuccess: () => void; onSkip: () => void }) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handlePay = async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/stripe/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'agent_worldstate', minutes: 1 }),
+        credentials: 'include',
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data?.error || 'Checkout failed')
+        return
+      }
+      if (data.url) {
+        // Redirect to Stripe — on return the success page triggers onSuccess
+        window.location.href = data.url
+      }
+    } catch {
+      setError('Network error')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold text-white">Activate Your Account</h2>
+        <p className="text-white/60 mt-2 text-sm">
+          A one-time $1 startup fee activates your API key and verifies your account.
+        </p>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 bg-red-500/20 border border-red-500/30 rounded-xl text-red-200 text-sm">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={handlePay}
+        disabled={isLoading}
+        className="w-full flex items-center justify-center gap-2 py-4 rounded-xl font-semibold bg-white text-emerald-900 hover:bg-emerald-50 disabled:opacity-50 transition-all"
+      >
+        {isLoading ? (
+          <Loader2 className="w-5 h-5 animate-spin" />
+        ) : (
+          <>
+            Pay $1 &mdash; Activate Account
+            <ArrowRight className="w-5 h-5" />
+          </>
+        )}
+      </button>
+
+      <button
+        type="button"
+        onClick={onSkip}
+        className="w-full py-2 text-white/50 text-sm hover:text-white/80 transition-colors"
+      >
+        Skip for now (limited access)
+      </button>
+    </div>
+  )
+}
+
 // Signup slide component
 function SignupSlide({ slide, onComplete }: { slide: typeof SLIDES[0], onComplete: () => void }) {
-  const [step, setStep] = useState<'form' | 'plan' | 'apikey'>('form')
+  const [step, setStep] = useState<'form' | 'plan' | 'fee' | 'apikey'>('form')
   const [selectedPlan, setSelectedPlan] = useState<SubscriptionTier>(SubscriptionTier.FREE)
+  const [startupFeePaid, setStartupFeePaid] = useState(false)
   const IconComponent = slide.icon
+
+  // Check if returning from Stripe success
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('success') === '1' || params.get('startup_fee') === 'paid') {
+      setStartupFeePaid(true)
+      setStep('apikey')
+    }
+  }, [])
 
   const handlePlanComplete = (plan: SubscriptionTier) => {
     setSelectedPlan(plan)
+    setStep('fee')
+  }
+
+  const handleFeeSuccess = () => {
+    setStartupFeePaid(true)
     setStep('apikey')
   }
-  
+
+  const handleFeeSkip = () => {
+    setStartupFeePaid(false)
+    setStep('apikey')
+  }
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
       {/* Left side - info */}
@@ -430,7 +526,7 @@ function SignupSlide({ slide, onComplete }: { slide: typeof SLIDES[0], onComplet
         >
           <IconComponent className="w-10 h-10 text-white" />
         </motion.div>
-        
+
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -438,7 +534,7 @@ function SignupSlide({ slide, onComplete }: { slide: typeof SLIDES[0], onComplet
         >
           {slide.title}
         </motion.h1>
-        
+
         <motion.p
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -447,7 +543,7 @@ function SignupSlide({ slide, onComplete }: { slide: typeof SLIDES[0], onComplet
         >
           {slide.description}
         </motion.p>
-        
+
         {/* Features list */}
         <motion.div
           initial={{ opacity: 0 }}
@@ -471,7 +567,7 @@ function SignupSlide({ slide, onComplete }: { slide: typeof SLIDES[0], onComplet
           ))}
         </motion.div>
       </div>
-      
+
       {/* Right side - form */}
       <motion.div
         initial={{ opacity: 0, x: 50 }}
@@ -483,8 +579,10 @@ function SignupSlide({ slide, onComplete }: { slide: typeof SLIDES[0], onComplet
           <SignupForm onSuccess={() => setStep('plan')} />
         ) : step === 'plan' ? (
           <PlanSelector onComplete={handlePlanComplete} />
+        ) : step === 'fee' ? (
+          <StartupFeeStep onSuccess={handleFeeSuccess} onSkip={handleFeeSkip} />
         ) : (
-          <ApiKeyStep plan={selectedPlan} onComplete={onComplete} />
+          <ApiKeyStep plan={selectedPlan} startupFeePaid={startupFeePaid} onComplete={onComplete} />
         )}
       </motion.div>
     </div>

--- a/lib/config/api-urls.ts
+++ b/lib/config/api-urls.ts
@@ -111,6 +111,12 @@ export const MINDEX_ENDPOINTS = {
   EARTH_MAP_LAYERS: `${API_URLS.MINDEX}/api/earth/map/layers`,
   EARTH_DOMAINS: `${API_URLS.MINDEX}/api/earth/domains`,
   EARTH_INGEST: `${API_URLS.MINDEX}/api/earth/ingest`,
+  // Worldview public API (per-user API keys, segregated from internal)
+  WORLDVIEW_SEARCH: `${API_URLS.MINDEX}/api/worldview/v1/search`,
+  // Internal admin API (requires MINDEX_INTERNAL_TOKEN)
+  INTERNAL_STATS: `${API_URLS.MINDEX}/api/mindex/internal/stats`,
+  INTERNAL_BETA_STATS: `${API_URLS.MINDEX}/api/mindex/internal/beta/stats`,
+  INTERNAL_USERS: `${API_URLS.MINDEX}/api/mindex/internal/users`,
 } as const
 
 /**

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -14,6 +14,9 @@ export const env = {
   // MINDEX runs on 192.168.0.189:8000 (dedicated database VM)
   mindexApiBaseUrl: process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || process.env.NEXT_PUBLIC_MINDEX_URL || "http://192.168.0.189:8000",
   mindexApiKey: process.env.MINDEX_API_KEY || "", // Server-only — must be set via env
+  // Internal token for MINDEX admin/internal endpoints (/api/mindex/internal/...)
+  // Shared secret between website and MINDEX backend — bypasses public API rate limits
+  mindexInternalToken: process.env.MINDEX_INTERNAL_TOKEN || process.env.INTERNAL_API_SECRET || "",
 
   // MyceliumSeg validation API (segmentation metrics for Petri Dish / scientific validation)
   myceliumsegApiUrl: process.env.NEXT_PUBLIC_MYCELIUMSEG_API_URL || process.env.MYCELIUMSEG_API_URL || "http://localhost:8010/mindex/myceliumseg",

--- a/lib/integrations/mindex.ts
+++ b/lib/integrations/mindex.ts
@@ -20,13 +20,19 @@ import type {
 
 // Create MINDEX HTTP client
 // MINDEX uses X-API-Key header instead of Bearer token
+const mindexHeaders: Record<string, string> = {
+  "X-API-Key": env.mindexApiKey || "",
+}
+// Include internal token for admin/internal endpoints when configured
+if (env.mindexInternalToken) {
+  mindexHeaders["x-internal-token"] = env.mindexInternalToken
+}
+
 const mindexClient = createHttpClient({
   baseUrl: env.mindexApiBaseUrl,
   timeout: 15000,
   retries: 2,
-  headers: {
-    "X-API-Key": env.mindexApiKey || "",
-  },
+  headers: mindexHeaders,
 })
 
 // ============================================

--- a/lib/mindex-internal.ts
+++ b/lib/mindex-internal.ts
@@ -1,0 +1,91 @@
+/**
+ * MINDEX Internal API Client
+ *
+ * Server-side utility for making authenticated calls to MINDEX internal
+ * endpoints (/api/mindex/internal/...). Uses x-internal-token header
+ * to bypass public API rate limits and access admin-only data.
+ *
+ * The other Claude Code agent is building the segregated internal/public
+ * API split on the MINDEX backend. Internal endpoints require the shared
+ * MINDEX_INTERNAL_TOKEN secret.
+ *
+ * March 19, 2026 — Segregated public/internal API migration
+ */
+
+const MINDEX_BASE = process.env.MINDEX_API_URL || "http://192.168.0.189:8000"
+const MINDEX_INTERNAL_TOKEN = process.env.MINDEX_INTERNAL_TOKEN || process.env.INTERNAL_API_SECRET
+
+/**
+ * Make an authenticated GET request to a MINDEX internal endpoint.
+ * Returns parsed JSON or null on failure.
+ */
+export async function mindexInternalGet<T = unknown>(
+  path: string,
+  options?: { timeout?: number }
+): Promise<T | null> {
+  const url = `${MINDEX_BASE}${path}`
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  }
+
+  if (MINDEX_INTERNAL_TOKEN) {
+    headers["x-internal-token"] = MINDEX_INTERNAL_TOKEN
+  }
+
+  try {
+    const res = await fetch(url, {
+      headers,
+      cache: "no-store",
+      signal: AbortSignal.timeout(options?.timeout ?? 10000),
+    })
+
+    if (!res.ok) {
+      console.warn(`[mindex-internal] ${path} returned ${res.status}`)
+      return null
+    }
+
+    return await res.json()
+  } catch (error) {
+    console.warn(`[mindex-internal] ${path} failed:`, error)
+    return null
+  }
+}
+
+/**
+ * Make an authenticated POST request to a MINDEX internal endpoint.
+ * Returns parsed JSON or null on failure.
+ */
+export async function mindexInternalPost<T = unknown>(
+  path: string,
+  body: unknown,
+  options?: { timeout?: number }
+): Promise<T | null> {
+  const url = `${MINDEX_BASE}${path}`
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  }
+
+  if (MINDEX_INTERNAL_TOKEN) {
+    headers["x-internal-token"] = MINDEX_INTERNAL_TOKEN
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      cache: "no-store",
+      signal: AbortSignal.timeout(options?.timeout ?? 10000),
+    })
+
+    if (!res.ok) {
+      console.warn(`[mindex-internal] POST ${path} returned ${res.status}`)
+      return null
+    }
+
+    return await res.json()
+  } catch (error) {
+    console.warn(`[mindex-internal] POST ${path} failed:`, error)
+    return null
+  }
+}


### PR DESCRIPTION
Aligns website with the MINDEX backend's segregated public/internal API split
(being built by another agent in the mindex repo).

Onboarding:
- POST /api/beta/onboard now sends user_type and startup_fee_paid to MINDEX
- Added $1 Stripe startup fee step in onboarding wizard before API key generation
- Frontend passes user_type and startup_fee_paid through to backend

Search:
- Created /api/worldview/v1/search proxy route with per-user API key forwarding
- /api/search tries MINDEX worldview endpoint first when USE_WORLDVIEW_SEARCH=true
- Added MINDEX_ENDPOINTS.WORLDVIEW_SEARCH to centralized URL config

Dashboard/Admin:
- /api/billing/mrr now tries /api/mindex/internal/beta/stats with x-internal-token
- Falls back to legacy /api/mindex/beta/stats if internal endpoint unavailable
- Added MINDEX_INTERNAL_TOKEN env var (shared secret for internal endpoints)
- Created lib/mindex-internal.ts reusable client for internal API calls
- MINDEX integration client includes x-internal-token when configured
- Added MINDEX_INTERNAL_TOKEN to admin API keys visibility

https://claude.ai/code/session_011xBFKiRnJZcoD6SXQjhBLp

## Summary by Sourcery

Align the website onboarding, search, and admin dashboards with MINDEX’s new segregated public/internal API, including startup fee tracking, worldview search proxying, and internal token–based admin stats.

New Features:
- Add a $1 Stripe startup fee step to the onboarding wizard and propagate startup_fee_paid to backend onboarding.
- Capture and forward user_type and startup_fee_paid from the frontend to the MINDEX onboarding API.
- Introduce a public /api/worldview/v1/search endpoint that proxies to MINDEX’s worldview search with per-user API key and server API key forwarding.

Enhancements:
- Update the unified /api/search endpoint to optionally prefer MINDEX worldview search results when enabled via configuration.
- Migrate admin MRR stats fetching to MINDEX internal beta stats endpoints with fallback to the legacy public endpoint.
- Extend the MINDEX integration client and config to support internal admin endpoints via a shared internal token.
- Expose the MINDEX internal token in the admin API keys view and centralize internal MINDEX URLs in config.
- Add a reusable mindex-internal client utility for authenticated calls to MINDEX internal endpoints.