### PR TITLE
Fix EMPTY_RESULTS reference to use nested results property

### DIFF
--- a/components/search/fluid/FluidSearchCanvas.tsx
+++ b/components/search/fluid/FluidSearchCanvas.tsx
@@ -1072,8 +1072,9 @@ export function FluidSearchCanvas({
     { type: "infrastructure", label: "Infrastructure", icon: "🏗️", gradient: "from-amber-500/30 to-yellow-500/20", hasData: len(infrastructure) > 0, depth: getParallaxDepth("infrastructure") },
     { type: "devices", label: "Devices", icon: "📡", gradient: "from-green-500/30 to-lime-500/20", hasData: len(devices) > 0, depth: getParallaxDepth("devices") },
     { type: "space_weather", label: "Space Weather", icon: "☀️", gradient: "from-yellow-500/30 to-red-500/20", hasData: len(spaceWeather) > 0, depth: getParallaxDepth("space_weather") },
+    { type: "cameras", label: "Cameras", icon: "📹", gradient: "from-slate-500/30 to-cyan-500/20", hasData: len(cameras) > 0, depth: getParallaxDepth("cameras") },
     { type: "embedding_atlas", label: "Atlas", icon: "🔮", gradient: "from-violet-500/30 to-purple-500/20", hasData: true, depth: getParallaxDepth("embedding_atlas") },
-  ]}, [len(species), len(compounds), len(genetics), len(research), len(mediaResults), len(locationResults), len(newsResults), mergedCrepData.length, earth2Data, len(mapObservations), suggestions?.widgets, suggestions?.queries, mycaMessages, len(events), len(aircraft), len(vessels), len(satellites), len(weather), len(emissions), len(infrastructure), len(devices), len(spaceWeather), species])
+  ]}, [len(species), len(compounds), len(genetics), len(research), len(mediaResults), len(locationResults), len(newsResults), mergedCrepData.length, earth2Data, len(mapObservations), suggestions?.widgets, suggestions?.queries, mycaMessages, len(events), len(aircraft), len(vessels), len(satellites), len(weather), len(emissions), len(infrastructure), len(devices), len(spaceWeather), len(cameras), species])
 
   // Always show all widgets in the dock/pills so users can explore or open them before a data-driven search
   const activeWidgets = widgetConfigs
@@ -1235,6 +1236,7 @@ export function FluidSearchCanvas({
       infrastructure: len(infrastructure),
       devices: len(devices),
       space_weather: len(spaceWeather),
+      cameras: len(cameras),
     }
     const key = `${localQuery}|${Object.values(dataMap).join(",")}`
     if (key === prevAutoExpandKeyRef.current) return

--- a/hooks/use-unified-search.ts
+++ b/hooks/use-unified-search.ts
@@ -158,8 +158,8 @@ export function useUnifiedSearch(
 
   // Extract results with memoization
   const results = useMemo(() => {
-    if (!data?.results) return EMPTY_RESULTS
-    return { ...EMPTY_RESULTS, ...data.results }
+    if (!data?.results) return EMPTY_RESULTS.results
+    return { ...EMPTY_RESULTS.results, ...data.results }
   }, [data])
 
   const species = useMemo(() => results.species || [], [results.species])

--- a/lib/search/unified-search-sdk.ts
+++ b/lib/search/unified-search-sdk.ts
@@ -326,7 +326,7 @@ export class UnifiedSearchClient {
     if (!normalizedQuery || normalizedQuery.length < 2) {
       return {
         query: "",
-        results: { ...EMPTY_RESULTS },
+        results: { ...EMPTY_RESULTS.results },
         totalCount: 0,
         timing: { total: 0, mindex: 0 },
         source: "cache",
@@ -421,7 +421,7 @@ export class UnifiedSearchClient {
       if (error instanceof Error && error.name === "AbortError") {
         return {
           query: "",
-          results: { ...EMPTY_RESULTS },
+          results: { ...EMPTY_RESULTS.results },
           totalCount: 0,
           timing: { total: performance.now() - startTime, mindex: 0 },
           source: "cache",
@@ -432,7 +432,7 @@ export class UnifiedSearchClient {
       console.error("Unified search error:", error)
       return {
         query: "",
-        results: { ...EMPTY_RESULTS },
+        results: { ...EMPTY_RESULTS.results },
         totalCount: 0,
         timing: { total: performance.now() - startTime, mindex: 0 },
         source: "cache",


### PR DESCRIPTION
## Summary
This PR fixes incorrect references to `EMPTY_RESULTS` throughout the codebase. The constant was being spread directly when it should reference its nested `results` property. Additionally, adds support for a new "cameras" data type in the search canvas.

## Key Changes
- **Fixed EMPTY_RESULTS references**: Updated three instances in `unified-search-sdk.ts` where `EMPTY_RESULTS` was being spread directly to instead spread `EMPTY_RESULTS.results`
- **Fixed hook memoization**: Corrected `use-unified-search.ts` to return and spread `EMPTY_RESULTS.results` instead of the parent object
- **Added cameras support**: 
  - Added "cameras" widget configuration to the search canvas with slate-to-cyan gradient styling
  - Updated dependency array in `useMemo` to include `len(cameras)`
  - Added cameras count to the data map used for auto-expand key generation

## Implementation Details
The `EMPTY_RESULTS` constant appears to have a structure where the actual results data is nested under a `results` property. The previous code was spreading the entire object instead of just the results property, which would have caused type mismatches and incorrect data structure in error/empty states. This fix ensures consistent data structure across all code paths.

The cameras widget follows the same pattern as other data type widgets (infrastructure, devices, space_weather, etc.) with appropriate icon, gradient, and data availability checks.

https://claude.ai/code/session_01UK2bARZKfDqMZGzy15LDVg

## Summary by Sourcery

Fix unified search empty-state handling and extend the search canvas to support cameras data.

New Features:
- Add a cameras widget to the fluid search canvas with dedicated styling and data presence handling.

Bug Fixes:
- Ensure unified search fallbacks spread EMPTY_RESULTS.results instead of the parent EMPTY_RESULTS object when returning empty queries or handling errors.
- Correct useUnifiedSearch result memoization to work with EMPTY_RESULTS.results rather than the full EMPTY_RESULTS structure.

Enhancements:
- Include cameras counts in memoization dependencies and auto-expand key generation so cameras-driven changes are reflected in the UI behavior.