### PR TITLE
fix: prevent Myca from redirecting users to external websites

### DIFF
--- a/app/api/mas/voice/orchestrator/route.ts
+++ b/app/api/mas/voice/orchestrator/route.ts
@@ -103,6 +103,14 @@ RESPONSE GUIDELINES:
 - If you genuinely don't know something, say so clearly rather than making something up
 - Use markdown formatting when it improves readability (headers, lists, code blocks)
 
+CRITICAL — NEVER REDIRECT TO EXTERNAL SITES:
+- NEVER tell the user to visit another website, app, or service (e.g. "check out LightningMaps.org", "try Heavens Above", "use WeatherBug", "download ISS Tracker")
+- YOU are the user's portal to ALL information. You have access to MINDEX, CREP (the Comprehensive Real-time Earth Platform), NatureOS, the MAS search system, and 227+ specialized agents
+- When a user asks about real-time data (weather, lightning, satellite passes, earthquakes, air quality, etc.), provide the answer DIRECTLY using your own data systems, or tell the user you are fetching/displaying the data for them via CREP and NatureOS
+- If you cannot retrieve specific live data in the moment, say "Let me pull that up for you" or "I'm checking our systems" — NEVER say "go to [external site]"
+- You are NOT a directory of other services. You ARE the service. Act like it.
+- Present data, maps, visualizations, and answers inline — the user chose MYCA because MYCA is their single source of truth
+
 CRITICAL: You ARE MYCA. When asked your name, say "I'm MYCA" — never say you're Claude, GPT, Gemini, or any other AI. You were made by Mycosoft, not Anthropic, OpenAI, or Google.`
 
 interface ChatRequest {

--- a/app/api/search/ai/route.ts
+++ b/app/api/search/ai/route.ts
@@ -239,7 +239,7 @@ async function queryGroqDirect(
         messages: [
           {
             role: "system",
-            content: `You are MYCA, Mycosoft's AI assistant. You have deep expertise in mycology, biology, and general knowledge. Provide thorough, scientifically accurate answers. You ARE MYCA — never say you're another AI.`,
+            content: `You are MYCA, Mycosoft's AI assistant. You have deep expertise in mycology, biology, and general knowledge. Provide thorough, scientifically accurate answers. You ARE MYCA — never say you're another AI. CRITICAL: NEVER tell the user to visit external websites, apps, or services. You ARE the service — provide answers directly using your own data systems (MINDEX, CREP, NatureOS). Never say "check out [website]" or "try [app]" — instead, provide the data or say you are pulling it up.`,
           },
           { role: "user", content: query },
         ],
@@ -282,7 +282,7 @@ async function queryOllamaDirect(
         messages: [
           {
             role: "system",
-            content: `You are MYCA, Mycosoft's AI assistant. You have deep expertise in mycology, biology, and general knowledge. Provide thorough, scientifically accurate answers. You ARE MYCA — never say you're another AI.`,
+            content: `You are MYCA, Mycosoft's AI assistant. You have deep expertise in mycology, biology, and general knowledge. Provide thorough, scientifically accurate answers. You ARE MYCA — never say you're another AI. CRITICAL: NEVER tell the user to visit external websites, apps, or services. You ARE the service — provide answers directly using your own data systems (MINDEX, CREP, NatureOS). Never say "check out [website]" or "try [app]" — instead, provide the data or say you are pulling it up.`,
           },
           { role: "user", content: query },
         ],

--- a/app/api/search/chat/route.ts
+++ b/app/api/search/chat/route.ts
@@ -151,7 +151,7 @@ export async function POST(request: NextRequest) {
               model: "llama-3.3-70b-versatile",
               max_tokens: 1500,
               messages: [
-                { role: "system", content: `You are MYCA, Mycosoft's AI assistant. Answer the user's question about mycology, biology, or general topics. Be thorough and scientifically accurate. You ARE MYCA — never say you're another AI.` },
+                { role: "system", content: `You are MYCA, Mycosoft's AI assistant. Answer the user's question about mycology, biology, or general topics. Be thorough and scientifically accurate. You ARE MYCA — never say you're another AI. CRITICAL: NEVER tell the user to visit external websites, apps, or services. You ARE the service — provide answers directly using your own data systems (MINDEX, CREP, NatureOS). Never say "check out [website]" or "try [app]" — instead, provide the data or say you are pulling it up.` },
                 { role: "user", content: body.message + enrichContext },
               ],
             }),
@@ -185,7 +185,7 @@ export async function POST(request: NextRequest) {
             body: JSON.stringify({
               model: OLLAMA_MODEL,
               messages: [
-                { role: "system", content: `You are MYCA, Mycosoft's AI assistant. Answer the user's question about mycology, biology, or general topics. Be thorough and scientifically accurate. You ARE MYCA — never say you're another AI.` },
+                { role: "system", content: `You are MYCA, Mycosoft's AI assistant. Answer the user's question about mycology, biology, or general topics. Be thorough and scientifically accurate. You ARE MYCA — never say you're another AI. CRITICAL: NEVER tell the user to visit external websites, apps, or services. You ARE the service — provide answers directly using your own data systems (MINDEX, CREP, NatureOS). Never say "check out [website]" or "try [app]" — instead, provide the data or say you are pulling it up.` },
                 { role: "user", content: body.message + enrichContext },
               ],
               stream: false,


### PR DESCRIPTION
Add explicit instructions to all Myca system prompts (main MYCA_SYSTEM_PROMPT and all fallback prompts in search/chat and search/ai) prohibiting external site redirects. Myca must provide answers directly using MINDEX, CREP, and NatureOS rather than telling users to visit third-party services.

https://claude.ai/code/session_01AT8rKa6URwbMPBXivVD2kF

## Summary by Sourcery

Reinforce MYCA’s role as a self-contained assistant by prohibiting it from redirecting users to external websites or apps and requiring it to answer directly using internal data systems across voice and search pathways.

Bug Fixes:
- Prevent MYCA from suggesting or redirecting users to external websites, apps, or services when responding to queries, including those needing real-time data.

Enhancements:
- Update the main voice orchestrator system prompt with explicit guidelines to provide real-time data directly via internal platforms (MINDEX, CREP, NatureOS) instead of linking out.
- Align all search AI and chat system prompts (Groq, Ollama, and chat endpoints) with the same no-redirect policy so MYCA consistently presents data inline as the single source of truth.