### PR TITLE
fix(ci): add SSH retry for flaky Cloudflare tunnel deploys

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -340,23 +340,52 @@ jobs:
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
             ProxyCommand cloudflared access ssh --hostname %h
-            ServerAliveInterval 60
-            ServerAliveCountMax 120
+            ConnectTimeout 30
+            ConnectionAttempts 3
+            ServerAliveInterval 30
+            ServerAliveCountMax 6
           EOF
           chmod 600 ~/.ssh/config
+
+          # Create retry wrapper for SSH commands through flaky tunnels
+          cat > /usr/local/bin/ssh-retry <<'RETRYSCRIPT'
+          #!/usr/bin/env bash
+          MAX_ATTEMPTS=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "SSH attempt $attempt/$MAX_ATTEMPTS..."
+            if ssh "$@"; then
+              exit 0
+            fi
+            rc=$?
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "SSH failed (exit $rc), retrying in ${DELAY}s..."
+              sleep $DELAY
+              DELAY=$((DELAY * 2))
+            fi
+          done
+          echo "::error::SSH failed after $MAX_ATTEMPTS attempts"
+          exit 1
+          RETRYSCRIPT
+          chmod +x /usr/local/bin/ssh-retry
+
+      - name: Verify tunnel connectivity
+        run: |
+          echo "Testing Cloudflare tunnel connectivity..."
+          ssh-retry production 'echo "Tunnel OK — $(hostname) — $(date)"'
 
       - name: Backup database
         continue-on-error: true
         run: |
-          ssh production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T postgres pg_dump -U mycosoft mycosoft > /backup/db-$(date +%Y%m%d-%H%M%S).sql 2>/dev/null || echo "No existing database to backup (first deploy?) — skipping"'
+          ssh-retry production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T postgres pg_dump -U mycosoft mycosoft > /backup/db-$(date +%Y%m%d-%H%M%S).sql 2>/dev/null || echo "No existing database to backup (first deploy?) — skipping"'
 
       - name: Sync compose file
         run: |
-          ssh production 'cd /opt/mycosoft/website && git fetch origin main && git checkout origin/main -- docker-compose.production.yml'
+          ssh-retry production 'cd /opt/mycosoft/website && git fetch origin main && git checkout origin/main -- docker-compose.production.yml'
 
       - name: Inject environment variables
         run: |
-          ssh production bash -s <<'ENVSCRIPT'
+          ssh-retry production bash -s <<'ENVSCRIPT'
             set -e
             cd /opt/mycosoft/website
             touch .env
@@ -364,7 +393,7 @@ jobs:
               sed -i "/^${var}=/d" .env
             done
           ENVSCRIPT
-          ssh production bash -s <<ENVSCRIPT2
+          ssh-retry production bash -s <<ENVSCRIPT2
             cd /opt/mycosoft/website
             echo 'NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}' >> .env
             echo 'NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}' >> .env
@@ -383,10 +412,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ssh production bash -s <<'BUILD'
+          ssh-retry production bash -s <<'BUILD'
             set -e
             cd /opt/mycosoft/website
-            
+
             echo "=== Authenticating with GHCR ==="
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
@@ -408,11 +437,11 @@ jobs:
       - name: Run database migrations
         continue-on-error: true
         run: |
-          ssh production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T website npm run db:migrate --if-present 2>/dev/null || echo "Migration skipped (no migrations or db not ready)"'
+          ssh-retry production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T website npm run db:migrate --if-present 2>/dev/null || echo "Migration skipped (no migrations or db not ready)"'
 
       - name: Health check
         run: |
-          ssh production bash -s <<'SCRIPT'
+          ssh-retry production bash -s <<'SCRIPT'
           echo "=== Waiting for service to be healthy ==="
           for i in 1 2 3 4 5; do
             if curl -sf http://localhost:3000/api/health; then
@@ -495,14 +524,38 @@ jobs:
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
             ProxyCommand cloudflared access ssh --hostname %h
-            ServerAliveInterval 60
-            ServerAliveCountMax 120
+            ConnectTimeout 30
+            ConnectionAttempts 3
+            ServerAliveInterval 30
+            ServerAliveCountMax 6
           EOF
           chmod 600 ~/.ssh/config
 
+          # Create retry wrapper for SSH commands through flaky tunnels
+          cat > /usr/local/bin/ssh-retry <<'RETRYSCRIPT'
+          #!/usr/bin/env bash
+          MAX_ATTEMPTS=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "SSH attempt $attempt/$MAX_ATTEMPTS..."
+            if ssh "$@"; then
+              exit 0
+            fi
+            rc=$?
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "SSH failed (exit $rc), retrying in ${DELAY}s..."
+              sleep $DELAY
+              DELAY=$((DELAY * 2))
+            fi
+          done
+          echo "::error::SSH failed after $MAX_ATTEMPTS attempts"
+          exit 1
+          RETRYSCRIPT
+          chmod +x /usr/local/bin/ssh-retry
+
       - name: Pull latest code on VM
         run: |
-          ssh production bash -s <<'SCRIPT'
+          ssh-retry production bash -s <<'SCRIPT'
             set -e
             cd /opt/mycosoft/website
             git fetch origin main
@@ -512,7 +565,7 @@ jobs:
 
       - name: Inject environment variables
         run: |
-          ssh production bash -s <<'ENVSCRIPT'
+          ssh-retry production bash -s <<'ENVSCRIPT'
             set -e
             cd /opt/mycosoft/website
             touch .env
@@ -520,7 +573,7 @@ jobs:
               sed -i "/^${var}=/d" .env
             done
           ENVSCRIPT
-          ssh production bash -s <<ENVSCRIPT2
+          ssh-retry production bash -s <<ENVSCRIPT2
             cd /opt/mycosoft/website
             echo 'NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}' >> .env
             echo 'NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}' >> .env
@@ -536,7 +589,7 @@ jobs:
 
       - name: Build and deploy on VM
         run: |
-          ssh production bash -s <<'BUILD'
+          ssh-retry production bash -s <<'BUILD'
             set -e
             cd /opt/mycosoft/website
 
@@ -573,7 +626,7 @@ jobs:
 
       - name: Health check
         run: |
-          ssh production bash -s <<'SCRIPT'
+          ssh-retry production bash -s <<'SCRIPT'
           for i in 1 2 3 4 5 6; do
             if curl -sf http://localhost:3000/api/health; then
               echo ""

--- a/.github/workflows/deploy-sandbox-production.yml
+++ b/.github/workflows/deploy-sandbox-production.yml
@@ -102,10 +102,34 @@ jobs:
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
             ProxyCommand cloudflared access ssh --hostname %h
-            ServerAliveInterval 60
-            ServerAliveCountMax 120
+            ConnectTimeout 30
+            ConnectionAttempts 3
+            ServerAliveInterval 30
+            ServerAliveCountMax 6
           EOF
           chmod 600 ~/.ssh/config
+
+          # Create retry wrapper for SSH commands through flaky tunnels
+          cat > /usr/local/bin/ssh-retry <<'RETRYSCRIPT'
+          #!/usr/bin/env bash
+          MAX_ATTEMPTS=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "SSH attempt $attempt/$MAX_ATTEMPTS..."
+            if ssh "$@"; then
+              exit 0
+            fi
+            rc=$?
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "SSH failed (exit $rc), retrying in ${DELAY}s..."
+              sleep $DELAY
+              DELAY=$((DELAY * 2))
+            fi
+          done
+          echo "::error::SSH failed after $MAX_ATTEMPTS attempts"
+          exit 1
+          RETRYSCRIPT
+          chmod +x /usr/local/bin/ssh-retry
 
       - name: Deploy to Sandbox VM
         env:
@@ -115,9 +139,9 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          echo "${GH_TOKEN}" | ssh production docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${GH_TOKEN}" | ssh-retry production docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-          ssh production bash -s <<DEPLOY
+          ssh-retry production bash -s <<DEPLOY
             set -e
             BASE_URL="https://mycosoft.com"
 


### PR DESCRIPTION
## Summary
- All recent production deploys are failing with `dial tcp ***:443: connect: connection timed out` — the Cloudflare tunnel to Sandbox VM (187) is intermittent
- Added `ssh-retry` wrapper that retries failed SSH commands 3x with exponential backoff (15s, 30s)
- Added `ConnectTimeout 30` and `ConnectionAttempts 3` to SSH config
- Added tunnel connectivity verification step before deploy starts
- Applied to both `ci-cd.yml` (production + instant deploy paths) and `deploy-sandbox-production.yml`

## Test plan
- [ ] Merge and verify deploy succeeds (or retries and succeeds)
- [ ] If tunnel is completely down, deploy fails cleanly after 3 attempts instead of hanging for 2+ minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden CI deployment workflows against flaky Cloudflare SSH tunnels by adding a retry wrapper, connectivity checks, and stricter SSH timeouts for production and sandbox deploys.

CI:
- Add an ssh-retry wrapper script with limited retry attempts and exponential backoff for all SSH-based deploy steps in production and sandbox workflows.
- Introduce a pre-deploy Cloudflare tunnel connectivity check in the main CI/CD workflow.
- Tighten SSH configuration in GitHub Actions to use connection timeouts and limited connection attempts tailored for unstable tunnels.