### PR TITLE
fix: ground station system — 7 critical bugs preventing map display

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -210,6 +210,7 @@ import { EntityDeckLayer } from "@/components/crep/layers/deck-entity-layer";
 import { EntityStreamClient } from "@/lib/crep/streaming/entity-websocket-client";
 import type { UnifiedEntity } from "@/lib/crep/entities/unified-entity-schema";
 import { getOrbitPath } from "@/lib/crep/orbit-path";
+import { useGroundStation } from "@/lib/ground-station/context";
 
 // Phase 2-6: New CREP layers and panels
 const GibsBaseLayers = dynamic(() => import("@/components/crep/layers/gibs-base-layers"), { ssr: false });
@@ -1711,7 +1712,7 @@ export default function CREPDashboardPage() {
   const [showPresenceWidget, setShowPresenceWidget] = useState(false);
 
   // Ground Station overlay state (Mar 2026)
-  const [showGroundStation, setShowGroundStation] = useState(false);
+  const [showGroundStation, setShowGroundStation] = useState(true); // Enabled by default — ground station is core CREP functionality
 
   
   // Selected entity states for map interaction
@@ -1857,7 +1858,8 @@ export default function CREPDashboardPage() {
   const [currentMission, setCurrentMission] = useState<MissionContext | null>(null);
   const [showMissionPrompt, setShowMissionPrompt] = useState(false);
 
-  // Ground Station UI handled via components using GroundStationProvider context
+  // Ground Station — consume context to render satellite positions + station on map
+  const { state: gsState } = useGroundStation();
 
   // Check for existing mission in localStorage on mount
   useEffect(() => {
@@ -4533,6 +4535,46 @@ export default function CREPDashboardPage() {
               </MapMarker>
             )}
           </MapComponent>
+
+          {/* Ground Station Location Marker */}
+          {showGroundStation && gsState.activeLocation && (
+            <MapMarker
+              latitude={gsState.activeLocation.lat}
+              longitude={gsState.activeLocation.lon || gsState.activeLocation.lng || 0}
+            >
+              <MarkerContent>
+                <div className="w-6 h-6 rounded-full bg-cyan-500/30 border-2 border-cyan-400 flex items-center justify-center animate-pulse" title={`Ground Station: ${gsState.activeLocation.name || "Active"}`}>
+                  <Radio className="w-3 h-3 text-cyan-300" />
+                </div>
+              </MarkerContent>
+            </MapMarker>
+          )}
+
+          {/* Ground Station Tracked Satellite Positions */}
+          {showGroundStation && Object.values(gsState.positions).map((pos) => {
+            if (!pos.lat || !pos.lon) return null;
+            const sat = gsState.satellites.find(s => s.norad_id === pos.norad_id);
+            const isTracking = gsState.trackingState?.norad_id === pos.norad_id;
+            return (
+              <MapMarker key={`gs-sat-${pos.norad_id}`} latitude={pos.lat} longitude={pos.lon}>
+                <MarkerContent>
+                  <div
+                    className={cn(
+                      "w-4 h-4 rounded-full flex items-center justify-center text-[8px] border",
+                      isTracking
+                        ? "bg-green-500/40 border-green-400 text-green-300 animate-pulse"
+                        : pos.is_visible
+                        ? "bg-cyan-500/30 border-cyan-400/60 text-cyan-300"
+                        : "bg-gray-500/20 border-gray-500/40 text-gray-400"
+                    )}
+                    title={`${sat?.name || `NORAD ${pos.norad_id}`} — Alt: ${pos.alt?.toFixed(0)}km, Az: ${pos.az?.toFixed(1)}°, El: ${pos.el?.toFixed(1)}°`}
+                  >
+                    <Satellite className="w-2.5 h-2.5" />
+                  </div>
+                </MarkerContent>
+              </MapMarker>
+            );
+          })}
 
           {/* Infrastructure Markers from Overpass API */}
           {infraFeatures.map((feat) => (

--- a/components/crep/ground-station/GSOverlayPanel.tsx
+++ b/components/crep/ground-station/GSOverlayPanel.tsx
@@ -59,7 +59,7 @@ export function GSOverlayPanel({
 
   const { state, selectGroup, selectSatellite, trackSatellite, stopTracking } = useGroundStation()
 
-  const connected = state.systemStatus === "connected"
+  const connected = state.connected // was state.systemStatus which doesn't exist
   const groups = state.groups.map(g => ({ id: g.id, name: g.name, satellite_count: g.satellite_ids?.length || 0 }))
   const selectedGroupId = state.selectedGroupId
   const satellites = state.satellites.map(sat => {
@@ -77,10 +77,11 @@ export function GSOverlayPanel({
     }
   })
   const trackingNoradId = state.trackingState?.norad_id
+  // Hardware state comes from separate arrays, not a single hardware object
   const hardwareStatus = {
-    rotator_connected: state.hardware.rotator?.status === "connected",
-    rig_connected: state.hardware.rig?.status === "connected",
-    sdr_connected: state.hardware.sdr?.status === "connected",
+    rotator_connected: (state.rotators?.length ?? 0) > 0 && state.rotators[0]?.status === "connected",
+    rig_connected: (state.rigs?.length ?? 0) > 0 && state.rigs[0]?.status === "connected",
+    sdr_connected: (state.sdrs?.length ?? 0) > 0 && state.sdrs[0]?.status === "connected",
   }
   const passCount = state.passes.length
   const nextPassTime = state.passes[0]?.aos_time

--- a/lib/ground-station/context.tsx
+++ b/lib/ground-station/context.tsx
@@ -325,15 +325,42 @@ export function GroundStationProvider({ children }: { children: React.ReactNode 
   // Initial data load
   useEffect(() => {
     checkConnection()
+
+    // Load locations and auto-select first one
+    const loadLocations = async () => {
+      try {
+        const res = await fetch("/api/ground-station/system?action=locations")
+        if (res.ok) {
+          const data = await res.json()
+          const locs: GSLocation[] = Array.isArray(data) ? data : data.locations || []
+          const active = locs.length > 0 ? locs[0] : null
+          dispatch({ type: "SET_LOCATIONS", locations: locs, active: active || undefined })
+          if (active) {
+            console.log(`[GS] Auto-selected location: ${active.name || "default"} (${active.lat}, ${active.lon})`)
+          }
+        }
+      } catch (e) {
+        console.warn("[GS] Failed to load locations:", e)
+      }
+    }
+    loadLocations()
+
+    // Load groups and auto-select first one
     const loadGroups = async () => {
       try {
         const res = await fetch("/api/ground-station/groups")
         if (res.ok) {
           const data = await res.json()
-          dispatch({ type: "SET_GROUPS", groups: Array.isArray(data) ? data : data.groups || [] })
+          const groups: GSGroup[] = Array.isArray(data) ? data : data.groups || []
+          dispatch({ type: "SET_GROUPS", groups })
+          // Auto-select first group so satellites load immediately
+          if (groups.length > 0 && !state.selectedGroupId) {
+            dispatch({ type: "SELECT_GROUP", groupId: groups[0].id })
+            console.log(`[GS] Auto-selected group: ${groups[0].name}`)
+          }
         }
-      } catch {
-        // silent
+      } catch (e) {
+        console.warn("[GS] Failed to load groups:", e)
       }
     }
     loadGroups()
@@ -431,7 +458,7 @@ export function GroundStationProvider({ children }: { children: React.ReactNode 
             }
           }
         } catch (e) {
-          // ignore parse errors
+          console.warn(`[GS] TLE propagation error for ${sat.name} (NORAD ${sat.norad_id}):`, (e as Error).message)
         }
       }
 


### PR DESCRIPTION
1. GSOverlayPanel: state.systemStatus → state.connected (property didn't exist)
2. GSOverlayPanel: state.hardware.rotator → state.rotators[0] (hardware is stored as separate arrays, not a single object — was crashing with "Cannot read property 'rotator' of undefined")
3. Context: auto-select first location on load (was never initialized, causing all satellite positions to compute relative to 0,0)
4. Context: auto-select first satellite group on load (no satellites loaded without manual group selection)
5. Context: add error logging to TLE propagation catch block (was silently swallowing all errors, making debugging impossible)
6. Dashboard: showGroundStation defaults to true (was false — GS never rendered even when everything else worked)
7. Dashboard: render GS satellite positions + station location on the map (GSOverlayPanel only showed a sidebar list — zero markers on the actual map). Now shows:
   - Cyan pulsing marker for active ground station location
   - Satellite position markers colored by visibility/tracking state
   - Tooltip with name, altitude, azimuth, elevation

## Summary by Sourcery

Enable and visualise ground station functionality on the CREP dashboard map while improving ground station context initialization and diagnostics.

New Features:
- Render the active ground station location and tracked satellite positions as markers on the CREP dashboard map, including visibility-based styling and tooltips.

Bug Fixes:
- Fix ground station overlay connection status and hardware connection checks to use the correct context state shape.
- Automatically select an initial ground station location and satellite group so satellites and positions load without manual user selection.

Enhancements:
- Default the ground station overlay to be visible on the dashboard as part of core CREP functionality.
- Add logging for ground station group loading and TLE propagation errors to aid debugging.