### PR TITLE
fix(deploy): bind Next.js to 0.0.0.0 in production Docker

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -70,6 +70,9 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
+      # Next.js standalone binds to HOSTNAME — force 0.0.0.0 so healthcheck
+      # (curl localhost:3000) works regardless of container/VM hostname.
+      - HOSTNAME=0.0.0.0
       # Data layer (in-stack)
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=redis://redis:6379


### PR DESCRIPTION
## Summary
- **Root cause of mycosoft.com being down**: Next.js 15 standalone server binds to `HOSTNAME` env var. The VM sets `HOSTNAME=mycosoft-sandbox`, so Next.js only listened on the container's internal IP (`172.28.0.5:3000`) — not `0.0.0.0` or `localhost`
- Docker healthcheck (`curl localhost:3000`) failed → website marked `unhealthy` → `cloudflared` refused to start (depends_on: service_healthy) → **entire Cloudflare tunnel was down**
- Fix: explicitly set `HOSTNAME=0.0.0.0` in `docker-compose.production.yml`

## Cascade
```
HOSTNAME=mycosoft-sandbox (VM env leaked into container)
  → Next.js binds to 172.28.0.5:3000 only
    → healthcheck curl localhost:3000 → connection refused
      → website container: unhealthy
        → cloudflared won't start (depends_on: service_healthy)
          → Cloudflare tunnel dead
            → CI/CD SSH timeout (all 3 retries)
              → deploy failed
```

## Already deployed
Hot-fixed directly on Sandbox VM via LAN SSH — site should be back up.

## Test plan
- [x] Verified `/proc/net/tcp` shows `00000000:0BB8` (0.0.0.0:3000) after fix
- [x] Healthcheck returns valid JSON from inside container
- [ ] https://mycosoft.com loads
- [ ] CI/CD deploy succeeds through tunnel on next merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deployment:
- Set HOSTNAME=0.0.0.0 for the web service in docker-compose.production.yml so the Next.js server listens on all interfaces and the Docker healthcheck can succeed.