### PR TITLE
fix: remove hallucinated position animations — use real API data only

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -1120,6 +1120,10 @@ function DeviceMarker({ device, isSelected, onClick }: {
 }
 
 // Human & Machines Baseline Data
+// STATIC REFERENCE ESTIMATES — not live data. These are approximate global totals
+// sourced from public statistics (World Bank, ICAO, IMO, FAA, IEA). The "active"
+// counters below use random jitter to simulate variation but are NOT real-time feeds.
+// TODO: Replace with real API data (WorldPop, FlightAware stats, IMO/AIS global count).
 const HUMAN_MACHINE_DATA = {
   population: { total: 8_123_456_789, birthsPerSec: 4.3, deathsPerSec: 1.8 },
   vehicles: { total: 1_446_000_000, active: 312_000_000, co2PerDay: 18_500_000 },
@@ -1737,7 +1741,7 @@ export default function CREPDashboardPage() {
   // Position extrapolation so planes/vessels/satellites move smoothly between API fetches
   const [extrapolatedCoords, setExtrapolatedCoords] = useState<Record<string, [number, number]>>({});
   const lastKnownRef = useRef<Record<string, { lng: number; lat: number; velLng: number; velLat: number; ts: number }>>({});
-  const MAX_EXTRAPOLATION_MS = 60000; // cap at 60s so we don't drift forever
+  const MAX_EXTRAPOLATION_MS = 30000; // cap at 30s — positions older than this use API data directly
   
   // Space weather state for NOAA scales
   const [noaaScales, setNoaaScales] = useState<NOAAScales>({ radio: 0, solar: 0, geomag: 0 });
@@ -3464,20 +3468,11 @@ export default function CREPDashboardPage() {
         const degPerSec = velKmS / 111; // ~111 km per degree at equator
         const velLng = Math.sin(h) * degPerSec;
         const velLat = Math.cos(h) * degPerSec;
-        const prev = lastKnownRef.current[s.id];
-        // Only accept new position if we don't have one yet, or if API position is ahead along velocity (avoids resetting to short segment)
-        let lng = apiLng;
-        let lat = apiLat;
-        if (prev) {
-          const dot = (apiLng - prev.lng) * prev.velLng + (apiLat - prev.lat) * prev.velLat;
-          if (dot < 0) {
-            lng = prev.lng;
-            lat = prev.lat;
-          }
-        }
+        // ALWAYS accept the API position — never reject corrections
+        // (was: velocity-lock rejected API positions behind the velocity vector, causing stale data)
         next[s.id] = {
-          lng,
-          lat,
+          lng: apiLng,
+          lat: apiLat,
           velLng,
           velLat,
           ts: now,

--- a/components/crep/markers/aircraft-marker.tsx
+++ b/components/crep/markers/aircraft-marker.tsx
@@ -83,40 +83,11 @@ export function AircraftMarker({ aircraft, isSelected = false, onClick, onClose 
     }
   }, [baseLongitude, baseLatitude, hasValidCoords]);
   
-  // Animate position based on velocity and heading
-  useEffect(() => {
-    if (!hasValidCoords) return;
-    if (!aircraft.velocity || !aircraft.heading || aircraft.onGround) {
-      return; // Don't animate if no velocity/heading or on ground
-    }
-    
-    const velocityKnots = aircraft.velocity;
-    const headingDeg = aircraft.heading;
-    
-    // Convert heading to radians
-    const headingRad = (headingDeg * Math.PI) / 180;
-    
-    // Calculate speed in degrees per second (approximate)
-    const speedDegPerSecond = (velocityKnots / 3600) / 60;
-    
-    const animate = () => {
-      const elapsed = (Date.now() - animationStartTime.current) / 1000; // seconds
-      
-      // Calculate displacement
-      const dLon = Math.sin(headingRad) * speedDegPerSecond * elapsed;
-      const dLat = Math.cos(headingRad) * speedDegPerSecond * elapsed;
-      
-      setAnimatedPosition({
-        longitude: (baseLongitude ?? 0) + dLon,
-        latitude: (baseLatitude ?? 0) + dLat
-      });
-    };
-    
-    const intervalId = setInterval(animate, ANIMATION_INTERVAL_MS);
-    animate(); // Run immediately
-    
-    return () => clearInterval(intervalId);
-  }, [baseLongitude, baseLatitude, aircraft.velocity, aircraft.heading, aircraft.onGround, hasValidCoords]);
+  // NO component-level position animation — use real positions only.
+  // The dashboard's extrapolation engine (CREPDashboardClient.tsx) already handles
+  // smooth position interpolation between API refreshes using velocity vectors.
+  // Adding a SECOND extrapolation layer here caused 2x position drift.
+  // The animatedPosition state is kept in sync via the reset effect above.
   
   // Compute derived values unconditionally
   const altitudeColor = getAltitudeColor(aircraft.altitude ?? null);

--- a/components/crep/markers/satellite-marker.tsx
+++ b/components/crep/markers/satellite-marker.tsx
@@ -88,49 +88,12 @@ export function SatelliteMarker({ satellite, isSelected = false, onClick, onClos
     }
   }, [baseLng, baseLat, isValidCoordinates]);
   
-  // Animate satellite position based on orbital period
-  useEffect(() => {
-    if (!isValidCoordinates) return;
-    
-    // Calculate orbital velocity from period or use default for LEO
-    const periodMinutes = satellite?.orbitalParams?.period || 90;
-    
-    // Angular velocity in degrees per second
-    const angularVelocityDegPerSec = 360 / (periodMinutes * 60);
-    
-    // Inclination for latitude oscillation
-    const inclination = satellite?.orbitalParams?.inclination || 45;
-    
-    const animate = () => {
-      const elapsed = (Date.now() - animationStartTime.current) / 1000;
-      
-      // Calculate longitude displacement
-      const dLon = angularVelocityDegPerSec * elapsed;
-      
-      // Calculate latitude oscillation
-      const oscillationPeriod = periodMinutes * 60;
-      const phase = (elapsed / oscillationPeriod) * 2 * Math.PI;
-      const dLat = Math.sin(phase) * inclination * 0.1;
-      
-      // Wrap longitude
-      let newLng = baseLng + dLon;
-      while (newLng > 180) newLng -= 360;
-      while (newLng < -180) newLng += 360;
-      
-      // Clamp latitude
-      const newLat = Math.max(-85, Math.min(85, baseLat + dLat));
-      
-      setAnimatedPosition({
-        lng: newLng,
-        lat: newLat
-      });
-    };
-    
-    const intervalId = setInterval(animate, ANIMATION_INTERVAL_MS);
-    animate();
-    
-    return () => clearInterval(intervalId);
-  }, [baseLng, baseLat, satellite?.orbitalParams?.period, satellite?.orbitalParams?.inclination, isValidCoordinates]);
+  // NO client-side orbital animation — use real positions from API/extrapolation only.
+  // Previously this used a simplified sinusoidal model with default values (90min period,
+  // 45° inclination) which produced hallucinated positions. Real satellite positions come
+  // from the dashboard's extrapolation engine (CelesTrak TLE data + velocity vectors) or
+  // the ground station's SGP4 propagation via satellite.js.
+  // The animatedPosition state is kept in sync via the reset effect above.
   
   // EARLY RETURNS AFTER ALL HOOKS
   if (!satellite || !isValidCoordinates) {

--- a/lib/crep/orbit-path.ts
+++ b/lib/crep/orbit-path.ts
@@ -1,9 +1,14 @@
 /**
  * Full-orbit ground track for satellites – Feb 18, 2026
  *
- * Computes a closed ground-track path (wraps around the planet) from
- * orbital period, inclination, and current position. Used for satellite
- * trajectory lines so the line is the full orbit, not a short segment.
+ * APPROXIMATE visualization-only ground track from orbital period and inclination.
+ * This is a simplified circular-orbit model for rendering trajectory LINES on the map.
+ * It does NOT compute actual satellite positions — those come from:
+ * - CelesTrak TLE data + velocity extrapolation (dashboard)
+ * - satellite.js SGP4 propagation (ground station context)
+ *
+ * Limitations: assumes circular orbit, no precession/drag/perturbations.
+ * Earth rotation rate: 0.25°/min (15°/hr) — simplified constant.
  */
 
 const TWO_PI = 2 * Math.PI;


### PR DESCRIPTION
Critical accuracy fixes for entity positions on the CREP map:

1. VELOCITY LOCK REMOVED: Satellite position sync previously rejected API corrections that conflicted with the velocity vector direction (dot product check). This caused positions to "lock" to stale data for up to 60 seconds. Now ALWAYS accepts the latest API position.

2. DOUBLE-EXTRAPOLATION REMOVED (aircraft): The aircraft marker had its own position extrapolation (velocity * elapsed) ON TOP of the dashboard's extrapolation engine, causing 2x position drift. Removed the component-level animation — the dashboard extrapolation is the single source of truth.

3. FAKE ORBITAL ANIMATION REMOVED (satellite): The satellite marker generated hallucinated orbital motion using a simplified sinusoidal model with default values (90min period, 45° inclination) when real orbital params were missing. This produced completely wrong positions. Now uses only real data from CelesTrak TLE + velocity extrapolation or the ground station's SGP4 propagation.

4. EXTRAPOLATION CAP REDUCED: 60s → 30s to limit drift accumulation.

5. orbit-path.ts: Added clear documentation that this is an APPROXIMATE visualization model for ground track lines only, not for actual satellite position computation.

6. HUMAN_MACHINE_DATA: Marked as static reference estimates (not live) with TODO to replace with real API feeds.

## Summary by Sourcery

Ensure CREP map entity positions rely solely on authoritative API/extrapolation data and clarify that certain visualizations and counters are approximate only.

Bug Fixes:
- Remove client-side orbital animation for satellite markers so their positions reflect only real extrapolated/propagated data.
- Remove component-level velocity-based animation for aircraft markers to eliminate duplicate extrapolation and drift.
- Always accept latest API satellite positions in the extrapolation engine instead of rejecting corrections based on velocity direction, preventing stale locked positions.
- Reduce the maximum extrapolation window from 60s to 30s to limit positional drift when API updates are delayed.

Enhancements:
- Clarify orbit-path ground track utilities as approximate, visualization-only models and not sources of actual satellite positions.
- Document HUMAN_MACHINE_DATA as static reference estimates with a note to replace them with real API-backed data in the future.