### PR TITLE
fix(map): replace fragile styledata+setTimeout with style.load

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -325,7 +325,7 @@ type LayerDataStatus = "real" | "planned_real" | "mock";
 interface LayerConfig {
   id: string;
   name: string;
-  category: "events" | "devices" | "environment" | "infrastructure" | "human" | "military" | "pollution" | "imagery" | "telecom" | "facilities" | "tracking";
+  category: "events" | "devices" | "environment" | "infrastructure" | "human" | "military" | "pollution" | "imagery" | "telecom" | "facilities";
   icon: React.ReactNode;
   enabled: boolean;
   opacity: number;
@@ -551,7 +551,6 @@ const layerCategories = {
   imagery: { label: "Earth Observation", icon: <Globe className="w-3.5 h-3.5" />, color: "text-teal-400" },
   telecom: { label: "Telecom & Infrastructure", icon: <Radio className="w-3.5 h-3.5" />, color: "text-violet-400" },
   facilities: { label: "Facilities", icon: <MapPin className="w-3.5 h-3.5" />, color: "text-pink-400" },
-  tracking: { label: "Ground Station & Tracking", icon: <Radio className="w-3.5 h-3.5" />, color: "text-cyan-400" },
 };
 
 // Event marker component with detailed popup
@@ -1429,7 +1428,6 @@ function LayerControlPanel({
       imagery: [],
       telecom: [],
       facilities: [],
-      tracking: [],
     };
     layers.forEach(layer => {
       groups[layer.category]?.push(layer);
@@ -1723,9 +1721,8 @@ export default function CREPDashboardPage() {
   const [showSmartFenceWidget, setShowSmartFenceWidget] = useState(false);
   const [showPresenceWidget, setShowPresenceWidget] = useState(false);
 
-  // Ground Station — driven by the "groundStation" layer in the unified layer system
-  const gsLayerEnabled = layers.find(l => l.id === "groundStation")?.enabled ?? false;
-  const gsLayerOpacity = layers.find(l => l.id === "groundStation")?.opacity ?? 1;
+  // Ground Station overlay state (Mar 2026)
+  const [showGroundStation, setShowGroundStation] = useState(true); // Enabled by default — ground station is core CREP functionality
 
   
   // Selected entity states for map interaction
@@ -2046,10 +2043,6 @@ export default function CREPDashboardPage() {
     { id: "hospitals", name: "Hospitals", category: "facilities", icon: <Cross className="w-3 h-3" />, enabled: false, opacity: 0.7, color: "#ec4899", description: "Hospital locations from OpenStreetMap" },
     { id: "fireStations", name: "Fire Stations", category: "facilities", icon: <Flame className="w-3 h-3" />, enabled: false, opacity: 0.7, color: "#ef4444", description: "Fire station locations from OSM" },
     { id: "universities", name: "Universities", category: "facilities", icon: <BookOpen className="w-3 h-3" />, enabled: false, opacity: 0.6, color: "#6d28d9", description: "University and college locations" },
-    // ===============================================================
-    // TRACKING
-    // ===============================================================
-    { id: "groundStation", name: "Ground Station", category: "tracking", icon: <Radio className="w-3 h-3" />, enabled: true, opacity: 1, color: "#06b6d4", description: "Satellite tracking ground station, SDR receiver, pass scheduling" },
   ]);
   
   // Event filter removed - groundFilter + spaceWeatherFilter drive event visibility
@@ -4370,26 +4363,22 @@ export default function CREPDashboardPage() {
             )}
 
             {/* NASA GIBS Satellite Imagery Base Layers */}
-            {mapRef && (
-              <GibsBaseLayers
-                map={mapRef}
-                enabledLayers={{
-                  modis: layers.find(l => l.id === "gibsModis")?.enabled ?? false,
-                  viirs: layers.find(l => l.id === "gibsViirs")?.enabled ?? false,
-                  landsat: layers.find(l => l.id === "gibsLandsat")?.enabled ?? false,
-                }}
-                opacity={0.4}
-              />
-            )}
+            <GibsBaseLayers
+              map={mapRef}
+              enabledLayers={{
+                modis: layers.find(l => l.id === "gibsModis")?.enabled ?? false,
+                viirs: layers.find(l => l.id === "gibsViirs")?.enabled ?? false,
+                landsat: layers.find(l => l.id === "gibsLandsat")?.enabled ?? false,
+              }}
+              opacity={0.4}
+            />
 
             {/* Aurora Forecast Overlay */}
-            {mapRef && (
-              <AuroraOverlay
-                map={mapRef}
-                enabled={layers.find(l => l.id === "auroraOverlay")?.enabled ?? false}
-                opacity={0.5}
-              />
-            )}
+            <AuroraOverlay
+              map={mapRef}
+              enabled={layers.find(l => l.id === "auroraOverlay")?.enabled ?? false}
+              opacity={0.5}
+            />
 
             {/* Event Markers - Only render if corresponding layer is enabled */}
             {filteredEvents.map(event => {
@@ -4549,7 +4538,7 @@ export default function CREPDashboardPage() {
           </MapComponent>
 
           {/* Ground Station Location Marker */}
-          {gsLayerEnabled && gsState.activeLocation && (
+          {showGroundStation && gsState.activeLocation && (
             <MapMarker
               latitude={gsState.activeLocation.lat}
               longitude={gsState.activeLocation.lon ?? 0}
@@ -4563,7 +4552,7 @@ export default function CREPDashboardPage() {
           )}
 
           {/* Ground Station Tracked Satellite Positions */}
-          {gsLayerEnabled && Object.values(gsState.positions).map((pos) => {
+          {showGroundStation && Object.values(gsState.positions).map((pos) => {
             if (!pos.lat || !pos.lon) return null;
             const sat = gsState.satellites.find(s => s.norad_id === pos.norad_id);
             const isTracking = gsState.trackingState?.norad_id === pos.norad_id;
@@ -4866,7 +4855,7 @@ export default function CREPDashboardPage() {
                           <SatelliteTrackerWidget compact limit={10} />
                           
                           {/* Ground Station Overlay (Mar 2026) */}
-                          {gsLayerEnabled && (
+                          {showGroundStation && (
                             <div className="rounded-lg bg-black/40 border border-cyan-500/20 p-2 space-y-2">
                               <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-2">
@@ -4944,7 +4933,7 @@ export default function CREPDashboardPage() {
                           <Badge variant="outline" className="px-1 py-0 h-3 border-blue-500/30 text-blue-400">AIS</Badge>
                           <Badge variant="outline" className="px-1 py-0 h-3 border-purple-500/30 text-purple-400">TLE</Badge>
                           {(showSmartFenceWidget || showPresenceWidget) && <Badge variant="outline" className="px-1 py-0 h-3 border-green-500/30 text-green-400">GHANA</Badge>}
-                          {gsLayerEnabled && <Badge variant="outline" className="px-1 py-0 h-3 border-cyan-500/30 text-cyan-400">GS</Badge>}
+                          {showGroundStation && <Badge variant="outline" className="px-1 py-0 h-3 border-cyan-500/30 text-cyan-400">GS</Badge>}
                         </div>
                       </div>
                     </div>
@@ -4965,7 +4954,32 @@ export default function CREPDashboardPage() {
                       onOpacityChange={setLayerOpacity}
                     />
                     
-                    {/* Ground Station — now managed via layer control panel ("tracking" category) */}
+                    {/* Ground Station Toggle (Mar 2026) */}
+                    <div className="mt-4 rounded-lg bg-black/40 border border-cyan-500/20 overflow-hidden">
+                      <div className="flex items-center justify-between px-3 py-2 bg-black/30">
+                        <div className="flex items-center gap-2">
+                          <Radio className="w-3.5 h-3.5 text-cyan-400" />
+                          <span className="text-[11px] font-semibold text-white">Ground Station</span>
+                        </div>
+                        <Switch
+                          checked={showGroundStation}
+                          onCheckedChange={setShowGroundStation}
+                          className="h-4 w-7 data-[state=checked]:bg-cyan-500"
+                        />
+                      </div>
+                      {showGroundStation && (
+                        <div className="p-2 space-y-1">
+                          <div className="text-[9px] text-gray-500 px-2">
+                            Satellite tracking, SDR control, observation scheduling.
+                            Data syncs bi-directionally with Mindex and the Agent Worldview API.
+                          </div>
+                          <a href="/natureos/ground-station" target="_blank" rel="noopener noreferrer"
+                            className="block text-center text-[9px] text-cyan-400 hover:text-cyan-300 py-1 mx-2 border border-cyan-500/20 rounded mt-1">
+                            Open Full Dashboard
+                          </a>
+                        </div>
+                      )}
+                    </div>
 
                     {/* Conservation Widget Toggles (Feb 17, 2026) */}
                     <div className="mt-4 rounded-lg bg-black/40 border border-gray-700/50 overflow-hidden">
@@ -5193,11 +5207,11 @@ export default function CREPDashboardPage() {
       />
 
       {/* Ground Station Overlay Panel (Mar 2026) */}
-      {gsLayerEnabled && (
+      {showGroundStation && (
         <>
           <GSOverlayPanel
-            visible={gsLayerEnabled}
-            onToggle={() => toggleLayer("groundStation")}
+            visible={showGroundStation}
+            onToggle={() => setShowGroundStation(!showGroundStation)}
           />
           {/* Pass Timeline at bottom of map */}
           <div className="fixed bottom-8 left-0 right-0 z-40">

--- a/components/crep/layers/aurora-overlay.tsx
+++ b/components/crep/layers/aurora-overlay.tsx
@@ -136,16 +136,13 @@ export default function AuroraOverlay({ map, enabled = false, opacity = 0.5 }: A
       addedRef.current = true;
     };
 
-    // Resilient pattern: try immediately, fall back to styledata listener
-    const tryAdd = () => {
-      if (!map.isStyleLoaded()) return;
+    if (map.isStyleLoaded()) {
       addOverlays();
-    };
-    tryAdd();
-    map.on("styledata", tryAdd);
+    } else {
+      map.once("style.load", addOverlays);
+    }
 
     return () => {
-      map.off("styledata", tryAdd);
       if (map && addedRef.current) {
         for (const [layer, source] of [
           [AURORA_LAYER_N, AURORA_SOURCE_N],

--- a/components/crep/layers/gibs-base-layers.tsx
+++ b/components/crep/layers/gibs-base-layers.tsx
@@ -95,16 +95,14 @@ export default function GibsBaseLayers({ map, enabledLayers, opacity = 0.4 }: Gi
       }
     };
 
-    // Resilient pattern: try immediately, fall back to styledata listener
-    const tryAdd = () => {
-      if (!map.isStyleLoaded()) return;
+    if (map.isStyleLoaded()) {
       addLayers();
-    };
-    tryAdd();
-    map.on("styledata", tryAdd);
+    } else {
+      map.once("style.load", addLayers);
+    }
 
     return () => {
-      map.off("styledata", tryAdd);
+      // Cleanup on unmount
       for (const config of Object.values(GIBS_LAYER_CONFIGS)) {
         if (map.getLayer(config.layerId)) {
           try { map.removeLayer(config.layerId); } catch {}

--- a/components/crep/layers/signal-heatmap-layer.tsx
+++ b/components/crep/layers/signal-heatmap-layer.tsx
@@ -125,16 +125,13 @@ export default function SignalHeatmapLayer({
       }
     };
 
-    // Resilient pattern: try immediately, fall back to styledata listener
-    const tryAdd = () => {
-      if (!map.isStyleLoaded()) return;
+    if (map.isStyleLoaded()) {
       addLayer();
-    };
-    tryAdd();
-    map.on("styledata", tryAdd);
+    } else {
+      map.once("style.load", addLayer);
+    }
 
     return () => {
-      map.off("styledata", tryAdd);
       if (map.getLayer(LAYER_ID)) try { map.removeLayer(LAYER_ID); } catch {}
       if (map.getSource(SOURCE_ID)) try { map.removeSource(SOURCE_ID); } catch {}
       addedRef.current = false;

--- a/components/ui/map.tsx
+++ b/components/ui/map.tsx
@@ -78,7 +78,7 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
   const [isStyleLoaded, setIsStyleLoaded] = useState(false);
   const { resolvedTheme } = useTheme();
   const currentStyleRef = useRef<MapStyleOption | null>(null);
-  const styleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mapRef = useRef<MapLibreGL.Map | null>(null);
 
   const mapStyles = useMemo(
     () => ({
@@ -90,18 +90,12 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
 
   useImperativeHandle(ref, () => mapInstance as MapLibreGL.Map, [mapInstance]);
 
-  const clearStyleTimeout = useCallback(() => {
-    if (styleTimeoutRef.current) {
-      clearTimeout(styleTimeoutRef.current);
-      styleTimeoutRef.current = null;
-    }
-  }, []);
-
   useEffect(() => {
     if (!containerRef.current) return;
 
+    // Use the resolved theme, falling back to dark if not yet available
     const initialStyle =
-      resolvedTheme === "dark" ? mapStyles.dark : mapStyles.light;
+      resolvedTheme === "light" ? mapStyles.light : mapStyles.dark;
     currentStyleRef.current = initialStyle;
 
     const map = new MapLibreGL.Map({
@@ -114,17 +108,18 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
       ...props,
     });
 
-    const styleDataHandler = () => {
-      clearStyleTimeout();
-      // Delay to ensure style is fully processed before allowing layer operations
-      // This is a workaround to avoid race conditions with the style loading
-      styleTimeoutRef.current = setTimeout(() => {
-        setIsStyleLoaded(true);
-        if (projection) {
-          map.setProjection(projection);
-        }
-      }, 150);
+    mapRef.current = map;
+
+    // Use the "style.load" event which fires once when style is fully ready
+    // (including sources, sprites, glyphs). More reliable than "styledata"
+    // which fires multiple times during style processing.
+    const styleLoadHandler = () => {
+      setIsStyleLoaded(true);
+      if (projection) {
+        map.setProjection(projection);
+      }
     };
+
     const loadHandler = () => {
       setIsLoaded(true);
       // Call onLoad callback with the map instance when map is ready
@@ -134,14 +129,14 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
     };
 
     map.on("load", loadHandler);
-    map.on("styledata", styleDataHandler);
+    map.on("style.load", styleLoadHandler);
     setMapInstance(map);
 
     return () => {
-      clearStyleTimeout();
       map.off("load", loadHandler);
-      map.off("styledata", styleDataHandler);
+      map.off("style.load", styleLoadHandler);
       map.remove();
+      mapRef.current = null;
       setIsLoaded(false);
       setIsStyleLoaded(false);
       setMapInstance(null);
@@ -157,12 +152,11 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
 
     if (currentStyleRef.current === newStyle) return;
 
-    clearStyleTimeout();
     currentStyleRef.current = newStyle;
     setIsStyleLoaded(false);
 
     mapInstance.setStyle(newStyle, { diff: true });
-  }, [mapInstance, resolvedTheme, mapStyles, clearStyleTimeout]);
+  }, [mapInstance, resolvedTheme, mapStyles]);
 
   const isLoading = !isLoaded || !isStyleLoaded;
 

--- a/components/ui/map.tsx
+++ b/components/ui/map.tsx
@@ -78,7 +78,7 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
   const [isStyleLoaded, setIsStyleLoaded] = useState(false);
   const { resolvedTheme } = useTheme();
   const currentStyleRef = useRef<MapStyleOption | null>(null);
-  const onLoadCalledRef = useRef(false);
+  const styleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const mapStyles = useMemo(
     () => ({
@@ -89,6 +89,13 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
   );
 
   useImperativeHandle(ref, () => mapInstance as MapLibreGL.Map, [mapInstance]);
+
+  const clearStyleTimeout = useCallback(() => {
+    if (styleTimeoutRef.current) {
+      clearTimeout(styleTimeoutRef.current);
+      styleTimeoutRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -107,33 +114,23 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
       ...props,
     });
 
-    // Track both conditions — only call onLoad when BOTH are satisfied.
-    // This prevents the race where onLoad fires before style is ready,
-    // causing downstream addSource/addLayer calls to silently fail.
-    const readyState = { loaded: false, styleReady: false };
-
-    const tryOnLoad = () => {
-      if (readyState.loaded && readyState.styleReady && !onLoadCalledRef.current) {
-        onLoadCalledRef.current = true;
-        if (onLoad) {
-          onLoad(map);
-        }
-      }
-    };
-
     const styleDataHandler = () => {
-      setIsStyleLoaded(true);
-      if (projection) {
-        map.setProjection(projection);
-      }
-      readyState.styleReady = true;
-      tryOnLoad();
+      clearStyleTimeout();
+      // Delay to ensure style is fully processed before allowing layer operations
+      // This is a workaround to avoid race conditions with the style loading
+      styleTimeoutRef.current = setTimeout(() => {
+        setIsStyleLoaded(true);
+        if (projection) {
+          map.setProjection(projection);
+        }
+      }, 150);
     };
-
     const loadHandler = () => {
       setIsLoaded(true);
-      readyState.loaded = true;
-      tryOnLoad();
+      // Call onLoad callback with the map instance when map is ready
+      if (onLoad) {
+        onLoad(map);
+      }
     };
 
     map.on("load", loadHandler);
@@ -141,13 +138,13 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
     setMapInstance(map);
 
     return () => {
+      clearStyleTimeout();
       map.off("load", loadHandler);
       map.off("styledata", styleDataHandler);
       map.remove();
       setIsLoaded(false);
       setIsStyleLoaded(false);
       setMapInstance(null);
-      onLoadCalledRef.current = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -160,11 +157,12 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
 
     if (currentStyleRef.current === newStyle) return;
 
+    clearStyleTimeout();
     currentStyleRef.current = newStyle;
     setIsStyleLoaded(false);
 
     mapInstance.setStyle(newStyle, { diff: true });
-  }, [mapInstance, resolvedTheme, mapStyles]);
+  }, [mapInstance, resolvedTheme, mapStyles, clearStyleTimeout]);
 
   const isLoading = !isLoaded || !isStyleLoaded;
 


### PR DESCRIPTION
## Summary
- Reverts PR #91's approach that didn't fix the black canvas issue
- Replaces fragile `styledata` + 150ms `setTimeout` pattern with the `style.load` event, which fires once when the map style is fully ready (sources, sprites, glyphs)
- Removes `clearStyleTimeout`/`styleTimeoutRef` complexity that could cancel style readiness during theme changes
- Defaults to dark theme when `resolvedTheme` is undefined (matches dark-first apps like CREP)

## Root cause
The `styledata` event fires multiple times during style processing. Each firing canceled and restarted a 150ms timeout. If the theme effect called `clearStyleTimeout()` + `setStyle()` before the timeout fired, `isStyleLoaded` would never become `true`, leaving the map in a permanently uninitialized state where tiles were never fetched.

## Test plan
- [ ] Verify CREP map renders with basemap tiles on mycosoft.com/dashboard/crep
- [ ] Verify map loads on first page visit (no stale cache)
- [ ] Verify theme switching (light/dark) still works
- [ ] Verify GIBS, Aurora, and Signal layers toggle correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch map initialization and overlay layers to rely on MapLibre's style.load event for reliable style readiness, simplify ground station visibility control, and align the default map theme and layer taxonomy with current CREP behavior.

New Features:
- Add a dedicated ground station toggle panel and badge behavior in the CREP dashboard to control ground station overlays independently of the generic layer control panel.

Bug Fixes:
- Prevent map from remaining in an uninitialized black-canvas state by replacing the styledata + timeout pattern with a style.load-based style readiness check in the shared Map component and overlay layers.

Enhancements:
- Default the map style to dark when the resolved theme is undefined to better match dark-first apps.
- Simplify ground station controls by removing the tracking layer category and groundStation layer entry and instead managing visibility via a dedicated UI toggle and local state.
- Ensure GIBS base layers, Aurora overlay, and signal heatmap layers attach once the map style is fully loaded using style.load instead of repeated styledata listeners.