### PR TITLE
Fix NLM page neumorphic colors for readability in both dark and light mode

### DIFF
--- a/app/myca/nlm/page.tsx
+++ b/app/myca/nlm/page.tsx
@@ -91,7 +91,7 @@ export default function NLMPage() {
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
               <div>
                 <div className="flex flex-wrap items-center gap-2 mb-2">
-                  <Badge variant="outline" className="bg-purple-500/20 border-purple-500/50 text-purple-700 dark:text-purple-300">
+                  <Badge variant="outline" className="bg-purple-500/20 border-purple-500/50 text-purple-700 dark:text-purple-700 dark:text-purple-300">
                     <Sparkles className="h-3 w-3 mr-1" /> Foundation Model
                   </Badge>
                   <Badge variant="outline" className="bg-green-500/20 border-green-500/50 text-green-700 dark:text-green-300">
@@ -277,7 +277,7 @@ export default function NLMPage() {
           <section>
             <Card>
               <CardHeader><CardTitle className="text-xl">Abstract</CardTitle></CardHeader>
-              <CardContent className="prose prose-invert max-w-none space-y-3">
+              <CardContent className="prose dark:prose-invert max-w-none space-y-3">
                 <p>
                   The <strong>Nature Learning Model (NLM)</strong> is a proposed class of multi-modal foundation models that learn the
                   <strong> information-bearing signals of living and non-living Earth systems</strong> and translate them into
@@ -408,10 +408,10 @@ export default function NLMPage() {
               <CardContent className="space-y-3">
                 <p className="text-sm text-muted-foreground">Rather than claiming literal semantics, NLM defines bio-tokens as learned motifs over multi-channel windows.</p>
                 <div className="space-y-2">
-                  <div className="p-3 bg-purple-500/10 rounded-lg border border-purple-500/20"><h4 className="font-medium text-sm text-purple-300">Level 0: Spike Primitives</h4><p className="text-xs text-muted-foreground mt-1">Basic electrical impulse patterns detected in mycelium</p></div>
-                  <div className="p-3 bg-purple-500/10 rounded-lg border border-purple-500/20"><h4 className="font-medium text-sm text-purple-300">Level 1: Burst &quot;Phrases&quot;</h4><p className="text-xs text-muted-foreground mt-1">Grouped spike patterns forming coherent signal units</p></div>
-                  <div className="p-3 bg-purple-500/10 rounded-lg border border-purple-500/20"><h4 className="font-medium text-sm text-purple-300">Level 2: State Transitions</h4><p className="text-xs text-muted-foreground mt-1">&quot;Messages&quot; as observable state change events</p></div>
-                  <div className="p-3 bg-purple-500/10 rounded-lg border border-purple-500/20"><h4 className="font-medium text-sm text-purple-300">Level 3: Ecosystem Dialogues</h4><p className="text-xs text-muted-foreground mt-1">Cross-organism signal correlation patterns spanning multiple species and environmental contexts</p></div>
+                  <div className="p-3 bg-purple-500/10 rounded-lg border border-purple-500/20"><h4 className="font-medium text-sm text-purple-700 dark:text-purple-300">Level 0: Spike Primitives</h4><p className="text-xs text-muted-foreground mt-1">Basic electrical impulse patterns detected in mycelium</p></div>
+                  <div className="p-3 bg-purple-500/10 rounded-lg border border-purple-500/20"><h4 className="font-medium text-sm text-purple-700 dark:text-purple-300">Level 1: Burst &quot;Phrases&quot;</h4><p className="text-xs text-muted-foreground mt-1">Grouped spike patterns forming coherent signal units</p></div>
+                  <div className="p-3 bg-purple-500/10 rounded-lg border border-purple-500/20"><h4 className="font-medium text-sm text-purple-700 dark:text-purple-300">Level 2: State Transitions</h4><p className="text-xs text-muted-foreground mt-1">&quot;Messages&quot; as observable state change events</p></div>
+                  <div className="p-3 bg-purple-500/10 rounded-lg border border-purple-500/20"><h4 className="font-medium text-sm text-purple-700 dark:text-purple-300">Level 3: Ecosystem Dialogues</h4><p className="text-xs text-muted-foreground mt-1">Cross-organism signal correlation patterns spanning multiple species and environmental contexts</p></div>
                 </div>
               </CardContent>
             </Card>

--- a/components/ui/neuromorphic/neuromorphic-styles.css
+++ b/components/ui/neuromorphic/neuromorphic-styles.css
@@ -5,9 +5,9 @@
  */
 
 .neuromorphic-page {
-  --neu-bg-primary: #e6e9ef;
-  --neu-bg-secondary: #d1d5db;
-  --neu-shadow-dark: #b8bcc2;
+  --neu-bg-primary: #f0f2f7;
+  --neu-bg-secondary: #e2e6ed;
+  --neu-shadow-dark: #c8ccd4;
   --neu-shadow-light: #ffffff;
   --neu-primary: #7c3aed;
   --neu-primary-dark: #6d28d9;
@@ -16,10 +16,10 @@
 }
 
 .neuromorphic-page.neuromorphic-dark {
-  --neu-bg-primary: #374151;
-  --neu-bg-secondary: #1f2937;
-  --neu-shadow-dark: #111827;
-  --neu-shadow-light: #4b5563;
+  --neu-bg-primary: #1a2030;
+  --neu-bg-secondary: #141a27;
+  --neu-shadow-dark: #0d1117;
+  --neu-shadow-light: #243045;
 }
 
 .neuromorphic-page {
@@ -27,7 +27,7 @@
   background: linear-gradient(145deg, var(--neu-bg-primary), var(--neu-bg-secondary));
   min-height: 100%;
   transition: background 0.5s ease;
-  color: #374151;
+  color: #1f2937;
 }
 
 .neuromorphic-page.neuromorphic-dark {
@@ -1111,6 +1111,119 @@
 /* Suggested prompts pills, agent chips (LiveDemo) */
 .neuromorphic-page.neuromorphic-dark .myca-page .rounded-lg[class*="bg-muted"] {
   background-color: #374151 !important;
+}
+
+/* ─── NLM page: ensure Cards, text, and prose are readable in both modes ─── */
+
+/* Light mode: Shadcn Cards on the NLM page need opaque light bg for contrast */
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] {
+  background-color: rgba(255, 255, 255, 0.75) !important;
+  backdrop-filter: blur(4px);
+}
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] h1,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] h2,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] h3,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] h4,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] p,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] span,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] li,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] td,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] th,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] label {
+  color: #1f2937;
+}
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] .text-muted-foreground,
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card"] [class*="text-muted"] {
+  color: #4b5563 !important;
+}
+.neuromorphic-page:not(.neuromorphic-dark) [data-slot="card-description"] {
+  color: #4b5563 !important;
+}
+/* Light mode: section headings outside cards */
+.neuromorphic-page:not(.neuromorphic-dark) h1,
+.neuromorphic-page:not(.neuromorphic-dark) h2,
+.neuromorphic-page:not(.neuromorphic-dark) h3 {
+  color: #111827;
+}
+.neuromorphic-page:not(.neuromorphic-dark) .text-muted-foreground {
+  color: #4b5563 !important;
+}
+/* Light mode: prose sections */
+.neuromorphic-page:not(.neuromorphic-dark) .prose {
+  color: #1f2937 !important;
+}
+.neuromorphic-page:not(.neuromorphic-dark) .prose strong {
+  color: #111827 !important;
+}
+.neuromorphic-page:not(.neuromorphic-dark) .prose p {
+  color: #1f2937 !important;
+}
+
+/* Dark mode: Shadcn Cards on the NLM page need proper dark bg */
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] {
+  background-color: rgba(20, 26, 39, 0.85) !important;
+  border-color: #2a3345 !important;
+  backdrop-filter: blur(4px);
+}
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] h1,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] h2,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] h3,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] h4,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] label {
+  color: #f3f4f6 !important;
+}
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] p,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] span,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] li,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] td,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] th {
+  color: #e5e7eb !important;
+}
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] .text-muted-foreground,
+.neuromorphic-page.neuromorphic-dark [data-slot="card"] [class*="text-muted"] {
+  color: #9ca3af !important;
+}
+.neuromorphic-page.neuromorphic-dark [data-slot="card-description"] {
+  color: #9ca3af !important;
+}
+/* Dark mode: section headings outside cards */
+.neuromorphic-page.neuromorphic-dark h1,
+.neuromorphic-page.neuromorphic-dark h2,
+.neuromorphic-page.neuromorphic-dark h3 {
+  color: #f3f4f6;
+}
+/* Dark mode: prose sections */
+.neuromorphic-page.neuromorphic-dark .prose {
+  color: #e5e7eb !important;
+}
+.neuromorphic-page.neuromorphic-dark .prose strong {
+  color: #f3f4f6 !important;
+}
+.neuromorphic-page.neuromorphic-dark .prose p {
+  color: #e5e7eb !important;
+}
+/* Dark mode: bg-background inside cards */
+.neuromorphic-page.neuromorphic-dark .bg-background {
+  background-color: #111827 !important;
+}
+/* Dark mode: NeuCard raised elements */
+.neuromorphic-page.neuromorphic-dark .neu-raised h1,
+.neuromorphic-page.neuromorphic-dark .neu-raised h2,
+.neuromorphic-page.neuromorphic-dark .neu-raised h3,
+.neuromorphic-page.neuromorphic-dark .neu-raised h4 {
+  color: #f3f4f6 !important;
+}
+.neuromorphic-page.neuromorphic-dark .neu-raised p,
+.neuromorphic-page.neuromorphic-dark .neu-raised span,
+.neuromorphic-page.neuromorphic-dark .neu-raised li {
+  color: #e5e7eb !important;
+}
+.neuromorphic-page.neuromorphic-dark .neu-raised .text-muted-foreground {
+  color: #9ca3af !important;
+}
+/* Light mode: NeuCard raised text */
+.neuromorphic-page:not(.neuromorphic-dark) .neu-raised .text-muted-foreground {
+  color: #4b5563 !important;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
- Dark mode: darken backgrounds from mid-gray (#374151) to proper dark (#1a2030)
  so light text has strong contrast
- Light mode: lighten backgrounds from #e6e9ef to #f0f2f7 and darken base text
  from #374151 to #1f2937 for better readability
- Add Card-level overrides ensuring Shadcn Cards get opaque backgrounds and
  proper text colors in both modes
- Fix prose-invert (always white text) → dark:prose-invert (theme-aware)
- Fix hardcoded text-purple-300 → text-purple-700 dark:text-purple-300

https://claude.ai/code/session_011YZwGNswgYcERPRjFnq3kA

## Summary by Sourcery

Improve NLM neuromorphic page readability and contrast in both light and dark modes, especially for cards, headings, and prose content.

Bug Fixes:
- Correct theme-aware prose styling by replacing always-on inverted prose with dark-mode-only inversion.
- Fix purple text color usage so headings and badges use darker purple in light mode while retaining light purple in dark mode for proper contrast.

Enhancements:
- Adjust neuromorphic light and dark background and text colors to increase contrast and readability.
- Add NLM-page-specific overrides to give Shadcn Cards opaque, theme-appropriate backgrounds and text colors in both light and dark modes.
- Refine text-muted and raised neuromorphic card text colors for clearer hierarchy across themes.