### PR TITLE
Fix CREP map: make public and fix page loading

### DIFF
--- a/app/natureos/crep/page.tsx
+++ b/app/natureos/crep/page.tsx
@@ -1,5 +1,5 @@
-"use client"
-
+// SERVER component — do NOT add "use client" here.
+// Reuse the existing CREP dashboard loader for the public NatureOS route.
 export const dynamic = "force-dynamic"
 
 export { default } from "@/app/dashboard/crep/CREPDashboardLoader"

--- a/lib/access/routes.ts
+++ b/lib/access/routes.ts
@@ -30,6 +30,7 @@ export const PUBLIC_ROUTES: RouteAccess[] = [
   { path: '/apps/earth-simulator', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Earth Simulator' },
   { path: '/apps/petri-dish-sim', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Petri Dish Simulator' },
   { path: '/apps/compound-sim', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Compound Analyzer' },
+  { path: '/natureos/crep', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'CREP Dashboard' },
 ]
 
 // Freemium routes - public with limits
@@ -135,7 +136,6 @@ export const COMPANY_ROUTES: RouteAccess[] = [
   { path: '/natureos/fci', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'FCI Monitor' },
   { path: '/natureos/fusarium', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'FUSARIUM' },
   { path: '/natureos/mindex', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'MINDEX' },
-  { path: '/natureos/crep', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'CREP Dashboard' },
   { path: '/natureos/storage', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Storage' },
   { path: '/natureos/containers', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Containers' },
   { path: '/natureos/monitoring', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Monitoring' },
@@ -341,6 +341,7 @@ const COMPANY_REQUIRED_PREFIXES: string[] = [
 
 const MIDDLEWARE_PUBLIC_EXCEPTIONS = [
   '/natureos/mindex/explorer',
+  '/natureos/crep',
   '/ancestry/explorer',
   '/apps/earth-simulator',
   '/apps/petri-dish-sim',


### PR DESCRIPTION
- Move /natureos/crep from COMPANY_ROUTES (company email required) to
  PUBLIC_ROUTES so anyone can access the map without authentication
- Add /natureos/crep to MIDDLEWARE_PUBLIC_EXCEPTIONS so the auth
  middleware doesn't redirect unauthenticated visitors
- Remove "use client" from natureos/crep/page.tsx — this is a server
  component that re-exports CREPDashboardLoader, matching the pattern
  used by dashboard/crep/page.tsx. The "use client" directive was
  breaking the `export const dynamic` route segment config.

https://claude.ai/code/session_013Ka7vLHp7MVWP34d1Lyxpi

## Summary by Sourcery

Make the NatureOS CREP dashboard route publicly accessible and ensure its Next.js page loads correctly as a server component.

New Features:
- Expose the /natureos/crep CREP dashboard as a public route accessible without authentication.

Bug Fixes:
- Fix the /natureos/crep page loading configuration by keeping it as a server component so the dynamic route settings work correctly.

Enhancements:
- Align the /natureos/crep page implementation with the existing CREP dashboard loader pattern used elsewhere.