### PR TITLE
fix: use GITHUB_TOKEN for GHCR auth in sandbox deploy

### DIFF
--- a/.github/workflows/deploy-sandbox-production.yml
+++ b/.github/workflows/deploy-sandbox-production.yml
@@ -80,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment: production
+    permissions:
+      packages: read
     steps:
       - name: Set image for deploy (GHCR uses lowercase)
         run: echo "IMAGE_FULL=${{ env.REGISTRY }}/$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]'):sandbox-latest" >> $GITHUB_ENV
@@ -106,17 +108,15 @@ jobs:
       - name: Deploy to Sandbox VM
         env:
           IMAGE_FULL: ${{ env.IMAGE_FULL }}
-          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
+          echo "${GH_TOKEN}" | ssh production docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
           ssh production bash -s <<DEPLOY
             set -e
             BASE_URL="https://mycosoft.com"
-
-            if [ -n "$GHCR_PULL_TOKEN" ]; then
-              echo "$GHCR_PULL_TOKEN" | docker login ghcr.io -u mycosoft --password-stdin
-            fi
 
             echo "=== Pulling image ==="
             docker pull "$IMAGE_FULL"


### PR DESCRIPTION
The deploy job relied on the optional GHCR_PULL_TOKEN secret for registry authentication. When not set, docker login was skipped and the image pull failed with "denied". Now uses GITHUB_TOKEN (like ci-cd.yml does) and authenticates before SSH-ing the pull.

https://claude.ai/code/session_01QS5vTzAMxFYBzTMGgaV9pw

## Summary by Sourcery

Update sandbox production deployment workflow to authenticate to GHCR using the built-in GITHUB_TOKEN instead of an optional custom secret.

Bug Fixes:
- Ensure sandbox deployment can always authenticate and pull images from GHCR by using GITHUB_TOKEN for docker login over SSH.

CI:
- Grant packages: read permission in the sandbox production deploy job to allow GHCR access with GITHUB_TOKEN.