### PR TITLE
fix: lazy-init neon() in seed route to prevent build crash

### DIFF
--- a/app/api/ground-station/seed/route.ts
+++ b/app/api/ground-station/seed/route.ts
@@ -22,10 +22,15 @@ import { gsDb, schema } from "@/lib/ground-station/db"
 
 export const dynamic = "force-dynamic"
 
-const rawSql = neon(process.env.DATABASE_URL || process.env.POSTGRES_URL || "")
+function getRawSql() {
+  const url = process.env.DATABASE_URL || process.env.POSTGRES_URL
+  if (!url) throw new Error("Ground Station: No DATABASE_URL or POSTGRES_URL configured")
+  return neon(url)
+}
 
 export async function POST() {
   try {
+    const rawSql = getRawSql()
     // =========================================================================
     // CREATE TABLES (idempotent) - use raw neon client for DDL
     // =========================================================================


### PR DESCRIPTION
The seed route had a top-level neon() call that crashed during next build when DATABASE_URL is not available (Docker build env). Move it into a function called at request time.

https://claude.ai/code/session_01MBKFaycfj2NMuujLxUF6ZN

## Summary by Sourcery

Bug Fixes:
- Prevent next build crashes by checking for DATABASE_URL/POSTGRES_URL and creating the neon client at request time.