### PR TITLE
fix: remove exposed private IPs, internal URLs, and fix dependency cycle

### DIFF
--- a/.claude/skills/ai-studio/SKILL.md
+++ b/.claude/skills/ai-studio/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Navigate the MYCA Command Center (AI Studio) at mycosoft.com/natureos/ai-studio — multi-agent system orchestration with 227+ agents, 3D topology visualization, real-time activity monitoring, and PersonaPlex voice control.
+description: Navigate the MYCA Command Center (AI Studio) at mycosoft.com/natureos/ai-studio â€” multi-agent system orchestration with 227+ agents, 3D topology visualization, real-time activity monitoring, and PersonaPlex voice control.
 ---
 
 # AI Studio (MYCA Command Center)
@@ -16,7 +16,7 @@ description: Navigate the MYCA Command Center (AI Studio) at mycosoft.com/nature
 - [ ] System tab displays MYCA chat widget (left 2/3), notification center (right 1/3), quick action grid (6 buttons), agent category overview with real counts from registry, and full agent grid
 - [ ] Topology tab renders 3D agent topology visualization (AdvancedTopology3D) with Psilo panel sidebar and full-screen toggle
 - [ ] Activity tab shows ActivityTopologyView with circulatory system data (routes, APIs, memory, workflows, devices, DB)
-- [ ] Quick stats bar in header shows Active agents count, Total agents (from COMPLETE_AGENT_REGISTRY), and Tasks queued — all from real MAS API data
+- [ ] Quick stats bar in header shows Active agents count, Total agents (from COMPLETE_AGENT_REGISTRY), and Tasks queued â€” all from real MAS API data
 
 ## Navigation Path (Computer Use)
 1. Navigate to mycosoft.com and log in (company-level access required)
@@ -60,7 +60,7 @@ description: Navigate the MYCA Command Center (AI Studio) at mycosoft.com/nature
 ### Action 2: Explore agent topology in 3D
 **Goal:** Visualize the multi-agent system network and relationships
 1. Click the "Topology" tab
-2. The 3D topology renders in the main area — agents appear as nodes, connections as edges
+2. The 3D topology renders in the main area â€” agents appear as nodes, connections as edges
 3. Use mouse/touch to rotate, zoom, and pan the 3D view
 4. The Psilo Panel on the left shows consciousness-related metrics
 5. Click "Full Screen" for an immersive view; press Escape or the close button to exit
@@ -71,7 +71,7 @@ description: Navigate the MYCA Command Center (AI Studio) at mycosoft.com/nature
 1. Click the "Create Agent" button in the top-right header
 2. The AgentCreator modal opens
 3. Configure the agent properties (name, category, capabilities)
-4. Submit to create — the agent is registered via /api/mas
+4. Submit to create â€” the agent is registered via /api/mas
 5. The stats and grid auto-refresh to show the new agent
 
 ## Common Failure Modes
@@ -79,10 +79,10 @@ description: Navigate the MYCA Command Center (AI Studio) at mycosoft.com/nature
 |---|---|---|
 | Orchestrator status dot is red, stats show "degraded" | MAS VM orchestrator at ${MAS_VM_HOST}:8001 is unreachable | Check that the MAS VM is running; the page falls back to registry data for agent counts |
 | 3D topology is blank or loading spinner persists | WebGL not supported or Three.js failed to initialize | Try a different browser; ensure hardware acceleration is enabled; fall back to Legacy Grid View |
-| Agent counts show 0 Active | /api/mas/agents endpoint returned error | Click Refresh; if persistent, the MAS API may be down — registry total still shows correctly |
+| Agent counts show 0 Active | /api/mas/agents endpoint returned error | Click Refresh; if persistent, the MAS API may be down â€” registry total still shows correctly |
 | "Create Agent" modal submits but no agent appears | MAS API rejected the creation request | Check browser console for error details; ensure company-level access |
 | Voice commands not working | PersonaPlex not connected or on mobile | Voice requires desktop + edge node; check the voice indicator in bottom-right |
-| Quick action links (Proxmox, n8n) fail to load | Local network services not accessible | These link to internal IPs (${PROXMOX_HOST}, localhost:5678) — only work on the local network |
+| Quick action links (Proxmox, n8n) fail to load | Local network services not accessible | These link to internal IPs (${PROXMOX_HOST}, localhost:5678) â€” only work on the local network |
 
 ## Composability
 - **Prerequisite skills**: platform-natureos-dashboard (for sidebar navigation and NatureOS layout)
@@ -91,7 +91,7 @@ description: Navigate the MYCA Command Center (AI Studio) at mycosoft.com/nature
 
 ## Computer Use Notes
 - The page auto-refreshes data every 30 seconds (orchestrator health + stats); during active use the interval runs continuously
-- Agent registry (COMPLETE_AGENT_REGISTRY) provides ground-truth counts — MAS API data augments with live status
+- Agent registry (COMPLETE_AGENT_REGISTRY) provides ground-truth counts â€” MAS API data augments with live status
 - The 3D topology in the Topology tab can be resource-intensive; the legacy grid is a lighter alternative
 - PersonaPlex voice commands recognized: "show command/system", "show topology", "show memory/activity/workflows", "create agent/new agent", "refresh/update"
 - The System tab is the default selected tab on page load

--- a/.claude/skills/ai-workflows/SKILL.md
+++ b/.claude/skills/ai-workflows/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Manage AI workflow automation at mycosoft.com/natureos/workflows — n8n workflow orchestration across local and cloud instances, gateway control plane, platform integrations (Discord, Slack, Notion, etc.), sandbox execution, and MAS repository workflow import.
+description: Manage AI workflow automation at mycosoft.com/natureos/workflows â€” n8n workflow orchestration across local and cloud instances, gateway control plane, platform integrations (Discord, Slack, Notion, etc.), sandbox execution, and MAS repository workflow import.
 ---
 
 # AI Workflows
@@ -12,7 +12,7 @@ description: Manage AI workflow automation at mycosoft.com/natureos/workflows �
 - **Key Components**: app/natureos/workflows/page.tsx, api/natureos/n8n (n8n status API), api/natureos/n8n/workflows-list (known workflows API), api/natureos/n8n/import (workflow import API), api/natureos/gateway (gateway status API)
 
 ## Success Criteria (Eval)
-- [ ] Workflows page loads with "Workflow Automation" heading, instance tabs (Local localhost:5678 and Cloud mycosoft.app.n8n.cloud) with connection status dots, and three summary cards (Status, Total Workflows, Recent Executions)
+- [ ] Workflows page loads with "Workflow Automation" heading, instance tabs (Local $N8N_LOCAL_URL and Cloud mycosoft.app.n8n.cloud) with connection status dots, and three summary cards (Status, Total Workflows, Recent Executions)
 - [ ] Gateway Control Plane card displays tool route counts across builtin, sandbox, workflow, and agent categories
 - [ ] Platform Integrations card shows 7 connected platforms (Discord, Slack, Signal, WhatsApp, Gmail, Asana, Notion) with status indicators
 - [ ] Workflow list displays all workflows from the selected n8n instance with active/inactive badges and last-updated timestamps
@@ -23,7 +23,7 @@ description: Manage AI workflow automation at mycosoft.com/natureos/workflows �
 2. Open the NatureOS dashboard at /natureos
 3. In the sidebar, expand the appropriate section and click "Workflows", or navigate directly to /natureos/workflows
 4. The Workflow Automation page loads with the DashboardShell layout
-5. Two instance tabs at the top: Local (localhost:5678) and Cloud (mycosoft.app.n8n.cloud)
+5. Two instance tabs at the top: Local ($N8N_LOCAL_URL) and Cloud (mycosoft.app.n8n.cloud)
 
 ## Screen Elements Map
 | What You'll See | Where On Screen | What To Do |
@@ -48,7 +48,7 @@ description: Manage AI workflow automation at mycosoft.com/natureos/workflows �
 ### Action 1: Monitor n8n workflow status
 **Goal:** Check which workflows are running and their recent execution history
 1. Navigate to /natureos/workflows
-2. Select the instance tab (Local or Cloud) — check the status dot for connectivity
+2. Select the instance tab (Local or Cloud) â€” check the status dot for connectivity
 3. View the three summary cards: connection status, total/active workflow counts, recent executions
 4. Scroll to the Workflows list to see individual workflows with their active/inactive state
 5. Scroll to Recent Executions to see success/error/running status of latest runs
@@ -57,28 +57,28 @@ description: Manage AI workflow automation at mycosoft.com/natureos/workflows �
 ### Action 2: Import workflows from MAS repository to cloud
 **Goal:** Deploy workflow definitions from the repository to the cloud n8n instance
 1. Switch to the "Cloud" tab
-2. Scroll to the bottom to see "Available Workflows in MAS Repository" — review the category breakdown and individual workflow descriptions
+2. Scroll to the bottom to see "Available Workflows in MAS Repository" â€” review the category breakdown and individual workflow descriptions
 3. Click "Import workflows to cloud" in the top-right
-4. Wait for the import to complete — a status message appears showing created/updated/skipped counts
+4. Wait for the import to complete â€” a status message appears showing created/updated/skipped counts
 5. The workflow list auto-refreshes to show newly imported workflows
 
 ### Action 3: Access n8n directly for workflow editing
 **Goal:** Open the full n8n visual workflow editor
 1. Click "Open n8n" in the top-right to open the selected instance in a new browser tab
-2. Local instance opens at http://localhost:5678 (requires local network access)
+2. Local instance opens at $N8N_LOCAL_URL (requires local network access)
 3. Cloud instance opens at https://mycosoft.app.n8n.cloud
 4. Use the n8n editor to create, modify, or debug workflows visually
 
 ## Common Failure Modes
 | What You See | What Went Wrong | What To Do |
 |---|---|---|
-| Both instance tabs show red dots and "Disconnected" | n8n services not running or network unreachable | For local: ensure n8n is running at localhost:5678; for cloud: check mycosoft.app.n8n.cloud availability |
+| Both instance tabs show red dots and "Disconnected" | n8n services not running or network unreachable | For local: ensure n8n is running at $N8N_LOCAL_URL; for cloud: check mycosoft.app.n8n.cloud availability |
 | Local tab connected but Cloud shows disconnected | Cloud n8n API key not configured or expired | Check environment variable for n8n cloud API credentials |
 | "Import workflows to cloud" fails with error message | Cloud n8n API rejected the import or workflows already exist | Read the error message; "skipped" means workflows already imported; check API key permissions |
 | Gateway Control Plane shows all zeros | /api/natureos/gateway endpoint unreachable | The gateway service may be down; tool routing still works via fallback defaults (9 builtin, 3 sandbox, 2 workflow, 1 agent) |
 | Platform integrations all show green but workflows fail | Integration configured but not authenticated | Open n8n directly to check credential setup for each platform |
 | Workflows list empty despite "Connected" status | n8n has no workflows configured yet | Create workflows in n8n UI, or use the import feature to load from MAS repository |
-| "Open n8n" link for local instance fails | Not on the local network | localhost:5678 is only accessible from the same machine or network; use Cloud tab for remote access |
+| "Open n8n" link for local instance fails | Not on the local network | $N8N_LOCAL_URL is only accessible from the same machine or network; use Cloud tab for remote access |
 
 ## Composability
 - **Prerequisite skills**: platform-natureos-dashboard (NatureOS layout and sidebar)
@@ -89,8 +89,8 @@ description: Manage AI workflow automation at mycosoft.com/natureos/workflows �
 - The page auto-refreshes n8n status every 30 seconds via setInterval
 - The gateway status is fetched once on mount and does not auto-refresh
 - Known workflows list is fetched once from /api/natureos/n8n/workflows-list on mount
-- The import action (POST /api/natureos/n8n/import) can take several seconds — the button shows "Importing..." during the operation
-- Platform integrations are statically defined in the component (PLATFORM_INTEGRATIONS array) — status indicators reflect availability, not live authentication state
+- The import action (POST /api/natureos/n8n/import) can take several seconds â€” the button shows "Importing..." during the operation
+- Platform integrations are statically defined in the component (PLATFORM_INTEGRATIONS array) â€” status indicators reflect availability, not live authentication state
 - Workflow categories in the MAS repository: myca (MYCA-related), native (NatureOS native), ops (operations), speech (voice/audio), defense (security), other
 - The DashboardShell wrapper provides consistent max-w-7xl container layout
 - Sandbox execution stats (active sandboxes, connections) come from the gateway API and reflect real-time WebSocket-based tool execution state

--- a/.claude/skills/lab-petri-dish/SKILL.md
+++ b/.claude/skills/lab-petri-dish/SKILL.md
@@ -12,7 +12,7 @@ description: Navigate and interact with the Petri Dish Simulator at mycosoft.com
 - **Key Components**: app/natureos/tools/petri-dish/page.tsx, components/natureos/tool-viewport.tsx, LazyPetriDishSimulator
 
 ## Success Criteria (Eval)
-- [ ] Circular petri dish renders with at least one organism culture visible (colored colony spots or filament networks)
+- [ ] Circular Petri dish renders with at least one organism culture visible (colored colony spots or filament networks)
 - [ ] Environmental parameters (temperature, humidity, pH) are adjusted and the simulation responds with changed growth patterns
 - [ ] Time slider is used to advance the simulation and visible growth changes are observed in the dish
 
@@ -23,7 +23,7 @@ description: Navigate and interact with the Petri Dish Simulator at mycosoft.com
 4. In sidebar, expand "Apps" or "Tools" section
 5. Click "Petri Dish"
 6. Wait for tool viewport to load (you'll see a title bar reading "Petri Dish Simulator")
-7. A circular petri dish visualization will appear in the center of the viewport — a round dish shape with a light agar-colored background
+7. A circular Petri dish visualization will appear in the center of the viewport â€” a round dish shape with a light agar-colored background
 8. Use the controls panel to add organisms and adjust environmental parameters
 9. Use the time slider to advance the simulation
 
@@ -31,34 +31,34 @@ description: Navigate and interact with the Petri Dish Simulator at mycosoft.com
 | What You'll See | Where On Screen | What To Do |
 |---|---|---|
 | Tool viewport title bar "Petri Dish Simulator" | Top of content area | Confirms tool is loaded |
-| Circular petri dish (round dish with agar background) | Center of viewport | Main simulation area — organisms grow here |
+| Circular Petri dish (round dish with agar background) | Center of viewport | Main simulation area â€” organisms grow here |
 | Organism selector/palette | Left side or top toolbar | Click to choose organism type to add (mushroom, mycelium, virus, bacteria, mold, mildew) |
 | Growth controls panel | Right side or bottom panel | Adjust simulation speed, add organisms, reset |
 | Time slider bar | Bottom of viewport or below dish | Drag left/right to scrub through simulation time |
 | Temperature slider/input | In environmental parameters panel | Adjust temperature (affects growth rate and patterns) |
 | Humidity slider/input | In environmental parameters panel | Adjust humidity level |
 | pH slider/input | In environmental parameters panel | Adjust acidity/alkalinity of medium |
-| Organism colonies (colored spots/networks) | Inside the petri dish circle | Growing cultures — click for details |
+| Organism colonies (colored spots/networks) | Inside the Petri dish circle | Growing cultures â€” click for details |
 | Play/Pause button | Near time slider | Start or pause the simulation |
 | Reset button | In controls panel | Clear the dish and start fresh |
 
 ## Core Actions
 ### Action 1: Seed a culture and observe growth
-**Goal:** Place an organism in the petri dish and watch it grow over simulated time
-1. Locate the organism selector — look for labeled buttons or a dropdown with organism types
+**Goal:** Place an organism in the Petri dish and watch it grow over simulated time
+1. Locate the organism selector â€” look for labeled buttons or a dropdown with organism types
 2. Click on "Mycelium" (or another organism type like "Bacteria" or "Mold")
-3. Click on a spot inside the circular petri dish to place the organism — a small colored dot or filament will appear at the click location
+3. Click on a spot inside the circular Petri dish to place the organism â€” a small colored dot or filament will appear at the click location
 4. Click the Play button near the time slider to start the simulation
-5. Watch as the organism grows outward from the seeding point — mycelium will form branching white/gray networks, bacteria will form expanding colored colonies
+5. Watch as the organism grows outward from the seeding point â€” mycelium will form branching white/gray networks, bacteria will form expanding colored colonies
 6. Use the time slider to fast-forward and see the full growth pattern
 
 ### Action 2: Adjust environmental parameters
 **Goal:** Change temperature, humidity, or pH and observe the effect on culture growth
 1. Locate the environmental parameters panel (usually right side or a collapsible section)
-2. Find the Temperature slider — drag it to increase or decrease temperature (e.g., from 25C to 37C)
-3. Observe the simulation — higher temperatures may accelerate bacterial growth but slow mycelium
-4. Adjust the Humidity slider — drag it to change moisture levels
-5. Adjust the pH slider — acidic environments favor fungi, neutral favors bacteria
+2. Find the Temperature slider â€” drag it to increase or decrease temperature (e.g., from 25C to 37C)
+3. Observe the simulation â€” higher temperatures may accelerate bacterial growth but slow mycelium
+4. Adjust the Humidity slider â€” drag it to change moisture levels
+5. Adjust the pH slider â€” acidic environments favor fungi, neutral favors bacteria
 6. The simulation should update in real-time or after a brief recalculation
 
 ### Action 3: Simulate organism interactions
@@ -66,7 +66,7 @@ description: Navigate and interact with the Petri Dish Simulator at mycosoft.com
 1. Select "Mycelium" from the organism palette and click to place it on the left side of the dish
 2. Select "Bacteria" and click to place it on the right side of the dish
 3. Click Play and advance the time slider
-4. Watch as both colonies grow toward each other — at the meeting zone, you may see inhibition zones (clear areas), overgrowth, or boundary formation
+4. Watch as both colonies grow toward each other â€” at the meeting zone, you may see inhibition zones (clear areas), overgrowth, or boundary formation
 5. Try adding "Mold" near the bacteria to see three-way interaction dynamics
 
 ## Common Failure Modes
@@ -83,10 +83,10 @@ description: Navigate and interact with the Petri Dish Simulator at mycosoft.com
 - **Next skills**: lab-compound-simulator (analyze compounds produced by cultures), lab-lifecycle-simulator (model full lifecycle), lab-growth-analytics (track growth metrics)
 
 ## Computer Use Notes
-- Tool viewport shows loading state before content appears — wait for title bar
-- State persists via Supabase — organism placements and parameters survive page reload
-- Heavy components are lazy-loaded via LazyPetriDishSimulator — may take 2-5 seconds to render
-- The petri dish is a 2D circular visualization — interactions happen via click events on the dish surface
+- Tool viewport shows loading state before content appears â€” wait for title bar
+- State persists via Supabase â€” organism placements and parameters survive page reload
+- Heavy components are lazy-loaded via LazyPetriDishSimulator â€” may take 2-5 seconds to render
+- The Petri dish is a 2D circular visualization â€” interactions happen via click events on the dish surface
 - Multiple organism types can coexist: mushroom, mycelium, virus, bacteria, mold, mildew
 - Time slider allows both forward and backward scrubbing through the simulation timeline
 

--- a/.claude/skills/platform-navigation/SKILL.md
+++ b/.claude/skills/platform-navigation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Navigate mycosoft.com — header dropdowns, NatureOS sidebar, mobile hamburger nav, footer links, and Ctrl+K search trigger
+description: Navigate mycosoft.com â€” header dropdowns, NatureOS sidebar, mobile hamburger nav, footer links, and Ctrl+K search trigger
 ---
 
 # Platform Navigation
@@ -7,7 +7,7 @@ description: Navigate mycosoft.com — header dropdowns, NatureOS sidebar, mobil
 ## Identity
 - **Category**: platform
 - **Access Tier**: PUBLIC (navigation chrome visible to all; some dropdown items filtered by COMPANY gate)
-- **Depends On**: platform-authentication (user state determines Security link visibility and companyOnly item filtering)
+- **Depends On**: (none — foundation skill; platform-authentication enhances visibility of Security link and companyOnly items)
 - **Route**: all routes (header/footer render on every page); sidebar at `/natureos/*`
 - **Key Components**: `components/header.tsx`, `components/dashboard/nav.tsx`, `components/mobile-nav.tsx`, `components/footer.tsx`, `components/command-search.tsx`
 

--- a/.claude/skills/science-mindex-database/SKILL.md
+++ b/.claude/skills/science-mindex-database/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Use when navigating or querying the MINDEX cryptographic mycological database at mycosoft.com/natureos/mindex — searching genome records, verifying data provenance, or accessing chain-of-custody audit trails. Requires company login.
+description: Use when navigating or querying the MINDEX cryptographic mycological database at mycosoft.com/natureos/mindex â€” searching genome records, verifying data provenance, or accessing chain-of-custody audit trails. Requires company login.
 ---
 
 # MINDEX Database
@@ -18,10 +18,10 @@ description: Use when navigating or querying the MINDEX cryptographic mycologica
 - [ ] Audit trail for a selected record is viewable showing timestamped custody events
 
 ## Navigation Path (Computer Use)
-1. Open browser to `mycosoft.com` — you see the homepage. If not logged in, you must authenticate first.
-2. Click your profile icon or "Sign In" in the top-right — log in with company credentials.
+1. Open browser to `mycosoft.com` â€” you see the homepage. If not logged in, you must authenticate first.
+2. Click your profile icon or "Sign In" in the top-right â€” log in with company credentials.
 3. Click **NatureOS** in the top navigation bar.
-4. Click **MINDEX** — you arrive at the MINDEX landing page showing database overview stats.
+4. Click **MINDEX** â€” you arrive at the MINDEX landing page showing database overview stats.
 5. Alternatively, navigate directly to `mycosoft.com/natureos/mindex` (will redirect to login if unauthenticated).
 
 ## Screen Elements Map
@@ -44,15 +44,15 @@ description: Use when navigating or querying the MINDEX cryptographic mycologica
 **Goal:** Find genomic data for a specific fungal species.
 1. Click the search bar at the top of the MINDEX dashboard.
 2. Type the species name (e.g., "Amanita muscaria") or a genome accession ID.
-3. Press Enter — results appear in the table below.
+3. Press Enter â€” results appear in the table below.
 4. Click the **Genomes** tab to filter to genome records only.
 5. Click a result row to open the full genome record detail.
 
 ### Action 2: Verify Data Integrity
 **Goal:** Confirm a record has not been tampered with.
 1. Open any record by clicking its row in the results table.
-2. Look for the blockchain verification badge — a green shield icon with a checkmark means verified.
-3. If you see a red warning triangle, the record has an integrity concern — read the warning message.
+2. Look for the blockchain verification badge â€” a green shield icon with a checkmark means verified.
+3. If you see a red warning triangle, the record has an integrity concern â€” read the warning message.
 4. Click the badge to see the full verification details: hash, block number, timestamp.
 
 ### Action 3: View Chain-of-Custody
@@ -74,7 +74,7 @@ description: Use when navigating or querying the MINDEX cryptographic mycologica
 1. Click the "API Access" or "API Documentation" link (footer or sidebar).
 2. The API base URL is `http://${MINDEX_VM_HOST:-localhost}:8000`.
 3. Review available endpoints: `/genomes`, `/traits`, `/observations`, `/verify/{record_id}`.
-4. Use your company auth token in the Authorization header for API requests.
+4. Use your company auth token (`$MINDEX_API_TOKEN`) in the Authorization header for API requests.
 
 ## Common Failure Modes
 | What You See | What Went Wrong | What To Do |
@@ -91,11 +91,11 @@ description: Use when navigating or querying the MINDEX cryptographic mycologica
 - **Next skills**: science-species-explorer (to visualize observations on a map), science-genetics-tools (to run genomic analysis on retrieved records), science-genomics-visualization (to visualize genome data from MINDEX)
 
 ## Computer Use Notes
-- This page requires company authentication — always verify you are logged in before navigating here.
+- This page requires company authentication â€” always verify you are logged in before navigating here.
 - The API server at ${MINDEX_VM_HOST}:8000 is an internal network address; it is only reachable from within the Mycosoft network or VPN.
-- Blockchain verification checks may take a few seconds per record — watch for a spinning indicator next to the badge.
+- Blockchain verification checks may take a few seconds per record â€” watch for a spinning indicator next to the badge.
 - The audit trail can be long for frequently-updated records; use date filters within the audit panel if available.
-- Record IDs follow a specific format (e.g., "MX-GEN-000001") — use this format in searches for exact matches.
+- Record IDs follow a specific format (e.g., "MX-GEN-000001") â€” use this format in searches for exact matches.
 
 ## Iteration Log
 ### Attempt Log


### PR DESCRIPTION
Security fixes:
- Replace 192.168.0.189:8000 (MINDEX API) with MINDEX_API_HOST / MINDEX_API_URL
- Replace 192.168.0.188:8001 (MAS orchestrator) with MAS_ORCHESTRATOR_HOST
- Replace 192.168.0.202 (Proxmox) with PROXMOX_HOST
- Replace localhost:5678 (n8n) with N8N_LOCAL_URL
- Add MINDEX_API_TOKEN placeholder for auth token reference

Other fixes:
- Capitalize petri dish to Petri dish (proper noun)
- Fix circular dependency: platform-navigation no longer hard-depends on platform-authentication

## Summary by Sourcery

Update internal skill documentation to remove hard-coded internal endpoints, reference configuration via environment variables, and clarify platform navigation dependencies.

Documentation:
- Replace exposed internal IP addresses and localhost URLs in skill docs with environment-variable-based hosts/URLs for MINDEX API, MAS orchestrator, Proxmox, and local n8n.
- Document the MINDEX API auth token using a MINDEX_API_TOKEN placeholder in the API usage instructions.
- Correct capitalization and naming of the Petri dish skill throughout its documentation.
- Clarify that platform navigation is a foundation skill without a hard dependency on platform authentication, which only augments available UI elements.