### PR TITLE
fix: lazy-init ground station DB to prevent build failure

### DIFF
--- a/lib/ground-station/db.ts
+++ b/lib/ground-station/db.ts
@@ -9,11 +9,25 @@ import { neon } from "@neondatabase/serverless"
 import { drizzle } from "drizzle-orm/neon-http"
 import * as schema from "@/schema/ground-station"
 
-const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL
-if (!databaseUrl) {
-  console.warn("Ground Station: No DATABASE_URL or POSTGRES_URL configured")
+let _gsDb: ReturnType<typeof drizzle> | null = null
+
+function getDb() {
+  if (!_gsDb) {
+    const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL
+    if (!databaseUrl) {
+      throw new Error("Ground Station: No DATABASE_URL or POSTGRES_URL configured")
+    }
+    const queryClient = neon(databaseUrl)
+    _gsDb = drizzle(queryClient, { schema })
+  }
+  return _gsDb
 }
 
-const queryClient = neon(databaseUrl || "")
-export const gsDb = drizzle(queryClient, { schema })
+export const gsDb = new Proxy({} as ReturnType<typeof drizzle>, {
+  get(_target, prop, receiver) {
+    const db = getDb()
+    const value = Reflect.get(db, prop, receiver)
+    return typeof value === "function" ? value.bind(db) : value
+  },
+})
 export { schema }


### PR DESCRIPTION
neon() was called at module import time, crashing next build when DATABASE_URL is not set (e.g. in Docker build). Use a Proxy to defer initialization to first actual DB query at runtime.

https://claude.ai/code/session_01MBKFaycfj2NMuujLxUF6ZN

## Summary by Sourcery

Bug Fixes:
- Prevent Next.js/Docker builds from crashing by avoiding database client initialization at module import when DATABASE_URL/POSTGRES_URL is not set.