### PR TITLE
feat: NLM training page — replace mock data with real API integration

### DIFF
--- a/app/api/natureos/nlm-training/route.ts
+++ b/app/api/natureos/nlm-training/route.ts
@@ -1,0 +1,393 @@
+/**
+ * NLM Training API Route
+ *
+ * Proxies to MAS NLM + GPU Node APIs for real model training control.
+ *
+ * GET  - Fetch training status, model info, device fleet, GPU metrics
+ * POST - Start/stop/pause training, save checkpoints, run inference
+ *
+ * NO MOCK DATA — returns real backend data or error if unavailable.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+
+const MAS_API_URL = process.env.MAS_API_URL || "http://192.168.0.188:8001"
+const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://192.168.0.189:8000"
+
+async function safeFetch(url: string, options?: RequestInit & { timeout?: number }) {
+  const timeout = options?.timeout ?? 8000
+  try {
+    const res = await fetch(url, {
+      ...options,
+      signal: AbortSignal.timeout(timeout),
+      cache: "no-store",
+    })
+    if (!res.ok) return null
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+
+// GET: Aggregate training dashboard data from real backends
+export async function GET(request: NextRequest) {
+  const section = request.nextUrl.searchParams.get("section") || "all"
+
+  try {
+    // Parallel fetch from all real backends
+    const [
+      nlmHealth,
+      nlmStatus,
+      nlmModelInfo,
+      nlmConfig,
+      gpuStatus,
+      devices,
+      networkDevices,
+      trainingRuns,
+      checkpoints,
+      dataStats,
+    ] = await Promise.all([
+      safeFetch(`${MAS_API_URL}/api/nlm/health`),
+      safeFetch(`${MAS_API_URL}/api/nlm/model/status`),
+      safeFetch(`${MAS_API_URL}/api/nlm/model/info`),
+      safeFetch(`${MAS_API_URL}/api/nlm/training/config`),
+      safeFetch(`${MAS_API_URL}/api/gpu-node/status`),
+      safeFetch(`${MAS_API_URL}/api/mycobrain/devices`),
+      safeFetch(`${MAS_API_URL}/api/devices`),
+      safeFetch(`${MAS_API_URL}/api/nlm/training/runs`),
+      safeFetch(`${MAS_API_URL}/api/nlm/training/checkpoints`),
+      safeFetch(`${MINDEX_API_URL}/api/mindex/internal/stats`),
+    ])
+
+    // Merge device lists from MycoBrain + MAS Device Registry
+    const mycoBrainDevices = (devices?.devices || []).map((d: any) => ({
+      ...d,
+      source: "mycobrain",
+    }))
+    const masDevices = (networkDevices?.devices || []).map((d: any) => ({
+      ...d,
+      source: "mas-registry",
+    }))
+    // Deduplicate by device_id
+    const allDeviceMap = new Map<string, any>()
+    for (const d of [...mycoBrainDevices, ...masDevices]) {
+      const key = d.device_id || d.id
+      if (key && !allDeviceMap.has(key)) allDeviceMap.set(key, d)
+    }
+    const allDevices = Array.from(allDeviceMap.values())
+
+    // Parse GPU metrics
+    const gpuMetrics = gpuStatus?.gpu
+      ? {
+          name: gpuStatus.gpu.name,
+          memoryUsed: gpuStatus.gpu.memory_used_mb,
+          memoryTotal: gpuStatus.gpu.memory_total_mb,
+          memoryPercent: gpuStatus.gpu.memory_percent,
+          utilization: gpuStatus.gpu.utilization_percent,
+          temperature: gpuStatus.gpu.temperature_c,
+          powerDraw: gpuStatus.gpu.power_draw_w,
+        }
+      : null
+
+    // Build training state from real backend data
+    const activeRun = trainingRuns?.runs?.find(
+      (r: any) => r.status === "training" || r.status === "paused"
+    )
+
+    const trainingState = activeRun
+      ? {
+          status: activeRun.status,
+          runId: activeRun.run_id,
+          epoch: activeRun.current_epoch || 0,
+          totalEpochs: activeRun.total_epochs || 0,
+          loss: activeRun.metrics?.loss ?? null,
+          accuracy: activeRun.metrics?.accuracy ?? null,
+          learningRate: activeRun.config?.learning_rate ?? null,
+          samplesProcessed: activeRun.metrics?.samples_processed ?? 0,
+          gradientNorm: activeRun.metrics?.gradient_norm ?? null,
+          elapsedTime: activeRun.metrics?.elapsed_seconds ?? 0,
+          startedAt: activeRun.started_at,
+          lossHistory: activeRun.metrics?.loss_history ?? [],
+          accuracyHistory: activeRun.metrics?.accuracy_history ?? [],
+        }
+      : {
+          status: "idle",
+          runId: null,
+          epoch: 0,
+          totalEpochs: 0,
+          loss: null,
+          accuracy: null,
+          learningRate: null,
+          samplesProcessed: 0,
+          gradientNorm: null,
+          elapsedTime: 0,
+          startedAt: null,
+          lossHistory: [],
+          accuracyHistory: [],
+        }
+
+    // NLM model config (real architecture params)
+    const modelConfig = nlmConfig || nlmModelInfo
+    const architecture = modelConfig
+      ? {
+          baseModel: modelConfig.base_model || modelConfig.architecture?.base_model || null,
+          hiddenSize: modelConfig.architecture?.hidden_size || modelConfig.hidden_size || null,
+          numLayers: modelConfig.architecture?.num_hidden_layers || modelConfig.num_layers || null,
+          numAttentionHeads:
+            modelConfig.architecture?.num_attention_heads || modelConfig.attention_heads || null,
+          vocabSize: modelConfig.architecture?.vocab_size || null,
+          maxPositionEmbeddings:
+            modelConfig.architecture?.max_position_embeddings || null,
+          useLora: modelConfig.architecture?.use_lora ?? null,
+          loraR: modelConfig.architecture?.lora_r || null,
+          loraAlpha: modelConfig.architecture?.lora_alpha || null,
+        }
+      : null
+
+    const hyperparameters = nlmConfig?.training || null
+
+    return NextResponse.json({
+      training: trainingState,
+      model: {
+        health: nlmHealth,
+        info: nlmModelInfo,
+        architecture,
+        hyperparameters,
+      },
+      gpu: gpuMetrics,
+      gpuContainers: gpuStatus?.containers || [],
+      devices: allDevices,
+      deviceCount: allDevices.length,
+      checkpoints: checkpoints?.checkpoints || [],
+      dataStats: dataStats || null,
+      connections: {
+        mas: nlmHealth !== null,
+        mindex: dataStats !== null,
+        gpu: gpuMetrics !== null,
+        mycobrain: mycoBrainDevices.length > 0,
+      },
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error("NLM Training API error:", error)
+    return NextResponse.json(
+      {
+        error: "Failed to fetch training dashboard data",
+        message: error instanceof Error ? error.message : "Unknown error",
+        connections: { mas: false, mindex: false, gpu: false, mycobrain: false },
+      },
+      { status: 503 }
+    )
+  }
+}
+
+// POST: Training control actions
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { action, ...params } = body
+
+    switch (action) {
+      case "start": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/training/start`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            learning_rate: params.learningRate,
+            batch_size: params.batchSize,
+            epochs: params.epochs,
+            warmup_steps: params.warmupSteps,
+            weight_decay: params.weightDecay,
+            dropout: params.dropout,
+            optimizer: params.optimizer,
+            scheduler: params.scheduler,
+            grad_clip: params.gradClip,
+            attention_heads: params.attentionHeads,
+            hidden_dim: params.hiddenDim,
+            num_layers: params.numLayers,
+            categories: params.categories,
+            resume_from: params.resumeFrom,
+          }),
+          signal: AbortSignal.timeout(30000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Failed to start training", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      case "stop": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/training/stop`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ run_id: params.runId }),
+          signal: AbortSignal.timeout(15000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Failed to stop training", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      case "pause": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/training/pause`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ run_id: params.runId }),
+          signal: AbortSignal.timeout(15000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Failed to pause training", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      case "resume": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/training/resume`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ run_id: params.runId }),
+          signal: AbortSignal.timeout(15000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Failed to resume training", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      case "checkpoint": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/training/checkpoint`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            run_id: params.runId,
+            label: params.label,
+          }),
+          signal: AbortSignal.timeout(30000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Failed to save checkpoint", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      case "load_checkpoint": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/training/load`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ checkpoint_id: params.checkpointId }),
+          signal: AbortSignal.timeout(30000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Failed to load checkpoint", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      case "inference": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/predict`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            text: params.text,
+            query_type: params.queryType || "general",
+            max_tokens: params.maxTokens || 512,
+            temperature: params.temperature || 0.7,
+            context: params.context,
+          }),
+          signal: AbortSignal.timeout(30000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Inference failed", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      case "mutate": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/training/mutate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            run_id: params.runId,
+            mutation_type: params.mutationType,
+            target_layer: params.targetLayer,
+            magnitude: params.magnitude,
+          }),
+          signal: AbortSignal.timeout(15000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Mutation failed", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      case "export": {
+        const res = await fetch(`${MAS_API_URL}/api/nlm/training/export`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            run_id: params.runId,
+            checkpoint_id: params.checkpointId,
+            format: params.format || "gguf",
+          }),
+          signal: AbortSignal.timeout(60000),
+        })
+        if (!res.ok) {
+          const detail = await res.text()
+          return NextResponse.json(
+            { error: "Export failed", detail },
+            { status: res.status }
+          )
+        }
+        return NextResponse.json(await res.json())
+      }
+
+      default:
+        return NextResponse.json(
+          { error: `Unknown action: ${action}` },
+          { status: 400 }
+        )
+    }
+  } catch (error) {
+    console.error("NLM Training action error:", error)
+    return NextResponse.json(
+      {
+        error: "Training action failed",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/app/natureos/model-training/page.tsx
+++ b/app/natureos/model-training/page.tsx
@@ -9,47 +9,74 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Slider } from "@/components/ui/slider"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import {
   Brain, Activity, Zap, Database, Play, Pause, RefreshCw, Download, Network, Cpu, Layers,
   Target, ArrowRight, Sparkles, ChevronRight, GitBranch, Settings, Eye, BarChart3,
   Wifi, WifiOff, Server, HardDrive, Upload, CircleDot, Dna, Shuffle, TrendingUp,
   Save, RotateCcw, Square, SkipForward, AlertTriangle, CheckCircle2, Clock,
-  Maximize2, Minimize2, SlidersHorizontal, Box, Workflow, Monitor
+  Maximize2, Minimize2, SlidersHorizontal, Box, Workflow, Monitor, Loader2, XCircle
 } from "lucide-react"
 import Link from "next/link"
 import FungaNetwork3D from "@/components/visualizers/FungaNetwork3D"
+import { NlmDemo } from "./translator"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface DeviceNode {
-  id: string
-  name: string
-  type: "mycobrain" | "jetson" | "sporebase" | "myconode" | "alarm"
-  status: "online" | "offline" | "degraded"
-  dataRate: number // samples/sec
-  lastSeen: number
-  metrics: { temp?: number; humidity?: number; voltage?: number; gas?: number[] }
-}
-
-interface TrainingMetrics {
-  epoch: number
-  loss: number
-  accuracy: number
-  learningRate: number
-  samplesProcessed: number
-  batchesCompleted: number
-  elapsedTime: number
-  gradientNorm: number
-  memoryUsage: number
-}
-
-interface LayerViz {
-  name: string
-  type: "attention" | "ffn" | "embedding" | "norm" | "output"
-  neurons: number
-  activation: number[]
-  weights: { min: number; max: number; mean: number; std: number }
+interface DashboardData {
+  training: {
+    status: "idle" | "training" | "paused" | "evaluating"
+    runId: string | null
+    epoch: number
+    totalEpochs: number
+    loss: number | null
+    accuracy: number | null
+    learningRate: number | null
+    samplesProcessed: number
+    gradientNorm: number | null
+    elapsedTime: number
+    startedAt: string | null
+    lossHistory: number[]
+    accuracyHistory: number[]
+  }
+  model: {
+    health: { status: string; model_loaded: boolean; model_name: string; model_version: string } | null
+    info: any
+    architecture: {
+      baseModel: string | null
+      hiddenSize: number | null
+      numLayers: number | null
+      numAttentionHeads: number | null
+      vocabSize: number | null
+      maxPositionEmbeddings: number | null
+      useLora: boolean | null
+      loraR: number | null
+      loraAlpha: number | null
+    } | null
+    hyperparameters: any
+  }
+  gpu: {
+    name: string
+    memoryUsed: number
+    memoryTotal: number
+    memoryPercent: number
+    utilization: number
+    temperature: number
+    powerDraw: number
+  } | null
+  gpuContainers: any[]
+  devices: any[]
+  deviceCount: number
+  checkpoints: any[]
+  dataStats: any
+  connections: {
+    mas: boolean
+    mindex: boolean
+    gpu: boolean
+    mycobrain: boolean
+  }
+  timestamp: string
 }
 
 interface MutationEvent {
@@ -58,64 +85,30 @@ interface MutationEvent {
   type: "prune" | "grow" | "rewire" | "perturb" | "merge"
   target: string
   magnitude: number
-  impact: number // delta accuracy
-}
-
-// ─── Simulated State Generators ───────────────────────────────────────────────
-
-function generateDevices(): DeviceNode[] {
-  return [
-    { id: "mushroom-1", name: "Mushroom 1", type: "mycobrain", status: "online", dataRate: 128, lastSeen: Date.now(), metrics: { temp: 22.4, humidity: 87, voltage: 3.28, gas: [420, 12, 0.8, 340] } },
-    { id: "hyphae-1", name: "Hyphae 1 SporeBase", type: "sporebase", status: "online", dataRate: 256, lastSeen: Date.now(), metrics: { temp: 21.8, humidity: 92, voltage: 3.31 } },
-    { id: "myconode-1", name: "MycoNode Alpha", type: "myconode", status: "online", dataRate: 64, lastSeen: Date.now(), metrics: { temp: 23.1, humidity: 78 } },
-    { id: "alarm-1", name: "Alarm Sentinel", type: "alarm", status: "degraded", dataRate: 32, lastSeen: Date.now() - 15000, metrics: { voltage: 3.05 } },
-    { id: "jetson-edge-1", name: "Jetson Edge NLM-1", type: "jetson", status: "online", dataRate: 512, lastSeen: Date.now(), metrics: { temp: 48.2 } },
-    { id: "jetson-edge-2", name: "Jetson Edge NLM-2", type: "jetson", status: "online", dataRate: 480, lastSeen: Date.now(), metrics: { temp: 51.7 } },
-  ]
-}
-
-function generateLayers(): LayerViz[] {
-  const layers: LayerViz[] = [
-    { name: "Signal Embedding", type: "embedding", neurons: 512, activation: [], weights: { min: -0.42, max: 0.39, mean: 0.001, std: 0.12 } },
-  ]
-  for (let i = 0; i < 6; i++) {
-    layers.push({ name: `Attention Block ${i + 1}`, type: "attention", neurons: 512, activation: [], weights: { min: -0.35, max: 0.33, mean: 0.0, std: 0.08 } })
-    layers.push({ name: `FFN Block ${i + 1}`, type: "ffn", neurons: 2048, activation: [], weights: { min: -0.28, max: 0.31, mean: 0.002, std: 0.09 } })
-    layers.push({ name: `LayerNorm ${i + 1}`, type: "norm", neurons: 512, activation: [], weights: { min: 0.85, max: 1.15, mean: 1.0, std: 0.04 } })
-  }
-  layers.push({ name: "Bio-Token Output", type: "output", neurons: 4096, activation: [], weights: { min: -0.22, max: 0.24, mean: -0.001, std: 0.07 } })
-  return layers
+  impact: number
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export default function ModelTrainingToolPage() {
-  // ── Training State
-  const [trainingStatus, setTrainingStatus] = useState<"idle" | "training" | "paused" | "evaluating">("idle")
-  const [metrics, setMetrics] = useState<TrainingMetrics>({
-    epoch: 0, loss: 2.45, accuracy: 0, learningRate: 0.0003, samplesProcessed: 0,
-    batchesCompleted: 0, elapsedTime: 0, gradientNorm: 1.2, memoryUsage: 0,
-  })
-  const [lossHistory, setLossHistory] = useState<number[]>([2.8, 2.6, 2.45])
-  const [accHistory, setAccHistory] = useState<number[]>([0, 2.1, 5.8])
-  const metricsRef = useRef(metrics)
-  metricsRef.current = metrics
+  // ── Dashboard state from real backend
+  const [data, setData] = useState<DashboardData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
 
-  // ── Hyperparameters
-  const [learningRate, setLearningRate] = useState(0.0003)
-  const [batchSize, setBatchSize] = useState(32)
-  const [maxEpochs, setMaxEpochs] = useState(100)
-  const [warmupSteps, setWarmupSteps] = useState(1000)
+  // ── Hyperparameters (editable, sent to backend on start)
+  const [learningRate, setLearningRate] = useState(2e-5)
+  const [batchSize, setBatchSize] = useState(4)
+  const [maxEpochs, setMaxEpochs] = useState(3)
+  const [warmupSteps, setWarmupSteps] = useState(100)
   const [weightDecay, setWeightDecay] = useState(0.01)
-  const [dropoutRate, setDropoutRate] = useState(0.1)
+  const [dropoutRate, setDropoutRate] = useState(0.05)
   const [optimizer, setOptimizer] = useState("adamw")
   const [scheduler, setScheduler] = useState("cosine")
   const [gradClip, setGradClip] = useState(1.0)
-  const [attentionHeads, setAttentionHeads] = useState(8)
-  const [hiddenDim, setHiddenDim] = useState(512)
-  const [numLayers, setNumLayers] = useState(6)
 
-  // ── Plasticity / Mutation
+  // ── Plasticity / Mutation (sent to backend)
   const [plasticityEnabled, setPlasticityEnabled] = useState(false)
   const [plasticityRate, setPlasticityRate] = useState(0.05)
   const [mutationMode, setMutationMode] = useState<"none" | "prune" | "grow" | "rewire" | "perturb">("none")
@@ -123,143 +116,203 @@ export default function ModelTrainingToolPage() {
   const [autoMutate, setAutoMutate] = useState(false)
   const [mutationThreshold, setMutationThreshold] = useState(0.01)
 
-  // ── Data Pipeline
-  const [devices, setDevices] = useState<DeviceNode[]>(generateDevices)
-  const [dataSourceFilter, setDataSourceFilter] = useState<string>("all")
-  const [mindexConnected, setMindexConnected] = useState(true)
-  const [nasConnected, setNasConnected] = useState(true)
-  const [totalSamplesIngested, setTotalSamplesIngested] = useState(0)
-  const [recursiveLearning, setRecursiveLearning] = useState(false)
-
   // ── Visualization
-  const [layers] = useState<LayerViz[]>(generateLayers)
   const [selectedLayer, setSelectedLayer] = useState<number | null>(null)
   const [vizMode, setVizMode] = useState<"network" | "weights" | "activations" | "attention">("network")
-  const [neuronActivity, setNeuronActivity] = useState<number[]>([])
   const [showFullscreen, setShowFullscreen] = useState(false)
 
-  // ── Checkpoints
-  const [checkpoints, setCheckpoints] = useState<{ id: string; epoch: number; loss: number; accuracy: number; timestamp: number; location: string }[]>([])
+  // ── Inference test
+  const [inferenceInput, setInferenceInput] = useState("")
+  const [inferenceOutput, setInferenceOutput] = useState<any>(null)
+  const [inferenceLoading, setInferenceLoading] = useState(false)
 
   // ── Active tab
   const [activeTab, setActiveTab] = useState("pipeline")
 
-  // ── Simulate training ticks
-  useEffect(() => {
-    if (trainingStatus !== "training") return
-    const interval = setInterval(() => {
-      setMetrics(prev => {
-        const newLoss = Math.max(0.01, prev.loss - (Math.random() * 0.015 + 0.002))
-        const newAcc = Math.min(99.5, prev.accuracy + (Math.random() * 0.4 + 0.05))
-        const newEpoch = prev.batchesCompleted > 0 && prev.batchesCompleted % 100 === 0 ? prev.epoch + 1 : prev.epoch
-        return {
-          ...prev,
-          epoch: newEpoch,
-          loss: newLoss,
-          accuracy: newAcc,
-          samplesProcessed: prev.samplesProcessed + batchSize,
-          batchesCompleted: prev.batchesCompleted + 1,
-          elapsedTime: prev.elapsedTime + 1,
-          gradientNorm: Math.max(0.01, prev.gradientNorm * (0.99 + Math.random() * 0.02)),
-          memoryUsage: Math.min(95, 40 + Math.random() * 20),
-          learningRate: learningRate,
-        }
-      })
-    }, 1000)
-    return () => clearInterval(interval)
-  }, [trainingStatus, batchSize, learningRate])
+  // ── Fetch dashboard data from real backend
+  const fetchData = useCallback(async () => {
+    try {
+      const res = await fetch("/api/natureos/nlm-training")
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const json: DashboardData = await res.json()
+      setData(json)
+      setError(null)
 
-  // ── Track loss/acc history
-  useEffect(() => {
-    if (trainingStatus === "training" && metrics.batchesCompleted % 10 === 0 && metrics.batchesCompleted > 0) {
-      setLossHistory(prev => [...prev.slice(-59), metrics.loss])
-      setAccHistory(prev => [...prev.slice(-59), metrics.accuracy])
+      // Sync hyperparameters from backend config on first load
+      if (json.model.hyperparameters) {
+        const hp = json.model.hyperparameters
+        if (hp.learning_rate) setLearningRate(hp.learning_rate)
+        if (hp.batch_size) setBatchSize(hp.batch_size)
+        if (hp.epochs) setMaxEpochs(hp.epochs)
+        if (hp.warmup_steps) setWarmupSteps(hp.warmup_steps)
+        if (hp.weight_decay) setWeightDecay(hp.weight_decay)
+        if (hp.lr_scheduler_type) setScheduler(hp.lr_scheduler_type)
+        if (hp.max_grad_norm) setGradClip(hp.max_grad_norm)
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to fetch data")
+    } finally {
+      setLoading(false)
     }
-  }, [metrics.batchesCompleted, trainingStatus, metrics.loss, metrics.accuracy])
-
-  // ── Simulate device data ingestion
-  useEffect(() => {
-    if (trainingStatus !== "training") return
-    const interval = setInterval(() => {
-      const onlineDevices = devices.filter(d => d.status === "online")
-      const ingestRate = onlineDevices.reduce((sum, d) => sum + d.dataRate, 0)
-      setTotalSamplesIngested(prev => prev + ingestRate)
-      setDevices(prev => prev.map(d => ({
-        ...d,
-        dataRate: d.status === "online" ? d.dataRate + Math.floor(Math.random() * 10 - 5) : 0,
-        lastSeen: d.status === "online" ? Date.now() : d.lastSeen,
-      })))
-    }, 2000)
-    return () => clearInterval(interval)
-  }, [trainingStatus, devices])
-
-  // ── Simulate neuron activity for visualization
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setNeuronActivity(Array.from({ length: 64 }, () => Math.random()))
-    }, 500)
-    return () => clearInterval(interval)
   }, [])
 
-  // ── Auto-mutation
+  // Initial fetch
   useEffect(() => {
-    if (!autoMutate || trainingStatus !== "training" || !plasticityEnabled) return
-    const interval = setInterval(() => {
-      const recentLoss = lossHistory.slice(-5)
-      if (recentLoss.length >= 5) {
-        const plateau = Math.abs(recentLoss[0] - recentLoss[4]) < mutationThreshold
-        if (plateau) {
-          const types: MutationEvent["type"][] = ["prune", "grow", "rewire", "perturb"]
-          const type = types[Math.floor(Math.random() * types.length)]
-          const event: MutationEvent = {
-            id: `mut-${Date.now()}`, timestamp: Date.now(), type, target: `Layer ${Math.floor(Math.random() * numLayers) + 1}`,
-            magnitude: plasticityRate, impact: Math.random() * 0.5 - 0.1,
-          }
-          setMutationLog(prev => [event, ...prev.slice(0, 49)])
-        }
-      }
-    }, 10000)
+    fetchData()
+  }, [fetchData])
+
+  // Polling: 3s during training, 10s otherwise
+  useEffect(() => {
+    const interval = setInterval(
+      fetchData,
+      data?.training.status === "training" ? 3000 : 10000
+    )
     return () => clearInterval(interval)
-  }, [autoMutate, trainingStatus, plasticityEnabled, lossHistory, mutationThreshold, plasticityRate, numLayers])
+  }, [fetchData, data?.training.status])
 
-  const handleStartTraining = useCallback(() => setTrainingStatus("training"), [])
-  const handlePauseTraining = useCallback(() => setTrainingStatus("paused"), [])
-  const handleStopTraining = useCallback(() => setTrainingStatus("idle"), [])
-  const handleResumeTraining = useCallback(() => setTrainingStatus("training"), [])
-
-  const handleSaveCheckpoint = useCallback(() => {
-    const cp = {
-      id: `ckpt-${Date.now()}`, epoch: metrics.epoch, loss: metrics.loss, accuracy: metrics.accuracy,
-      timestamp: Date.now(), location: mindexConnected ? "MINDEX + NAS" : "NAS only",
+  // ── Training control actions
+  const sendAction = async (action: string, params: Record<string, any> = {}) => {
+    setActionLoading(action)
+    try {
+      const res = await fetch("/api/natureos/nlm-training", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, ...params }),
+      })
+      const json = await res.json()
+      if (!res.ok) {
+        setError(json.error || "Action failed")
+      } else {
+        setError(null)
+        // Refresh data after action
+        await fetchData()
+      }
+      return json
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Action failed")
+    } finally {
+      setActionLoading(null)
     }
-    setCheckpoints(prev => [cp, ...prev.slice(0, 19)])
-  }, [metrics, mindexConnected])
+  }
 
-  const handleApplyMutation = useCallback(() => {
-    if (mutationMode === "none") return
-    const event: MutationEvent = {
-      id: `mut-${Date.now()}`, timestamp: Date.now(), type: mutationMode,
-      target: selectedLayer !== null ? layers[selectedLayer].name : "Global",
-      magnitude: plasticityRate, impact: Math.random() * 0.3 - 0.05,
+  const handleStartTraining = () =>
+    sendAction("start", {
+      learningRate,
+      batchSize,
+      epochs: maxEpochs,
+      warmupSteps,
+      weightDecay,
+      dropout: dropoutRate,
+      optimizer,
+      scheduler,
+      gradClip,
+    })
+
+  const handlePauseTraining = () =>
+    sendAction("pause", { runId: data?.training.runId })
+
+  const handleStopTraining = () =>
+    sendAction("stop", { runId: data?.training.runId })
+
+  const handleResumeTraining = () =>
+    sendAction("resume", { runId: data?.training.runId })
+
+  const handleSaveCheckpoint = () =>
+    sendAction("checkpoint", { runId: data?.training.runId })
+
+  const handleExport = () =>
+    sendAction("export", {
+      runId: data?.training.runId,
+      format: "gguf",
+    })
+
+  const handleApplyMutation = () => {
+    if (mutationMode === "none" || !data?.training.runId) return
+    sendAction("mutate", {
+      runId: data.training.runId,
+      mutationType: mutationMode,
+      targetLayer: selectedLayer !== null ? `layer_${selectedLayer}` : null,
+      magnitude: plasticityRate,
+    })
+  }
+
+  const handleLoadCheckpoint = (checkpointId: string) =>
+    sendAction("load_checkpoint", { checkpointId })
+
+  const handleRunInference = async () => {
+    if (!inferenceInput.trim()) return
+    setInferenceLoading(true)
+    setInferenceOutput(null)
+    try {
+      const res = await fetch("/api/natureos/nlm-training", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "inference",
+          text: inferenceInput,
+          queryType: "general",
+          maxTokens: 512,
+          temperature: 0.7,
+        }),
+      })
+      const json = await res.json()
+      setInferenceOutput(json)
+    } catch (e) {
+      setInferenceOutput({ error: e instanceof Error ? e.message : "Inference failed" })
+    } finally {
+      setInferenceLoading(false)
     }
-    setMutationLog(prev => [event, ...prev.slice(0, 49)])
-  }, [mutationMode, selectedLayer, layers, plasticityRate])
+  }
 
-  const onlineCount = devices.filter(d => d.status === "online").length
-  const totalDataRate = devices.filter(d => d.status === "online").reduce((s, d) => s + d.dataRate, 0)
+  // ── Derived values
+  const trainingStatus = data?.training.status || "idle"
+  const onlineDevices = data?.devices.filter((d: any) => d.status === "online") || []
+  const totalDevices = data?.deviceCount || 0
+  const totalDataRate = onlineDevices.reduce((s: number, d: any) => s + (d.dataRate || d.data_rate || 0), 0)
+  const connections = data?.connections || { mas: false, mindex: false, gpu: false, mycobrain: false }
+  const lossHistory = data?.training.lossHistory || []
+  const accHistory = data?.training.accuracyHistory || []
+  const arch = data?.model.architecture
+  const gpu = data?.gpu
+  const checkpoints = data?.checkpoints || []
 
   // ── Mini sparkline renderer
-  const Sparkline = ({ data, color, height = 40 }: { data: number[]; color: string; height?: number }) => {
-    if (data.length < 2) return <div className="text-xs text-muted-foreground">Collecting data...</div>
-    const min = Math.min(...data)
-    const max = Math.max(...data)
+  const Sparkline = ({ data: chartData, color, height = 40 }: { data: number[]; color: string; height?: number }) => {
+    if (chartData.length < 2) return <div className="text-xs text-muted-foreground">Waiting for data...</div>
+    const min = Math.min(...chartData)
+    const max = Math.max(...chartData)
     const range = max - min || 1
     const w = 200
-    const points = data.map((v, i) => `${(i / (data.length - 1)) * w},${height - ((v - min) / range) * (height - 4)}`).join(" ")
+    const points = chartData.map((v, i) => `${(i / (chartData.length - 1)) * w},${height - ((v - min) / range) * (height - 4)}`).join(" ")
     return (
       <svg viewBox={`0 0 ${w} ${height}`} className="w-full" style={{ height }}>
         <polyline fill="none" stroke={color} strokeWidth="2" points={points} />
       </svg>
+    )
+  }
+
+  // ── Connection status indicator
+  const ConnectionBadge = ({ name, connected }: { name: string; connected: boolean }) => (
+    <Badge variant="outline" className={`text-xs ${connected ? "bg-green-500/10 text-green-400 border-green-500/30" : "bg-red-500/10 text-red-400 border-red-500/30"}`}>
+      {connected ? <CheckCircle2 className="h-3 w-3 mr-1" /> : <XCircle className="h-3 w-3 mr-1" />}
+      {name}
+    </Badge>
+  )
+
+  // ── Loading state
+  if (loading && !data) {
+    return (
+      <div className="min-h-dvh bg-background flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <Loader2 className="h-8 w-8 animate-spin mx-auto text-purple-500" />
+          <p className="text-muted-foreground">Connecting to NLM Training Infrastructure...</p>
+          <div className="flex gap-2 justify-center">
+            <Badge variant="outline" className="text-xs">MAS 192.168.0.188</Badge>
+            <Badge variant="outline" className="text-xs">GPU 192.168.0.190</Badge>
+            <Badge variant="outline" className="text-xs">MINDEX 192.168.0.189</Badge>
+          </div>
+        </div>
+      </div>
     )
   }
 
@@ -273,38 +326,61 @@ export default function ModelTrainingToolPage() {
               <Brain className="h-6 w-6 text-purple-500" />
               <h1 className="text-xl font-bold">NLM Training Tool</h1>
             </div>
-            <Badge variant="outline" className={trainingStatus === "training" ? "bg-green-500/20 text-green-400 border-green-500/50 animate-pulse" : trainingStatus === "paused" ? "bg-amber-500/20 text-amber-400 border-amber-500/50" : "bg-muted text-muted-foreground"}>
+            <Badge
+              variant="outline"
+              className={
+                trainingStatus === "training"
+                  ? "bg-green-500/20 text-green-400 border-green-500/50 animate-pulse"
+                  : trainingStatus === "paused"
+                    ? "bg-amber-500/20 text-amber-400 border-amber-500/50"
+                    : trainingStatus === "evaluating"
+                      ? "bg-blue-500/20 text-blue-400 border-blue-500/50"
+                      : "bg-muted text-muted-foreground"
+              }
+            >
               {trainingStatus === "training" ? "Training" : trainingStatus === "paused" ? "Paused" : trainingStatus === "evaluating" ? "Evaluating" : "Idle"}
             </Badge>
             <Badge variant="outline" className="text-xs">
-              <Wifi className="h-3 w-3 mr-1" /> {onlineCount}/{devices.length} Devices
+              <Wifi className="h-3 w-3 mr-1" /> {onlineDevices.length}/{totalDevices} Devices
             </Badge>
-            {mindexConnected && <Badge variant="outline" className="text-xs bg-green-500/10 text-green-400"><Database className="h-3 w-3 mr-1" /> MINDEX</Badge>}
-            {nasConnected && <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-400"><HardDrive className="h-3 w-3 mr-1" /> NAS</Badge>}
+            <ConnectionBadge name="MAS" connected={connections.mas} />
+            <ConnectionBadge name="MINDEX" connected={connections.mindex} />
+            <ConnectionBadge name="GPU" connected={connections.gpu} />
           </div>
           <div className="flex items-center gap-2">
             {trainingStatus === "idle" && (
-              <Button size="sm" className="bg-green-600 hover:bg-green-700" onClick={handleStartTraining}>
-                <Play className="h-4 w-4 mr-1" /> Start Training
+              <Button size="sm" className="bg-green-600 hover:bg-green-700" onClick={handleStartTraining} disabled={actionLoading === "start"}>
+                {actionLoading === "start" ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Play className="h-4 w-4 mr-1" />} Start Training
               </Button>
             )}
             {trainingStatus === "training" && (
               <>
-                <Button size="sm" variant="outline" onClick={handlePauseTraining}><Pause className="h-4 w-4 mr-1" /> Pause</Button>
-                <Button size="sm" variant="destructive" onClick={handleStopTraining}><Square className="h-4 w-4 mr-1" /> Stop</Button>
+                <Button size="sm" variant="outline" onClick={handlePauseTraining} disabled={!!actionLoading}>
+                  <Pause className="h-4 w-4 mr-1" /> Pause
+                </Button>
+                <Button size="sm" variant="destructive" onClick={handleStopTraining} disabled={!!actionLoading}>
+                  <Square className="h-4 w-4 mr-1" /> Stop
+                </Button>
               </>
             )}
             {trainingStatus === "paused" && (
               <>
-                <Button size="sm" className="bg-green-600 hover:bg-green-700" onClick={handleResumeTraining}><Play className="h-4 w-4 mr-1" /> Resume</Button>
-                <Button size="sm" variant="destructive" onClick={handleStopTraining}><Square className="h-4 w-4 mr-1" /> Stop</Button>
+                <Button size="sm" className="bg-green-600 hover:bg-green-700" onClick={handleResumeTraining} disabled={!!actionLoading}>
+                  <Play className="h-4 w-4 mr-1" /> Resume
+                </Button>
+                <Button size="sm" variant="destructive" onClick={handleStopTraining} disabled={!!actionLoading}>
+                  <Square className="h-4 w-4 mr-1" /> Stop
+                </Button>
               </>
             )}
-            <Button size="sm" variant="outline" onClick={handleSaveCheckpoint} disabled={trainingStatus === "idle"}>
+            <Button size="sm" variant="outline" onClick={handleSaveCheckpoint} disabled={trainingStatus === "idle" || !!actionLoading}>
               <Save className="h-4 w-4 mr-1" /> Checkpoint
             </Button>
-            <Button size="sm" variant="outline" disabled={trainingStatus === "idle"}>
+            <Button size="sm" variant="outline" onClick={handleExport} disabled={trainingStatus === "idle" || !!actionLoading}>
               <Download className="h-4 w-4 mr-1" /> Export
+            </Button>
+            <Button size="sm" variant="ghost" onClick={fetchData}>
+              <RefreshCw className="h-4 w-4" />
             </Button>
             <Link href="/myca/nlm">
               <Button size="sm" variant="ghost" className="text-muted-foreground">NLM Docs <ArrowRight className="h-3 w-3 ml-1" /></Button>
@@ -313,18 +389,53 @@ export default function ModelTrainingToolPage() {
         </div>
       </div>
 
+      {/* ── Error Banner ──────────────────────────────────────────────────── */}
+      {error && (
+        <div className="bg-red-500/10 border-b border-red-500/30 px-4 py-2">
+          <div className="container mx-auto flex items-center gap-2 text-sm text-red-400">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>{error}</span>
+            <Button size="sm" variant="ghost" className="ml-auto h-6 text-xs" onClick={() => setError(null)}>Dismiss</Button>
+          </div>
+        </div>
+      )}
+
       {/* ── Live Metrics Bar ─────────────────────────────────────────────── */}
       <div className="border-b bg-muted/30">
         <div className="container mx-auto px-4 py-2">
           <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-3 text-center">
-            <div><div className="text-xs text-muted-foreground">Epoch</div><div className="text-lg font-bold">{metrics.epoch}/{maxEpochs}</div></div>
-            <div><div className="text-xs text-muted-foreground">Loss</div><div className="text-lg font-bold text-red-400">{metrics.loss.toFixed(4)}</div></div>
-            <div><div className="text-xs text-muted-foreground">Accuracy</div><div className="text-lg font-bold text-green-400">{metrics.accuracy.toFixed(2)}%</div></div>
-            <div><div className="text-xs text-muted-foreground">LR</div><div className="text-lg font-bold">{learningRate.toExponential(1)}</div></div>
-            <div><div className="text-xs text-muted-foreground">Samples</div><div className="text-lg font-bold">{(metrics.samplesProcessed / 1000).toFixed(1)}K</div></div>
-            <div><div className="text-xs text-muted-foreground">Grad Norm</div><div className="text-lg font-bold">{metrics.gradientNorm.toFixed(3)}</div></div>
-            <div><div className="text-xs text-muted-foreground">VRAM</div><div className="text-lg font-bold">{metrics.memoryUsage.toFixed(0)}%</div></div>
-            <div><div className="text-xs text-muted-foreground">Data Rate</div><div className="text-lg font-bold text-blue-400">{totalDataRate}/s</div></div>
+            <div>
+              <div className="text-xs text-muted-foreground">Epoch</div>
+              <div className="text-lg font-bold">{data?.training.epoch ?? 0}/{data?.training.totalEpochs || maxEpochs}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Loss</div>
+              <div className="text-lg font-bold text-red-400">{data?.training.loss != null ? data.training.loss.toFixed(4) : "—"}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Accuracy</div>
+              <div className="text-lg font-bold text-green-400">{data?.training.accuracy != null ? `${data.training.accuracy.toFixed(2)}%` : "—"}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">LR</div>
+              <div className="text-lg font-bold">{data?.training.learningRate != null ? data.training.learningRate.toExponential(1) : learningRate.toExponential(1)}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Samples</div>
+              <div className="text-lg font-bold">{data?.training.samplesProcessed ? `${(data.training.samplesProcessed / 1000).toFixed(1)}K` : "0"}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Grad Norm</div>
+              <div className="text-lg font-bold">{data?.training.gradientNorm != null ? data.training.gradientNorm.toFixed(3) : "—"}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">GPU VRAM</div>
+              <div className="text-lg font-bold">{gpu ? `${gpu.memoryPercent.toFixed(0)}%` : "—"}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">GPU Temp</div>
+              <div className="text-lg font-bold text-blue-400">{gpu ? `${gpu.temperature}°C` : "—"}</div>
+            </div>
           </div>
         </div>
       </div>
@@ -332,64 +443,74 @@ export default function ModelTrainingToolPage() {
       {/* ── Main Content ─────────────────────────────────────────────────── */}
       <div className="container mx-auto px-4 py-4">
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid w-full grid-cols-3 sm:grid-cols-6 mb-4">
+          <TabsList className="grid w-full grid-cols-3 sm:grid-cols-7 mb-4">
             <TabsTrigger value="pipeline" className="text-xs sm:text-sm"><Workflow className="h-3 w-3 mr-1 hidden sm:inline" />Pipeline</TabsTrigger>
             <TabsTrigger value="visualization" className="text-xs sm:text-sm"><Eye className="h-3 w-3 mr-1 hidden sm:inline" />Visualize</TabsTrigger>
             <TabsTrigger value="parameters" className="text-xs sm:text-sm"><SlidersHorizontal className="h-3 w-3 mr-1 hidden sm:inline" />Parameters</TabsTrigger>
             <TabsTrigger value="plasticity" className="text-xs sm:text-sm"><Dna className="h-3 w-3 mr-1 hidden sm:inline" />Plasticity</TabsTrigger>
             <TabsTrigger value="data" className="text-xs sm:text-sm"><BarChart3 className="h-3 w-3 mr-1 hidden sm:inline" />Metrics</TabsTrigger>
             <TabsTrigger value="checkpoints" className="text-xs sm:text-sm"><Save className="h-3 w-3 mr-1 hidden sm:inline" />Checkpoints</TabsTrigger>
+            <TabsTrigger value="inference" className="text-xs sm:text-sm"><Brain className="h-3 w-3 mr-1 hidden sm:inline" />Inference</TabsTrigger>
           </TabsList>
 
-          {/* ══════════════════════════════════════════════════════════════ */}
-          {/* PIPELINE TAB                                                  */}
-          {/* ══════════════════════════════════════════════════════════════ */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
+          {/* PIPELINE TAB                                                   */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
           <TabsContent value="pipeline" className="space-y-4">
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-              {/* Device Fleet */}
+              {/* Device Fleet — Real data from MAS Device Registry + MycoBrain */}
               <Card className="lg:col-span-2">
                 <CardHeader className="pb-3">
                   <CardTitle className="flex items-center gap-2 text-lg"><Server className="h-5 w-5 text-blue-400" /> Device Fleet — Live Data Sources</CardTitle>
-                  <CardDescription>Mycobrain devices + Nvidia Jetson edge nodes feeding training data</CardDescription>
+                  <CardDescription>MycoBrain devices + Jetson edge nodes from MAS Device Registry</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-3">
-                  {devices.map(device => (
-                    <div key={device.id} className={`flex items-center justify-between p-3 rounded-lg border ${device.status === "online" ? "border-green-500/30 bg-green-500/5" : device.status === "degraded" ? "border-amber-500/30 bg-amber-500/5" : "border-red-500/30 bg-red-500/5"}`}>
-                      <div className="flex items-center gap-3">
-                        <div className={`w-2 h-2 rounded-full ${device.status === "online" ? "bg-green-500 animate-pulse" : device.status === "degraded" ? "bg-amber-500" : "bg-red-500"}`} />
-                        <div>
-                          <div className="font-medium text-sm">{device.name}</div>
-                          <div className="text-xs text-muted-foreground flex items-center gap-2">
-                            <Badge variant="outline" className="text-[10px] h-4">{device.type}</Badge>
-                            {device.metrics.temp && <span>{device.metrics.temp.toFixed(1)}°C</span>}
-                            {device.metrics.humidity && <span>{device.metrics.humidity}% RH</span>}
-                            {device.metrics.voltage && <span>{device.metrics.voltage.toFixed(2)}V</span>}
+                  {data?.devices && data.devices.length > 0 ? (
+                    data.devices.map((device: any) => (
+                      <div key={device.device_id || device.id} className={`flex items-center justify-between p-3 rounded-lg border ${device.status === "online" ? "border-green-500/30 bg-green-500/5" : device.status === "degraded" || device.status === "stale" ? "border-amber-500/30 bg-amber-500/5" : "border-red-500/30 bg-red-500/5"}`}>
+                        <div className="flex items-center gap-3">
+                          <div className={`w-2 h-2 rounded-full ${device.status === "online" ? "bg-green-500 animate-pulse" : device.status === "degraded" || device.status === "stale" ? "bg-amber-500" : "bg-red-500"}`} />
+                          <div>
+                            <div className="font-medium text-sm">{device.display_name || device.device_name || device.name || device.device_id}</div>
+                            <div className="text-xs text-muted-foreground flex items-center gap-2">
+                              <Badge variant="outline" className="text-[10px] h-4">{device.device_role || device.type || device.board_type}</Badge>
+                              {device.firmware_version && <span>v{device.firmware_version}</span>}
+                              {device.host && <span>{device.host}</span>}
+                              {device.sensors?.length > 0 && <span>{device.sensors.length} sensors</span>}
+                            </div>
                           </div>
                         </div>
+                        <div className="text-right">
+                          <div className="text-sm font-mono">{device.connection_type || device.source}</div>
+                          <div className="text-xs text-muted-foreground">{device.status}</div>
+                        </div>
                       </div>
-                      <div className="text-right">
-                        <div className="text-sm font-mono">{device.dataRate} smp/s</div>
-                        <div className="text-xs text-muted-foreground">{device.status === "online" ? "streaming" : device.status}</div>
-                      </div>
+                    ))
+                  ) : (
+                    <div className="text-center py-8 text-muted-foreground">
+                      <Server className="h-12 w-12 mx-auto mb-3 opacity-20" />
+                      <p className="text-sm">No devices detected.</p>
+                      <p className="text-xs mt-1">Ensure MAS Device Registry and MycoBrain service are running.</p>
+                      {!connections.mas && <p className="text-xs text-red-400 mt-2">MAS connection unavailable (192.168.0.188:8001)</p>}
                     </div>
-                  ))}
+                  )}
                 </CardContent>
               </Card>
 
-              {/* Pipeline Flow */}
+              {/* Pipeline Flow + GPU Status */}
               <div className="space-y-4">
                 <Card>
                   <CardHeader className="pb-3">
-                    <CardTitle className="text-lg flex items-center gap-2"><Workflow className="h-5 w-5 text-purple-400" /> Data Pipeline</CardTitle>
+                    <CardTitle className="text-lg flex items-center gap-2"><Workflow className="h-5 w-5 text-purple-400" /> System Pipeline</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-3">
                     {[
-                      { label: "Mycobrain Devices", icon: CircleDot, color: "text-green-400", detail: `${onlineCount} online`, ok: onlineCount > 0 },
-                      { label: "Jetson Edge NLM", icon: Cpu, color: "text-blue-400", detail: "Preprocessing", ok: devices.some(d => d.type === "jetson" && d.status === "online") },
-                      { label: "MAS / HPL / MDP / MMP", icon: Network, color: "text-purple-400", detail: "Routing active", ok: true },
-                      { label: "MINDEX", icon: Database, color: "text-green-400", detail: mindexConnected ? "Connected" : "Disconnected", ok: mindexConnected },
-                      { label: "NLM GPU Training", icon: Zap, color: "text-amber-400", detail: trainingStatus === "training" ? "Running" : "Standby", ok: trainingStatus === "training" },
-                      { label: "Weight Storage (NAS)", icon: HardDrive, color: "text-blue-400", detail: nasConnected ? "Synced" : "Disconnected", ok: nasConnected },
+                      { label: "MAS Orchestrator", icon: Network, color: "text-purple-400", detail: connections.mas ? "Connected (188:8001)" : "Disconnected", ok: connections.mas },
+                      { label: "MycoBrain Devices", icon: CircleDot, color: "text-green-400", detail: `${onlineDevices.length} online`, ok: connections.mycobrain },
+                      { label: "MINDEX Database", icon: Database, color: "text-green-400", detail: connections.mindex ? "Connected (189:8000)" : "Disconnected", ok: connections.mindex },
+                      { label: "GPU Node (190)", icon: Cpu, color: "text-amber-400", detail: gpu ? `${gpu.name} — ${gpu.utilization}% util` : "Disconnected", ok: connections.gpu },
+                      { label: "NLM Model", icon: Brain, color: "text-purple-400", detail: data?.model.health?.model_loaded ? `Loaded (${data.model.health.model_version})` : "Not loaded", ok: data?.model.health?.model_loaded ?? false },
+                      { label: "Training Engine", icon: Zap, color: "text-amber-400", detail: trainingStatus === "training" ? `Running (epoch ${data?.training.epoch})` : trainingStatus === "paused" ? "Paused" : "Standby", ok: trainingStatus === "training" },
                     ].map((step, i) => (
                       <div key={i} className="flex items-center gap-3">
                         <div className={`w-8 h-8 rounded-full flex items-center justify-center ${step.ok ? "bg-green-500/20" : "bg-red-500/20"}`}>
@@ -399,35 +520,50 @@ export default function ModelTrainingToolPage() {
                           <div className="text-sm font-medium truncate">{step.label}</div>
                           <div className="text-xs text-muted-foreground">{step.detail}</div>
                         </div>
-                        {step.ok ? <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" /> : <AlertTriangle className="h-4 w-4 text-red-400 shrink-0" />}
-                        {i < 5 && <div className="absolute -bottom-2 left-4 h-3 w-px bg-muted-foreground/20 hidden" />}
+                        {step.ok ? <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" /> : <XCircle className="h-4 w-4 text-red-400 shrink-0" />}
                       </div>
                     ))}
                   </CardContent>
                 </Card>
 
-                <Card>
-                  <CardHeader className="pb-3">
-                    <CardTitle className="text-sm">Ingestion Stats</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-2 text-sm">
-                    <div className="flex justify-between"><span className="text-muted-foreground">Total Ingested</span><span className="font-mono">{(totalSamplesIngested / 1e6).toFixed(3)}M</span></div>
-                    <div className="flex justify-between"><span className="text-muted-foreground">Live Rate</span><span className="font-mono">{totalDataRate} smp/s</span></div>
-                    <div className="flex justify-between"><span className="text-muted-foreground">Recursive Learning</span>
-                      <Switch checked={recursiveLearning} onCheckedChange={setRecursiveLearning} />
-                    </div>
-                    {recursiveLearning && (
-                      <p className="text-xs text-amber-400 mt-1">Recursive mode: model outputs feed back as augmented training data for continuous self-improvement.</p>
-                    )}
-                  </CardContent>
-                </Card>
+                {/* GPU Metrics Card */}
+                {gpu && (
+                  <Card>
+                    <CardHeader className="pb-3">
+                      <CardTitle className="text-sm flex items-center gap-2"><Cpu className="h-4 w-4 text-amber-400" /> GPU — {gpu.name}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2 text-sm">
+                      <div className="flex justify-between"><span className="text-muted-foreground">VRAM</span><span className="font-mono">{gpu.memoryUsed}MB / {gpu.memoryTotal}MB ({gpu.memoryPercent.toFixed(0)}%)</span></div>
+                      <Progress value={gpu.memoryPercent} className="h-2" />
+                      <div className="flex justify-between"><span className="text-muted-foreground">Utilization</span><span className="font-mono">{gpu.utilization}%</span></div>
+                      <Progress value={gpu.utilization} className="h-2" />
+                      <div className="flex justify-between"><span className="text-muted-foreground">Temperature</span><span className="font-mono">{gpu.temperature}°C</span></div>
+                      <div className="flex justify-between"><span className="text-muted-foreground">Power</span><span className="font-mono">{gpu.powerDraw}W</span></div>
+                    </CardContent>
+                  </Card>
+                )}
+
+                {/* Data Stats from MINDEX */}
+                {data?.dataStats && (
+                  <Card>
+                    <CardHeader className="pb-3"><CardTitle className="text-sm">MINDEX Data Stats</CardTitle></CardHeader>
+                    <CardContent className="space-y-2 text-sm">
+                      {Object.entries(data.dataStats).map(([key, val]) => (
+                        <div key={key} className="flex justify-between">
+                          <span className="text-muted-foreground">{key.replace(/_/g, " ")}</span>
+                          <span className="font-mono">{typeof val === "number" ? val.toLocaleString() : String(val)}</span>
+                        </div>
+                      ))}
+                    </CardContent>
+                  </Card>
+                )}
               </div>
             </div>
           </TabsContent>
 
-          {/* ══════════════════════════════════════════════════════════════ */}
-          {/* VISUALIZATION TAB                                             */}
-          {/* ══════════════════════════════════════════════════════════════ */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
+          {/* VISUALIZATION TAB                                              */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
           <TabsContent value="visualization" className="space-y-4">
             <div className="flex items-center gap-2 mb-2">
               <Button size="sm" variant={vizMode === "network" ? "default" : "outline"} onClick={() => setVizMode("network")}><Box className="h-3 w-3 mr-1" /> Network</Button>
@@ -448,92 +584,75 @@ export default function ModelTrainingToolPage() {
                     <Brain className="h-5 w-5 text-purple-400" />
                     Live Neural Network — {vizMode === "network" ? "Transformer Architecture" : vizMode === "weights" ? "Weight Distribution" : vizMode === "activations" ? "Activation Map" : "Attention Heads"}
                   </CardTitle>
-                  <CardDescription>{layers.length} layers, {attentionHeads} attention heads, {hiddenDim} hidden dim</CardDescription>
+                  <CardDescription>
+                    {arch ? `${arch.numLayers || "?"} layers, ${arch.numAttentionHeads || "?"} attention heads, ${arch.hiddenSize || "?"} hidden dim` : "Connect to MAS to load model architecture"}
+                    {arch?.baseModel && ` — Base: ${arch.baseModel}`}
+                  </CardDescription>
                 </CardHeader>
                 <CardContent>
                   {vizMode === "network" && (
-                    <FungaNetwork3D status={trainingStatus === "training" ? "live" : trainingStatus === "paused" ? "degraded" : "loading"} loss={metrics.loss} />
+                    <FungaNetwork3D status={trainingStatus === "training" ? "live" : trainingStatus === "paused" ? "degraded" : "loading"} loss={data?.training.loss ?? 2.5} />
                   )}
 
                   {vizMode === "weights" && (
-                    <div className="space-y-2">
-                      {layers.map((layer, i) => (
-                        <div key={i} className="flex items-center gap-2 text-xs">
-                          <span className="w-32 truncate text-muted-foreground">{layer.name}</span>
-                          <div className="flex-1 h-4 bg-muted/30 rounded relative overflow-hidden">
-                            <div className="absolute inset-y-0 bg-gradient-to-r from-blue-600 via-transparent to-red-600 opacity-40" style={{ left: `${((layer.weights.min + 1) / 2) * 100}%`, right: `${(1 - (layer.weights.max + 1) / 2) * 100}%` }} />
-                            <div className="absolute inset-y-0 w-px bg-white/50" style={{ left: `${((layer.weights.mean + 1) / 2) * 100}%` }} />
-                          </div>
-                          <span className="w-20 text-right font-mono">&sigma;={layer.weights.std.toFixed(3)}</span>
-                        </div>
-                      ))}
+                    <div className="text-center py-12 text-muted-foreground">
+                      <BarChart3 className="h-12 w-12 mx-auto mb-3 opacity-20" />
+                      <p className="text-sm">Weight visualization requires an active training run.</p>
+                      <p className="text-xs mt-1">Start training to view real-time weight distributions from the GPU node.</p>
                     </div>
                   )}
 
                   {vizMode === "activations" && (
-                    <div className="grid grid-cols-8 gap-1">
-                      {neuronActivity.map((v, i) => (
-                        <div key={i} className="aspect-square rounded" style={{ backgroundColor: `rgba(168, 85, 247, ${v})` }} title={`Neuron ${i}: ${(v * 100).toFixed(0)}%`} />
-                      ))}
-                      <div className="col-span-8 text-xs text-muted-foreground mt-2 text-center">
-                        Live neuron activation heatmap — 64 sample neurons across selected layer
-                      </div>
+                    <div className="text-center py-12 text-muted-foreground">
+                      <Activity className="h-12 w-12 mx-auto mb-3 opacity-20" />
+                      <p className="text-sm">Activation maps are streamed from the GPU during training.</p>
+                      <p className="text-xs mt-1">Start training to see live neuron activation heatmaps.</p>
                     </div>
                   )}
 
                   {vizMode === "attention" && (
-                    <div className="space-y-3">
-                      <p className="text-sm text-muted-foreground">Attention head activity across {attentionHeads} heads</p>
-                      <div className="grid grid-cols-4 gap-2">
-                        {Array.from({ length: attentionHeads }, (_, h) => (
-                          <Card key={h} className="p-3">
-                            <div className="text-xs font-medium mb-1">Head {h + 1}</div>
-                            <div className="grid grid-cols-4 gap-px">
-                              {Array.from({ length: 16 }, (_, j) => {
-                                const v = neuronActivity[(h * 16 + j) % neuronActivity.length] ?? 0.3
-                                return <div key={j} className="aspect-square rounded-sm" style={{ backgroundColor: `rgba(59, 130, 246, ${v})` }} />
-                              })}
-                            </div>
-                          </Card>
-                        ))}
-                      </div>
+                    <div className="text-center py-12 text-muted-foreground">
+                      <Eye className="h-12 w-12 mx-auto mb-3 opacity-20" />
+                      <p className="text-sm">Attention head visualization requires an active model.</p>
+                      <p className="text-xs mt-1">Load the NLM model or start training to see attention patterns.</p>
                     </div>
                   )}
                 </CardContent>
               </Card>
 
-              {/* Layer Detail Panel */}
+              {/* Training Curves */}
               {!showFullscreen && (
                 <div className="space-y-4">
                   <Card>
-                    <CardHeader className="pb-3">
-                      <CardTitle className="text-sm">Layer Inspector</CardTitle>
-                    </CardHeader>
+                    <CardHeader className="pb-3"><CardTitle className="text-sm">Model Architecture</CardTitle></CardHeader>
                     <CardContent>
-                      {selectedLayer !== null ? (
-                        <div className="space-y-3">
-                          <div className="font-medium">{layers[selectedLayer].name}</div>
-                          <div className="grid grid-cols-2 gap-2 text-xs">
-                            <div><span className="text-muted-foreground">Type:</span> {layers[selectedLayer].type}</div>
-                            <div><span className="text-muted-foreground">Neurons:</span> {layers[selectedLayer].neurons}</div>
-                            <div><span className="text-muted-foreground">W min:</span> {layers[selectedLayer].weights.min.toFixed(3)}</div>
-                            <div><span className="text-muted-foreground">W max:</span> {layers[selectedLayer].weights.max.toFixed(3)}</div>
-                            <div><span className="text-muted-foreground">W mean:</span> {layers[selectedLayer].weights.mean.toFixed(4)}</div>
-                            <div><span className="text-muted-foreground">W std:</span> {layers[selectedLayer].weights.std.toFixed(4)}</div>
-                          </div>
-                          <div className="pt-2 border-t space-y-2">
-                            <p className="text-xs text-muted-foreground">Apply mutation to this layer:</p>
-                            <div className="flex gap-1 flex-wrap">
-                              {(["prune", "grow", "rewire", "perturb"] as const).map(m => (
-                                <Button key={m} size="sm" variant="outline" className="text-xs h-7" onClick={() => { setMutationMode(m); handleApplyMutation() }}>
-                                  {m}
-                                </Button>
-                              ))}
-                            </div>
+                      {arch ? (
+                        <div className="space-y-2 text-xs">
+                          <div className="grid grid-cols-2 gap-2">
+                            <div><span className="text-muted-foreground">Base Model:</span></div>
+                            <div className="font-mono truncate">{arch.baseModel}</div>
+                            <div><span className="text-muted-foreground">Hidden Size:</span></div>
+                            <div className="font-mono">{arch.hiddenSize}</div>
+                            <div><span className="text-muted-foreground">Layers:</span></div>
+                            <div className="font-mono">{arch.numLayers}</div>
+                            <div><span className="text-muted-foreground">Attn Heads:</span></div>
+                            <div className="font-mono">{arch.numAttentionHeads}</div>
+                            <div><span className="text-muted-foreground">Vocab Size:</span></div>
+                            <div className="font-mono">{arch.vocabSize?.toLocaleString()}</div>
+                            <div><span className="text-muted-foreground">Max Position:</span></div>
+                            <div className="font-mono">{arch.maxPositionEmbeddings?.toLocaleString()}</div>
+                            {arch.useLora && (
+                              <>
+                                <div><span className="text-muted-foreground">LoRA r:</span></div>
+                                <div className="font-mono">{arch.loraR}</div>
+                                <div><span className="text-muted-foreground">LoRA alpha:</span></div>
+                                <div className="font-mono">{arch.loraAlpha}</div>
+                              </>
+                            )}
                           </div>
                         </div>
                       ) : (
-                        <p className="text-sm text-muted-foreground">Click a layer in the network view to inspect it.</p>
+                        <p className="text-sm text-muted-foreground">Connect to MAS to load model architecture.</p>
                       )}
                     </CardContent>
                   </Card>
@@ -556,50 +675,50 @@ export default function ModelTrainingToolPage() {
             </div>
           </TabsContent>
 
-          {/* ══════════════════════════════════════════════════════════════ */}
-          {/* PARAMETERS TAB                                                */}
-          {/* ══════════════════════════════════════════════════════════════ */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
+          {/* PARAMETERS TAB                                                 */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
           <TabsContent value="parameters" className="space-y-4">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               {/* Training Hyperparameters */}
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2"><Settings className="h-5 w-5" /> Training Hyperparameters</CardTitle>
-                  <CardDescription>Adjust live — changes apply at next batch</CardDescription>
+                  <CardDescription>Configure before starting training — sent to GPU node on start</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-5">
                   <div className="space-y-2">
                     <Label className="flex justify-between"><span>Learning Rate</span><span className="font-mono text-sm">{learningRate.toExponential(1)}</span></Label>
-                    <Slider min={-6} max={-1} step={0.1} value={[Math.log10(learningRate)]} onValueChange={([v]) => setLearningRate(Math.pow(10, v))} />
+                    <Slider min={-6} max={-1} step={0.1} value={[Math.log10(learningRate)]} onValueChange={([v]) => setLearningRate(Math.pow(10, v))} disabled={trainingStatus === "training"} />
                   </div>
                   <div className="space-y-2">
                     <Label className="flex justify-between"><span>Batch Size</span><span className="font-mono text-sm">{batchSize}</span></Label>
-                    <Slider min={1} max={256} step={1} value={[batchSize]} onValueChange={([v]) => setBatchSize(v)} />
+                    <Slider min={1} max={64} step={1} value={[batchSize]} onValueChange={([v]) => setBatchSize(v)} disabled={trainingStatus === "training"} />
                   </div>
                   <div className="space-y-2">
                     <Label className="flex justify-between"><span>Max Epochs</span><span className="font-mono text-sm">{maxEpochs}</span></Label>
-                    <Slider min={1} max={1000} step={1} value={[maxEpochs]} onValueChange={([v]) => setMaxEpochs(v)} />
+                    <Slider min={1} max={100} step={1} value={[maxEpochs]} onValueChange={([v]) => setMaxEpochs(v)} disabled={trainingStatus === "training"} />
                   </div>
                   <div className="space-y-2">
                     <Label className="flex justify-between"><span>Warmup Steps</span><span className="font-mono text-sm">{warmupSteps}</span></Label>
-                    <Slider min={0} max={10000} step={100} value={[warmupSteps]} onValueChange={([v]) => setWarmupSteps(v)} />
+                    <Slider min={0} max={5000} step={50} value={[warmupSteps]} onValueChange={([v]) => setWarmupSteps(v)} disabled={trainingStatus === "training"} />
                   </div>
                   <div className="space-y-2">
                     <Label className="flex justify-between"><span>Weight Decay</span><span className="font-mono text-sm">{weightDecay}</span></Label>
-                    <Slider min={0} max={0.1} step={0.001} value={[weightDecay]} onValueChange={([v]) => setWeightDecay(v)} />
+                    <Slider min={0} max={0.1} step={0.001} value={[weightDecay]} onValueChange={([v]) => setWeightDecay(v)} disabled={trainingStatus === "training"} />
                   </div>
                   <div className="space-y-2">
-                    <Label className="flex justify-between"><span>Dropout</span><span className="font-mono text-sm">{dropoutRate}</span></Label>
-                    <Slider min={0} max={0.5} step={0.01} value={[dropoutRate]} onValueChange={([v]) => setDropoutRate(v)} />
+                    <Label className="flex justify-between"><span>LoRA Dropout</span><span className="font-mono text-sm">{dropoutRate}</span></Label>
+                    <Slider min={0} max={0.5} step={0.01} value={[dropoutRate]} onValueChange={([v]) => setDropoutRate(v)} disabled={trainingStatus === "training"} />
                   </div>
                   <div className="space-y-2">
                     <Label className="flex justify-between"><span>Gradient Clipping</span><span className="font-mono text-sm">{gradClip}</span></Label>
-                    <Slider min={0.1} max={10} step={0.1} value={[gradClip]} onValueChange={([v]) => setGradClip(v)} />
+                    <Slider min={0.1} max={10} step={0.1} value={[gradClip]} onValueChange={([v]) => setGradClip(v)} disabled={trainingStatus === "training"} />
                   </div>
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <Label>Optimizer</Label>
-                      <Select value={optimizer} onValueChange={setOptimizer}>
+                      <Select value={optimizer} onValueChange={setOptimizer} disabled={trainingStatus === "training"}>
                         <SelectTrigger><SelectValue /></SelectTrigger>
                         <SelectContent>
                           <SelectItem value="adamw">AdamW</SelectItem>
@@ -612,7 +731,7 @@ export default function ModelTrainingToolPage() {
                     </div>
                     <div className="space-y-2">
                       <Label>LR Scheduler</Label>
-                      <Select value={scheduler} onValueChange={setScheduler}>
+                      <Select value={scheduler} onValueChange={setScheduler} disabled={trainingStatus === "training"}>
                         <SelectTrigger><SelectValue /></SelectTrigger>
                         <SelectContent>
                           <SelectItem value="cosine">Cosine Annealing</SelectItem>
@@ -627,71 +746,69 @@ export default function ModelTrainingToolPage() {
                 </CardContent>
               </Card>
 
-              {/* Architecture Parameters */}
+              {/* Architecture (read from backend) */}
               <Card>
                 <CardHeader>
-                  <CardTitle className="flex items-center gap-2"><Layers className="h-5 w-5" /> Architecture Parameters</CardTitle>
-                  <CardDescription>Model structure — requires restart to apply</CardDescription>
+                  <CardTitle className="flex items-center gap-2"><Layers className="h-5 w-5" /> Model Architecture</CardTitle>
+                  <CardDescription>Read from NLM config on MAS — architecture changes require backend update</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-5">
-                  <div className="space-y-2">
-                    <Label className="flex justify-between"><span>Attention Heads</span><span className="font-mono text-sm">{attentionHeads}</span></Label>
-                    <Slider min={1} max={32} step={1} value={[attentionHeads]} onValueChange={([v]) => setAttentionHeads(v)} />
-                  </div>
-                  <div className="space-y-2">
-                    <Label className="flex justify-between"><span>Hidden Dimension</span><span className="font-mono text-sm">{hiddenDim}</span></Label>
-                    <Slider min={64} max={4096} step={64} value={[hiddenDim]} onValueChange={([v]) => setHiddenDim(v)} />
-                  </div>
-                  <div className="space-y-2">
-                    <Label className="flex justify-between"><span>Transformer Layers</span><span className="font-mono text-sm">{numLayers}</span></Label>
-                    <Slider min={1} max={24} step={1} value={[numLayers]} onValueChange={([v]) => setNumLayers(v)} />
-                  </div>
-
-                  <div className="p-4 rounded-lg bg-muted/50 border space-y-2">
-                    <h4 className="font-medium text-sm">Model Summary</h4>
-                    <div className="grid grid-cols-2 gap-1 text-xs text-muted-foreground">
-                      <span>Total Parameters:</span><span className="font-mono">{((hiddenDim * hiddenDim * 4 * numLayers + hiddenDim * 4096) / 1e6).toFixed(1)}M</span>
-                      <span>Embedding Dim:</span><span className="font-mono">{hiddenDim}</span>
-                      <span>FFN Dim:</span><span className="font-mono">{hiddenDim * 4}</span>
-                      <span>Head Dim:</span><span className="font-mono">{Math.floor(hiddenDim / attentionHeads)}</span>
-                      <span>Vocab Size:</span><span className="font-mono">4,096 bio-tokens</span>
-                      <span>Context Length:</span><span className="font-mono">8,192 frames</span>
-                    </div>
-                  </div>
-
-                  <div className="p-4 rounded-lg bg-blue-500/10 border border-blue-500/20">
-                    <h4 className="font-medium text-sm mb-2 flex items-center gap-2"><Network className="h-4 w-4 text-blue-400" /> Integration Stack</h4>
-                    <div className="grid grid-cols-2 gap-2 text-xs">
-                      {[
-                        { name: "MAS", desc: "Multi-Agent System orchestration" },
-                        { name: "HPL", desc: "Hyphae Processing Language" },
-                        { name: "MDP", desc: "Mycelium Data Protocol" },
-                        { name: "MMP", desc: "Mycelium Messaging Protocol" },
-                        { name: "MINDEX", desc: "Data provenance & indexing" },
-                        { name: "FCI", desc: "Fungal Computer Interface" },
-                      ].map(s => (
-                        <div key={s.name} className="flex items-center gap-2">
-                          <CheckCircle2 className="h-3 w-3 text-green-500 shrink-0" />
-                          <span><strong>{s.name}</strong> — {s.desc}</span>
+                  {arch ? (
+                    <>
+                      <div className="p-4 rounded-lg bg-muted/50 border space-y-2">
+                        <h4 className="font-medium text-sm">NLM Configuration (from MAS)</h4>
+                        <div className="grid grid-cols-2 gap-1 text-xs text-muted-foreground">
+                          <span>Base Model:</span><span className="font-mono">{arch.baseModel}</span>
+                          <span>Hidden Size:</span><span className="font-mono">{arch.hiddenSize}</span>
+                          <span>Layers:</span><span className="font-mono">{arch.numLayers}</span>
+                          <span>Attention Heads:</span><span className="font-mono">{arch.numAttentionHeads}</span>
+                          <span>Head Dim:</span><span className="font-mono">{arch.hiddenSize && arch.numAttentionHeads ? Math.floor(arch.hiddenSize / arch.numAttentionHeads) : "—"}</span>
+                          <span>Vocab Size:</span><span className="font-mono">{arch.vocabSize?.toLocaleString()}</span>
+                          <span>Context Length:</span><span className="font-mono">{arch.maxPositionEmbeddings?.toLocaleString()} tokens</span>
+                          <span>Fine-Tuning:</span><span className="font-mono">{arch.useLora ? `LoRA (r=${arch.loraR}, α=${arch.loraAlpha})` : "Full"}</span>
                         </div>
-                      ))}
+                      </div>
+
+                      <div className="p-4 rounded-lg bg-blue-500/10 border border-blue-500/20">
+                        <h4 className="font-medium text-sm mb-2 flex items-center gap-2"><Network className="h-4 w-4 text-blue-400" /> Integration Stack</h4>
+                        <div className="grid grid-cols-2 gap-2 text-xs">
+                          {[
+                            { name: "MAS", desc: "Multi-Agent System orchestration", ok: connections.mas },
+                            { name: "MINDEX", desc: "Data provenance & indexing", ok: connections.mindex },
+                            { name: "GPU Node", desc: "192.168.0.190 — training compute", ok: connections.gpu },
+                            { name: "MycoBrain", desc: "IoT device telemetry", ok: connections.mycobrain },
+                            { name: "NLM API", desc: "Prediction & inference", ok: data?.model.health !== null },
+                            { name: "Qdrant", desc: "Vector embeddings (189:6333)", ok: connections.mindex },
+                          ].map(s => (
+                            <div key={s.name} className="flex items-center gap-2">
+                              {s.ok ? <CheckCircle2 className="h-3 w-3 text-green-500 shrink-0" /> : <XCircle className="h-3 w-3 text-red-400 shrink-0" />}
+                              <span><strong>{s.name}</strong> — {s.desc}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="text-center py-12 text-muted-foreground">
+                      <Layers className="h-12 w-12 mx-auto mb-3 opacity-20" />
+                      <p className="text-sm">Architecture config unavailable.</p>
+                      <p className="text-xs mt-1">Connect to MAS to load the NLM model configuration.</p>
                     </div>
-                  </div>
+                  )}
                 </CardContent>
               </Card>
             </div>
           </TabsContent>
 
-          {/* ══════════════════════════════════════════════════════════════ */}
-          {/* PLASTICITY TAB                                                */}
-          {/* ══════════════════════════════════════════════════════════════ */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
+          {/* PLASTICITY TAB                                                 */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
           <TabsContent value="plasticity" className="space-y-4">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-              {/* Plasticity Controls */}
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2"><Dna className="h-5 w-5 text-purple-400" /> Neural Plasticity Engine</CardTitle>
-                  <CardDescription>Live model mutation and evolutionary adaptation</CardDescription>
+                  <CardDescription>Live model mutation — commands sent to GPU training node</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-5">
                   <div className="flex items-center justify-between">
@@ -702,7 +819,7 @@ export default function ModelTrainingToolPage() {
                   <div className="space-y-2">
                     <Label className="flex justify-between"><span>Plasticity Rate</span><span className="font-mono text-sm">{plasticityRate.toFixed(3)}</span></Label>
                     <Slider min={0.001} max={0.2} step={0.001} value={[plasticityRate]} onValueChange={([v]) => setPlasticityRate(v)} disabled={!plasticityEnabled} />
-                    <p className="text-xs text-muted-foreground">Controls the magnitude of structural changes applied during mutation events.</p>
+                    <p className="text-xs text-muted-foreground">Controls the magnitude of structural changes sent to the training node.</p>
                   </div>
 
                   <div className="space-y-2">
@@ -719,27 +836,21 @@ export default function ModelTrainingToolPage() {
                     </Select>
                   </div>
 
-                  <Button className="w-full" disabled={!plasticityEnabled || mutationMode === "none"} onClick={handleApplyMutation}>
-                    <Shuffle className="h-4 w-4 mr-2" /> Apply Mutation Now
+                  <Button className="w-full" disabled={!plasticityEnabled || mutationMode === "none" || trainingStatus !== "training" || !!actionLoading} onClick={handleApplyMutation}>
+                    {actionLoading === "mutate" ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Shuffle className="h-4 w-4 mr-2" />}
+                    Apply Mutation Now
                   </Button>
 
-                  <div className="border-t pt-4 space-y-3">
-                    <div className="flex items-center justify-between">
-                      <Label className="flex items-center gap-2"><RotateCcw className="h-4 w-4" /> Auto-Mutate on Plateau</Label>
-                      <Switch checked={autoMutate} onCheckedChange={setAutoMutate} disabled={!plasticityEnabled} />
-                    </div>
-                    <div className="space-y-2">
-                      <Label className="flex justify-between"><span>Plateau Threshold</span><span className="font-mono text-sm">{mutationThreshold}</span></Label>
-                      <Slider min={0.001} max={0.1} step={0.001} value={[mutationThreshold]} onValueChange={([v]) => setMutationThreshold(v)} disabled={!autoMutate || !plasticityEnabled} />
-                      <p className="text-xs text-muted-foreground">Triggers mutation when loss change over 5 epochs is below this threshold.</p>
-                    </div>
-                  </div>
+                  {trainingStatus !== "training" && plasticityEnabled && (
+                    <p className="text-xs text-amber-400">Training must be active to apply mutations.</p>
+                  )}
 
                   <div className="p-4 rounded-lg bg-purple-500/10 border border-purple-500/20">
                     <h4 className="font-medium text-sm mb-2">Model Evolution System</h4>
                     <p className="text-xs text-muted-foreground">
-                      NLM&apos;s plasticity engine enables live structural evolution of the model during training. Unlike static architectures,
-                      NLM can prune dead neurons, grow new pathways, rewire attention patterns, and inject controlled perturbations
+                      NLM&apos;s plasticity engine enables live structural evolution during training.
+                      Mutation commands are sent to the GPU training node which applies them to the active model.
+                      Prune dead neurons, grow new pathways, rewire attention patterns, and inject controlled perturbations
                       to escape local minima — inspired by biological neural plasticity in mycelial networks.
                     </p>
                   </div>
@@ -757,7 +868,7 @@ export default function ModelTrainingToolPage() {
                     <div className="text-center py-8 text-muted-foreground">
                       <Dna className="h-12 w-12 mx-auto mb-3 opacity-20" />
                       <p className="text-sm">No mutations applied yet.</p>
-                      <p className="text-xs">Enable plasticity and apply mutations to see the evolution log.</p>
+                      <p className="text-xs">Enable plasticity, start training, and apply mutations to see the evolution log.</p>
                     </div>
                   ) : (
                     <div className="space-y-2 max-h-[500px] overflow-y-auto">
@@ -785,9 +896,9 @@ export default function ModelTrainingToolPage() {
             </div>
           </TabsContent>
 
-          {/* ══════════════════════════════════════════════════════════════ */}
-          {/* METRICS TAB                                                   */}
-          {/* ══════════════════════════════════════════════════════════════ */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
+          {/* METRICS TAB                                                    */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
           <TabsContent value="data" className="space-y-4">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <Card>
@@ -818,70 +929,46 @@ export default function ModelTrainingToolPage() {
               <Card>
                 <CardHeader className="pb-2"><CardTitle className="text-sm">Training Progress</CardTitle></CardHeader>
                 <CardContent>
-                  <Progress value={(metrics.epoch / maxEpochs) * 100} className="h-3 mb-2" />
-                  <div className="text-xs text-muted-foreground">Epoch {metrics.epoch} of {maxEpochs} ({((metrics.epoch / maxEpochs) * 100).toFixed(1)}%)</div>
+                  <Progress value={data?.training.totalEpochs ? (data.training.epoch / data.training.totalEpochs) * 100 : 0} className="h-3 mb-2" />
+                  <div className="text-xs text-muted-foreground">Epoch {data?.training.epoch ?? 0} of {data?.training.totalEpochs || maxEpochs}</div>
                 </CardContent>
               </Card>
               <Card>
                 <CardHeader className="pb-2"><CardTitle className="text-sm">Gradient Health</CardTitle></CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">{metrics.gradientNorm.toFixed(4)}</div>
+                  <div className="text-2xl font-bold">{data?.training.gradientNorm != null ? data.training.gradientNorm.toFixed(4) : "—"}</div>
                   <div className="text-xs text-muted-foreground">
-                    {metrics.gradientNorm < 0.01 ? "Warning: Vanishing gradients" : metrics.gradientNorm > 5 ? "Warning: Exploding gradients" : "Healthy gradient flow"}
+                    {data?.training.gradientNorm != null
+                      ? data.training.gradientNorm < 0.01
+                        ? "Warning: Vanishing gradients"
+                        : data.training.gradientNorm > 5
+                          ? "Warning: Exploding gradients"
+                          : "Healthy gradient flow"
+                      : "Start training to monitor gradient health"}
                   </div>
                 </CardContent>
               </Card>
               <Card>
-                <CardHeader className="pb-2"><CardTitle className="text-sm">Data Throughput</CardTitle></CardHeader>
+                <CardHeader className="pb-2"><CardTitle className="text-sm">GPU Utilization</CardTitle></CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">{(totalSamplesIngested / 1e6).toFixed(3)}M</div>
+                  <div className="text-2xl font-bold">{gpu ? `${gpu.utilization}%` : "—"}</div>
                   <div className="text-xs text-muted-foreground">
-                    Total samples processed from {onlineCount} devices at {totalDataRate} samples/sec
+                    {gpu ? `${gpu.name} — ${gpu.memoryUsed}MB/${gpu.memoryTotal}MB VRAM` : "GPU node not connected (192.168.0.190)"}
                   </div>
                 </CardContent>
               </Card>
             </div>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2"><TrendingUp className="h-5 w-5" /> Inference Test</CardTitle>
-                <CardDescription>Feed a test signal and see model output in real time</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="p-4 rounded-lg bg-muted/50 border">
-                    <h4 className="text-sm font-medium mb-2">Input Signal (Raw)</h4>
-                    <div className="font-mono text-xs text-green-400 bg-background p-3 rounded overflow-x-auto">
-                      {`[${Array.from({ length: 8 }, () => (Math.random() * 2 - 1).toFixed(3)).join(", ")}...]`}
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-2">8192-frame window from Mushroom 1 FCI electrode array</p>
-                  </div>
-                  <div className="p-4 rounded-lg bg-muted/50 border">
-                    <h4 className="text-sm font-medium mb-2">Model Output (Inference)</h4>
-                    <pre className="font-mono text-xs text-amber-400 bg-background p-3 rounded overflow-x-auto">
-{`{
-  "state": "nutrient_seeking",
-  "confidence": ${(0.5 + Math.random() * 0.45).toFixed(3)},
-  "bio_tokens": ["t17_burst", "co2_rise"],
-  "predicted_next": "growth_shift",
-  "uncertainty": ${(Math.random() * 0.3).toFixed(3)}
-}`}
-                    </pre>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
           </TabsContent>
 
-          {/* ══════════════════════════════════════════════════════════════ */}
-          {/* CHECKPOINTS TAB                                               */}
-          {/* ══════════════════════════════════════════════════════════════ */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
+          {/* CHECKPOINTS TAB                                                */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
           <TabsContent value="checkpoints" className="space-y-4">
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
               <Card className="lg:col-span-2">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2"><Save className="h-5 w-5" /> Saved Checkpoints</CardTitle>
-                  <CardDescription>Model weights stored in MINDEX + local NAS</CardDescription>
+                  <CardDescription>Model weights stored via MAS on MINDEX + NAS</CardDescription>
                 </CardHeader>
                 <CardContent>
                   {checkpoints.length === 0 ? (
@@ -892,21 +979,25 @@ export default function ModelTrainingToolPage() {
                     </div>
                   ) : (
                     <div className="space-y-2">
-                      {checkpoints.map(cp => (
-                        <div key={cp.id} className="flex items-center justify-between p-3 rounded-lg border bg-muted/30">
+                      {checkpoints.map((cp: any) => (
+                        <div key={cp.id || cp.checkpoint_id} className="flex items-center justify-between p-3 rounded-lg border bg-muted/30">
                           <div className="flex items-center gap-3">
                             <div className="w-8 h-8 rounded bg-purple-500/20 flex items-center justify-center text-xs font-bold">{cp.epoch}</div>
                             <div>
-                              <div className="text-sm font-medium">Epoch {cp.epoch}</div>
+                              <div className="text-sm font-medium">Epoch {cp.epoch}{cp.label ? ` — ${cp.label}` : ""}</div>
                               <div className="text-xs text-muted-foreground">
-                                Loss: {cp.loss.toFixed(4)} | Acc: {cp.accuracy.toFixed(2)}% | {cp.location}
+                                Loss: {cp.loss?.toFixed(4) ?? "—"} | Acc: {cp.accuracy?.toFixed(2) ?? "—"}% | {cp.location || cp.storage || "MAS"}
                               </div>
                             </div>
                           </div>
                           <div className="flex items-center gap-2">
-                            <span className="text-xs text-muted-foreground">{new Date(cp.timestamp).toLocaleString()}</span>
-                            <Button size="sm" variant="ghost" className="h-7 text-xs"><SkipForward className="h-3 w-3 mr-1" /> Load</Button>
-                            <Button size="sm" variant="ghost" className="h-7 text-xs"><Download className="h-3 w-3 mr-1" /> Export</Button>
+                            <span className="text-xs text-muted-foreground">{cp.created_at ? new Date(cp.created_at).toLocaleString() : ""}</span>
+                            <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={() => handleLoadCheckpoint(cp.id || cp.checkpoint_id)} disabled={!!actionLoading}>
+                              <SkipForward className="h-3 w-3 mr-1" /> Load
+                            </Button>
+                            <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={() => sendAction("export", { checkpointId: cp.id || cp.checkpoint_id })} disabled={!!actionLoading}>
+                              <Download className="h-3 w-3 mr-1" /> Export
+                            </Button>
                           </div>
                         </div>
                       ))}
@@ -922,20 +1013,20 @@ export default function ModelTrainingToolPage() {
                   </CardHeader>
                   <CardContent className="space-y-3 text-sm">
                     <div className="flex items-center justify-between">
-                      <span>MINDEX</span>
-                      <Badge variant={mindexConnected ? "default" : "destructive"} className="text-xs">{mindexConnected ? "Connected" : "Disconnected"}</Badge>
+                      <span>MINDEX (189:8000)</span>
+                      <Badge variant={connections.mindex ? "default" : "destructive"} className="text-xs">{connections.mindex ? "Connected" : "Disconnected"}</Badge>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span>Local NAS</span>
-                      <Badge variant={nasConnected ? "default" : "destructive"} className="text-xs">{nasConnected ? "Connected" : "Disconnected"}</Badge>
+                      <span>GPU Node (190)</span>
+                      <Badge variant={connections.gpu ? "default" : "destructive"} className="text-xs">{connections.gpu ? "Connected" : "Disconnected"}</Badge>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>MAS (188:8001)</span>
+                      <Badge variant={connections.mas ? "default" : "destructive"} className="text-xs">{connections.mas ? "Connected" : "Disconnected"}</Badge>
                     </div>
                     <div className="flex items-center justify-between">
                       <span>Checkpoints</span>
                       <span className="font-mono">{checkpoints.length}</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span>Auto-Save</span>
-                      <Switch defaultChecked />
                     </div>
                   </CardContent>
                 </Card>
@@ -945,13 +1036,85 @@ export default function ModelTrainingToolPage() {
                     <CardTitle className="text-sm">Weight Versioning</CardTitle>
                   </CardHeader>
                   <CardContent className="text-xs text-muted-foreground space-y-2">
-                    <p>All checkpoints are versioned in MINDEX with full provenance — device source, training config, mutation history, and dataset snapshot hash.</p>
-                    <p>Weights are also synced to the local NAS for fast restore and offline training continuity.</p>
+                    <p>All checkpoints are versioned via MAS with full provenance — device source, training config, mutation history, and dataset snapshot hash.</p>
+                    <p>Weights are stored on MINDEX (Postgres + Qdrant) and synced to NAS for fast restore and offline training continuity.</p>
                     <p>Load any checkpoint to resume training from that point or compare model behavior across versions.</p>
                   </CardContent>
                 </Card>
               </div>
             </div>
+          </TabsContent>
+
+          {/* ═══════════════════════════════════════════════════════════════ */}
+          {/* INFERENCE TAB                                                  */}
+          {/* ═══════════════════════════════════════════════════════════════ */}
+          <TabsContent value="inference" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2"><Brain className="h-5 w-5 text-purple-400" /> NLM Inference Test</CardTitle>
+                <CardDescription>Send a query to the live NLM model via MAS and see the real response</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label>Input Query</Label>
+                    <Textarea
+                      value={inferenceInput}
+                      onChange={(e) => setInferenceInput(e.target.value)}
+                      placeholder="e.g., What are the key characteristics of Ganoderma lucidum?"
+                      className="min-h-[200px] font-mono text-xs"
+                    />
+                    <Button onClick={handleRunInference} disabled={inferenceLoading || !inferenceInput.trim()}>
+                      {inferenceLoading ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Zap className="h-4 w-4 mr-2" />}
+                      Run Inference
+                    </Button>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Model Response</Label>
+                    <Card className="min-h-[200px] p-3">
+                      {inferenceOutput ? (
+                        inferenceOutput.error ? (
+                          <div className="text-sm text-red-400">
+                            <p className="font-medium">Error:</p>
+                            <pre className="whitespace-pre-wrap break-words text-xs mt-1">{inferenceOutput.error}</pre>
+                            {inferenceOutput.detail && <pre className="whitespace-pre-wrap break-words text-xs mt-1 text-muted-foreground">{inferenceOutput.detail}</pre>}
+                          </div>
+                        ) : (
+                          <div className="space-y-2">
+                            <pre className="whitespace-pre-wrap break-words text-xs">{inferenceOutput.text}</pre>
+                            <div className="border-t pt-2 mt-2 grid grid-cols-2 gap-1 text-[10px] text-muted-foreground">
+                              {inferenceOutput.model && <div>Model: {inferenceOutput.model}</div>}
+                              {inferenceOutput.confidence != null && <div>Confidence: {(inferenceOutput.confidence * 100).toFixed(1)}%</div>}
+                              {inferenceOutput.tokens_used != null && <div>Tokens: {inferenceOutput.tokens_used}</div>}
+                              {inferenceOutput.latency_ms != null && <div>Latency: {inferenceOutput.latency_ms.toFixed(0)}ms</div>}
+                            </div>
+                            {inferenceOutput.sources?.length > 0 && (
+                              <div className="border-t pt-2 text-xs">
+                                <span className="text-muted-foreground">Sources: </span>
+                                {inferenceOutput.sources.join(", ")}
+                              </div>
+                            )}
+                          </div>
+                        )
+                      ) : (
+                        <p className="text-xs text-muted-foreground">Enter a query and run inference to see the NLM model response.</p>
+                      )}
+                    </Card>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* NLM Mycospeak Translator (existing component) */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2"><Dna className="h-5 w-5 text-green-400" /> Mycospeak Signal Interpreter</CardTitle>
+                <CardDescription>Feed bioelectric signal data and get NLM interpretation</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <NlmDemo />
+              </CardContent>
+            </Card>
           </TabsContent>
         </Tabs>
       </div>


### PR DESCRIPTION
## Summary
- Rewrote `/natureos/model-training` page from 100% client-side mock simulation to real backend integration
- New `/api/natureos/nlm-training` route proxies to MAS NLM endpoints, GPU node, MAS Device Registry, MycoBrain, and MINDEX in parallel
- All training controls (start/stop/pause/resume/checkpoint/export/mutate) send real POST requests to MAS
- Real device fleet from MAS Device Registry, real GPU metrics via nvidia-smi, real NLM model architecture from config
- Added Inference tab with freeform NLM query + Mycospeak translator
- Zero mock data remains — every value comes from a real API call

**Companion PR:** MycosoftLabs/mycosoft-mas — `claude/nlm-training-control-api` (MAS-side training control router + GPU training service)

## Test plan
- [ ] Verify page loads and shows connection status for MAS/MINDEX/GPU/MycoBrain
- [ ] Verify real devices appear from MAS Device Registry
- [ ] Verify Start Training sends POST to MAS and training status updates
- [ ] Verify GPU metrics display when GPU node is reachable
- [ ] Verify inference tab returns real NLM responses
- [ ] Verify checkpoints save/load through MAS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace the NLM training UI’s client-side simulation with a real backend-driven dashboard that controls and monitors NLM training via MAS and related services.

New Features:
- Add a Next.js API route that aggregates NLM training status, GPU metrics, device fleet data, checkpoints, and MINDEX stats from MAS and MINDEX backends.
- Introduce real training control actions (start, stop, pause, resume, checkpoint, load, mutate, export, inference) wired from the UI to MAS APIs.
- Add an inference tab with freeform NLM query support and Mycospeak signal interpreter integration in the training tool UI.

Enhancements:
- Update the NLM training page to consume live backend data for training metrics, devices, architecture, and GPU status instead of local mock state.
- Improve UI feedback with connection badges, loading and error states, and backend-sourced architecture and integration stack summaries.