### PR TITLE
Fix CREP public access gating and mobile hamburger menu crash

### DIFF
--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { createPortal } from "react-dom"
+import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { AnimatePresence, motion } from "framer-motion"

--- a/lib/access/routes.ts
+++ b/lib/access/routes.ts
@@ -31,6 +31,7 @@ export const PUBLIC_ROUTES: RouteAccess[] = [
   { path: '/apps/petri-dish-sim', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Petri Dish Simulator' },
   { path: '/apps/compound-sim', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Compound Analyzer' },
   { path: '/natureos/crep', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'CREP Dashboard' },
+  { path: '/dashboard/crep', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'CREP Dashboard (public)' },
 ]
 
 // Freemium routes - public with limits
@@ -342,6 +343,7 @@ const COMPANY_REQUIRED_PREFIXES: string[] = [
 const MIDDLEWARE_PUBLIC_EXCEPTIONS = [
   '/natureos/mindex/explorer',
   '/natureos/crep',
+  '/dashboard/crep',
   '/ancestry/explorer',
   '/apps/earth-simulator',
   '/apps/petri-dish-sim',


### PR DESCRIPTION
- Add /dashboard/crep to PUBLIC_ROUTES and MIDDLEWARE_PUBLIC_EXCEPTIONS
  so unauthenticated users are no longer redirected to login
- Add missing `import Image from "next/image"` in mobile-nav.tsx which
  caused a runtime error breaking the entire hamburger menu

https://claude.ai/code/session_01GJZGfgxcGJ4x7Y8Qb7PZNE

## Summary by Sourcery

Allow public access to the CREP dashboard route and fix the mobile navigation crash caused by a missing dependency import.

New Features:
- Expose the /dashboard/crep route as a publicly accessible CREP dashboard path.

Bug Fixes:
- Prevent unauthenticated users from being redirected to login when visiting the public CREP dashboard route.
- Fix a runtime error in the mobile navigation hamburger menu by adding the missing image component import.