### PR TITLE
fix: add DashboardHero to /natureos page

### DIFF
--- a/app/natureos/page.tsx
+++ b/app/natureos/page.tsx
@@ -1,12 +1,16 @@
+"use client"
+
 import { Suspense } from "react"
 
 import { DashboardHeader } from "@/components/dashboard/header"
 import { DashboardShell } from "@/components/dashboard/shell"
+import { DashboardHero } from "@/components/dashboard/dashboard-hero"
 import { NatureOSWelcome } from "@/components/natureos/natureos-welcome"
 
 export default function NatureOSPage() {
   return (
     <DashboardShell>
+      <DashboardHero displayName="Explorer" isSuperAdmin={false} />
       <DashboardHeader
         heading="NatureOS Dashboard"
         text="Quick actions and fleet-wide health for the NatureOS platform."


### PR DESCRIPTION
The redesigned NatureOS hero section was only added to /dashboard but not to /natureos. This adds the DashboardHero component to the NatureOS page so visitors see the full platform intro.

https://claude.ai/code/session_01QS5vTzAMxFYBzTMGgaV9pw