### PR TITLE
fix(crep): prevent dashboard crash from undefined passes prop

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -340,23 +340,52 @@ jobs:
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
             ProxyCommand cloudflared access ssh --hostname %h
-            ServerAliveInterval 60
-            ServerAliveCountMax 120
+            ConnectTimeout 30
+            ConnectionAttempts 3
+            ServerAliveInterval 30
+            ServerAliveCountMax 6
           EOF
           chmod 600 ~/.ssh/config
+
+          # Create retry wrapper for SSH commands through flaky tunnels
+          cat > /usr/local/bin/ssh-retry <<'RETRYSCRIPT'
+          #!/usr/bin/env bash
+          MAX_ATTEMPTS=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "SSH attempt $attempt/$MAX_ATTEMPTS..."
+            if ssh "$@"; then
+              exit 0
+            fi
+            rc=$?
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "SSH failed (exit $rc), retrying in ${DELAY}s..."
+              sleep $DELAY
+              DELAY=$((DELAY * 2))
+            fi
+          done
+          echo "::error::SSH failed after $MAX_ATTEMPTS attempts"
+          exit 1
+          RETRYSCRIPT
+          chmod +x /usr/local/bin/ssh-retry
+
+      - name: Verify tunnel connectivity
+        run: |
+          echo "Testing Cloudflare tunnel connectivity..."
+          ssh-retry production 'echo "Tunnel OK — $(hostname) — $(date)"'
 
       - name: Backup database
         continue-on-error: true
         run: |
-          ssh production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T postgres pg_dump -U mycosoft mycosoft > /backup/db-$(date +%Y%m%d-%H%M%S).sql 2>/dev/null || echo "No existing database to backup (first deploy?) — skipping"'
+          ssh-retry production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T postgres pg_dump -U mycosoft mycosoft > /backup/db-$(date +%Y%m%d-%H%M%S).sql 2>/dev/null || echo "No existing database to backup (first deploy?) — skipping"'
 
       - name: Sync compose file
         run: |
-          ssh production 'cd /opt/mycosoft/website && git fetch origin main && git checkout origin/main -- docker-compose.production.yml'
+          ssh-retry production 'cd /opt/mycosoft/website && git fetch origin main && git checkout origin/main -- docker-compose.production.yml'
 
       - name: Inject environment variables
         run: |
-          ssh production bash -s <<'ENVSCRIPT'
+          ssh-retry production bash -s <<'ENVSCRIPT'
             set -e
             cd /opt/mycosoft/website
             touch .env
@@ -364,7 +393,7 @@ jobs:
               sed -i "/^${var}=/d" .env
             done
           ENVSCRIPT
-          ssh production bash -s <<ENVSCRIPT2
+          ssh-retry production bash -s <<ENVSCRIPT2
             cd /opt/mycosoft/website
             echo 'NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}' >> .env
             echo 'NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}' >> .env
@@ -383,10 +412,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ssh production bash -s <<'BUILD'
+          ssh-retry production bash -s <<'BUILD'
             set -e
             cd /opt/mycosoft/website
-            
+
             echo "=== Authenticating with GHCR ==="
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
@@ -408,11 +437,11 @@ jobs:
       - name: Run database migrations
         continue-on-error: true
         run: |
-          ssh production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T website npm run db:migrate --if-present 2>/dev/null || echo "Migration skipped (no migrations or db not ready)"'
+          ssh-retry production 'cd /opt/mycosoft/website && docker compose -f docker-compose.production.yml exec -T website npm run db:migrate --if-present 2>/dev/null || echo "Migration skipped (no migrations or db not ready)"'
 
       - name: Health check
         run: |
-          ssh production bash -s <<'SCRIPT'
+          ssh-retry production bash -s <<'SCRIPT'
           echo "=== Waiting for service to be healthy ==="
           for i in 1 2 3 4 5; do
             if curl -sf http://localhost:3000/api/health; then
@@ -495,14 +524,38 @@ jobs:
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
             ProxyCommand cloudflared access ssh --hostname %h
-            ServerAliveInterval 60
-            ServerAliveCountMax 120
+            ConnectTimeout 30
+            ConnectionAttempts 3
+            ServerAliveInterval 30
+            ServerAliveCountMax 6
           EOF
           chmod 600 ~/.ssh/config
 
+          # Create retry wrapper for SSH commands through flaky tunnels
+          cat > /usr/local/bin/ssh-retry <<'RETRYSCRIPT'
+          #!/usr/bin/env bash
+          MAX_ATTEMPTS=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "SSH attempt $attempt/$MAX_ATTEMPTS..."
+            if ssh "$@"; then
+              exit 0
+            fi
+            rc=$?
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "SSH failed (exit $rc), retrying in ${DELAY}s..."
+              sleep $DELAY
+              DELAY=$((DELAY * 2))
+            fi
+          done
+          echo "::error::SSH failed after $MAX_ATTEMPTS attempts"
+          exit 1
+          RETRYSCRIPT
+          chmod +x /usr/local/bin/ssh-retry
+
       - name: Pull latest code on VM
         run: |
-          ssh production bash -s <<'SCRIPT'
+          ssh-retry production bash -s <<'SCRIPT'
             set -e
             cd /opt/mycosoft/website
             git fetch origin main
@@ -512,7 +565,7 @@ jobs:
 
       - name: Inject environment variables
         run: |
-          ssh production bash -s <<'ENVSCRIPT'
+          ssh-retry production bash -s <<'ENVSCRIPT'
             set -e
             cd /opt/mycosoft/website
             touch .env
@@ -520,7 +573,7 @@ jobs:
               sed -i "/^${var}=/d" .env
             done
           ENVSCRIPT
-          ssh production bash -s <<ENVSCRIPT2
+          ssh-retry production bash -s <<ENVSCRIPT2
             cd /opt/mycosoft/website
             echo 'NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}' >> .env
             echo 'NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}' >> .env
@@ -536,7 +589,7 @@ jobs:
 
       - name: Build and deploy on VM
         run: |
-          ssh production bash -s <<'BUILD'
+          ssh-retry production bash -s <<'BUILD'
             set -e
             cd /opt/mycosoft/website
 
@@ -573,7 +626,7 @@ jobs:
 
       - name: Health check
         run: |
-          ssh production bash -s <<'SCRIPT'
+          ssh-retry production bash -s <<'SCRIPT'
           for i in 1 2 3 4 5 6; do
             if curl -sf http://localhost:3000/api/health; then
               echo ""

--- a/.github/workflows/deploy-sandbox-production.yml
+++ b/.github/workflows/deploy-sandbox-production.yml
@@ -102,10 +102,34 @@ jobs:
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
             ProxyCommand cloudflared access ssh --hostname %h
-            ServerAliveInterval 60
-            ServerAliveCountMax 120
+            ConnectTimeout 30
+            ConnectionAttempts 3
+            ServerAliveInterval 30
+            ServerAliveCountMax 6
           EOF
           chmod 600 ~/.ssh/config
+
+          # Create retry wrapper for SSH commands through flaky tunnels
+          cat > /usr/local/bin/ssh-retry <<'RETRYSCRIPT'
+          #!/usr/bin/env bash
+          MAX_ATTEMPTS=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "SSH attempt $attempt/$MAX_ATTEMPTS..."
+            if ssh "$@"; then
+              exit 0
+            fi
+            rc=$?
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "SSH failed (exit $rc), retrying in ${DELAY}s..."
+              sleep $DELAY
+              DELAY=$((DELAY * 2))
+            fi
+          done
+          echo "::error::SSH failed after $MAX_ATTEMPTS attempts"
+          exit 1
+          RETRYSCRIPT
+          chmod +x /usr/local/bin/ssh-retry
 
       - name: Deploy to Sandbox VM
         env:
@@ -115,9 +139,9 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          echo "${GH_TOKEN}" | ssh production docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${GH_TOKEN}" | ssh-retry production docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-          ssh production bash -s <<DEPLOY
+          ssh-retry production bash -s <<DEPLOY
             set -e
             BASE_URL="https://mycosoft.com"
 

--- a/components/crep/ground-station/GSPassTimeline.tsx
+++ b/components/crep/ground-station/GSPassTimeline.tsx
@@ -32,7 +32,7 @@ interface GSPassTimelineProps {
 }
 
 export function GSPassTimeline({
-  passes,
+  passes = [],
   hoursWindow = 24,
   onSelectPass,
   onTrackSatellite,


### PR DESCRIPTION
## Summary
- `GSPassTimeline` was rendered without a `passes` prop in `CREPDashboardClient.tsx:5212`, causing `passes.filter()` to throw `TypeError: Cannot read properties of undefined (reading 'filter')`
- This crashed the entire CREP dashboard (caught by error boundary, showing "CREP Dashboard Error")
- Fix: default `passes = []` in the component's destructured props

## Test plan
- [ ] Visit https://mycosoft.com/dashboard/crep — should load the full map instead of showing error
- [ ] Ground station pass timeline renders empty when no passes available
- [ ] No console errors related to `.filter()` on undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve deployment reliability over Cloudflare tunnels and prevent the CREP ground station timeline from crashing when no passes are provided.

Bug Fixes:
- Default the CREP ground station pass timeline component to an empty passes list to avoid crashes when the prop is omitted.

Build:
- Add an ssh-retry wrapper script with exponential backoff for SSH commands in CI/CD workflows to better tolerate flaky Cloudflare tunnels.
- Tune SSH configuration in deployment workflows with connect timeouts, limited connection attempts, and shorter server keepalive settings.
- Update deployment and backup steps in CI workflows to use the ssh-retry wrapper for all remote SSH operations.

CI:
- Add tunnel connectivity verification step in CI to ensure Cloudflare SSH access before running deployment steps.

Deployment:
- Use ssh-retry for sandbox and production deployment commands to make remote deployments more robust against transient tunnel failures.