### PR TITLE
Fix ssh-retry chmod permission error in setup-ssh action

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -206,7 +206,7 @@ runs:
           echo 'echo "::error::  5. SSH behind Cloudflare Access — set CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET (Service Auth token) in repo secrets"'
           echo 'exit 1'
         } | sudo tee /usr/local/bin/ssh-retry > /dev/null
-        chmod +x /usr/local/bin/ssh-retry
+        sudo chmod +x /usr/local/bin/ssh-retry
 
     - name: Verify tunnel connectivity
       shell: bash


### PR DESCRIPTION
Add sudo to chmod command since the file is owned by root after sudo tee.

https://claude.ai/code/session_015C86PjpcWQNPVuNzBposKL

## Summary by Sourcery

Bug Fixes:
- Run chmod with sudo for /usr/local/bin/ssh-retry to avoid permission errors after creation with sudo tee.