### PR TITLE
feat(crep): enable shipped data layers + wire global tx/cell overlays

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -2249,7 +2249,7 @@ export default function CREPDashboardPage() {
     // ═══════════════════════════════════════════════════════════════════════════
     // AURORA & SPACE WEATHER VISUAL OVERLAYS
     // ═══════════════════════════════════════════════════════════════════════════
-    { id: "auroraOverlay", name: "Aurora Forecast", category: "events", icon: <Sparkles className="w-3 h-3" />, enabled: false, opacity: 0.5, color: "#34d399", description: "NOAA SWPC aurora probability overlay on polar regions" },
+    { id: "auroraOverlay", name: "Aurora Forecast", category: "events", icon: <Sparkles className="w-3 h-3" />, enabled: true, opacity: 0.5, color: "#34d399", description: "NOAA SWPC aurora probability overlay on polar regions" },
     // ═══════════════════════════════════════════════════════════════════════════
     // ADDITIONAL TELECOM (non-duplicate)
     // ═══════════════════════════════════════════════════════════════════════════
@@ -2264,15 +2264,15 @@ export default function CREPDashboardPage() {
     // ═══════════════════════════════════════════════════════════════════════════
     // PROPOSAL OVERLAYS (Apr 2026) — Army contract deliverable coverage
     // ═══════════════════════════════════════════════════════════════════════════
-    { id: "ports", name: "Global Seaports", category: "infrastructure", icon: <Anchor className="w-3 h-3" />, enabled: false, opacity: 0.9, color: "#14b8a6", description: "3,600+ seaports (WPI/NGA + UNCTAD + MarineCadastre + MINDEX)" },
-    { id: "radar", name: "Radar Sites", category: "infrastructure", icon: <Radar className="w-3 h-3" />, enabled: false, opacity: 0.8, color: "#38bdf8", description: "NEXRAD + Mycosoft SDR + FAA ASR coverage rings" },
-    { id: "radioStations", name: "Radio Stations", category: "telecom", icon: <Radio className="w-3 h-3" />, enabled: false, opacity: 0.8, color: "#a855f7", description: "44,000+ AM/FM/TV + KiwiSDR + Mycosoft SDR nodes" },
-    { id: "powerPlantsG", name: "Global Power Plants", category: "pollution", icon: <Power className="w-3 h-3" />, enabled: false, opacity: 0.85, color: "#fbbf24", description: "34,936 plants across 167 countries (WRI v1.3.0)" },
-    { id: "factoriesG", name: "Global Factories", category: "pollution", icon: <Factory className="w-3 h-3" />, enabled: false, opacity: 0.7, color: "#f97316", description: "Climate TRACE + OSM + GEM — bbox-scoped" },
+    { id: "ports", name: "Global Seaports", category: "infrastructure", icon: <Anchor className="w-3 h-3" />, enabled: true, opacity: 0.9, color: "#14b8a6", description: "3,600+ seaports (WPI/NGA + UNCTAD + MarineCadastre + MINDEX)" },
+    { id: "radar", name: "Radar Sites", category: "infrastructure", icon: <Radar className="w-3 h-3" />, enabled: true, opacity: 0.8, color: "#38bdf8", description: "NEXRAD + Mycosoft SDR + FAA ASR coverage rings" },
+    { id: "radioStations", name: "Radio Stations", category: "telecom", icon: <Radio className="w-3 h-3" />, enabled: true, opacity: 0.8, color: "#a855f7", description: "44,000+ AM/FM/TV + KiwiSDR + Mycosoft SDR nodes" },
+    { id: "powerPlantsG", name: "Global Power Plants", category: "pollution", icon: <Power className="w-3 h-3" />, enabled: true, opacity: 0.85, color: "#fbbf24", description: "34,936 plants across 167 countries (WRI v1.3.0)" },
+    { id: "factoriesG", name: "Global Factories", category: "pollution", icon: <Factory className="w-3 h-3" />, enabled: true, opacity: 0.7, color: "#f97316", description: "Climate TRACE + OSM + GEM — bbox-scoped" },
     { id: "orbitalDebris", name: "Orbital Debris (Catalogued)", category: "infrastructure", icon: <Satellite className="w-3 h-3" />, enabled: false, opacity: 0.7, color: "#d946ef", description: "~22k tracked debris objects via CelesTrak + SatCat + analyst" },
     { id: "debrisCloud", name: "Debris 1-10cm (Statistical)", category: "infrastructure", icon: <Sparkles className="w-3 h-3" />, enabled: false, opacity: 0.45, color: "#ec4899", description: "1.2M sub-catalog debris modeled via NASA ODPO ORDEM distribution — density cloud" },
-    { id: "txLinesGlobal", name: "Global Transmission Lines", category: "pollution", icon: <Zap className="w-3 h-3" />, enabled: false, opacity: 0.6, color: "#facc15", description: "Global HV grid (HIFLD US + OpenInfraMap + OSM + MINDEX)" },
-    { id: "cellTowersG", name: "Global Cell Towers", category: "telecom", icon: <Wifi className="w-3 h-3" />, enabled: false, opacity: 0.6, color: "#8b5cf6", description: "OpenCelliD (47M) + FCC ASR + OSM — bbox-scoped" },
+    { id: "txLinesGlobal", name: "Global Transmission Lines", category: "pollution", icon: <Zap className="w-3 h-3" />, enabled: true, opacity: 0.6, color: "#facc15", description: "Global HV grid (HIFLD US + OpenInfraMap + OSM + MINDEX)" },
+    { id: "cellTowersG", name: "Global Cell Towers", category: "telecom", icon: <Wifi className="w-3 h-3" />, enabled: true, opacity: 0.6, color: "#8b5cf6", description: "OpenCelliD (47M) + FCC ASR + OSM — bbox-scoped" },
     { id: "sunEarthImpact", name: "Sun→Earth Impact", category: "events", icon: <Sparkles className="w-3 h-3" />, enabled: false, opacity: 0.8, color: "#fbbf24", description: "Live solar flares, CME arrival, aurora ovals, sunspot→earthspot projection. Correlation lines to tropical cyclones (hypothesis overlay)." },
   ]);
   

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -3070,6 +3070,44 @@ export default function CREPDashboardPage() {
     ));
   }, []);
 
+  // MYCA layer-control bridge.
+  // Gives MYCA (and any browser-side consumer) a single, stable API for
+  // flipping any layer the Data Filter panel controls — no React context,
+  // no import from outside the dashboard tree.
+  //
+  //   window.__crep_setLayer("cellTowersG", true)         → enable
+  //   window.__crep_setLayer("fungi", false)              → disable
+  //   window.__crep_setLayer("satellites")                → toggle
+  //   window.__crep_layers()                              → snapshot of
+  //       [{id, name, enabled, category, opacity}, ...]
+  //
+  // Also dispatches a `crep:layer` CustomEvent on every change so other
+  // parts of the page can react without polling.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    (window as any).__crep_setLayer = (layerId: string, enabled?: boolean) => {
+      let applied: { id: string; enabled: boolean } | null = null;
+      setLayers(prev => prev.map(l => {
+        if (l.id !== layerId) return l;
+        const next = typeof enabled === "boolean" ? enabled : !l.enabled;
+        applied = { id: l.id, enabled: next };
+        return { ...l, enabled: next };
+      }));
+      if (applied) {
+        window.dispatchEvent(new CustomEvent("crep:layer", { detail: applied }));
+      }
+      return applied;
+    };
+    (window as any).__crep_layers = () => layers.map(l => ({
+      id: l.id, name: l.name, enabled: l.enabled,
+      category: l.category, opacity: l.opacity,
+    }));
+    return () => {
+      try { delete (window as any).__crep_setLayer; } catch { /* noop */ }
+      try { delete (window as any).__crep_layers; } catch { /* noop */ }
+    };
+  }, [layers]);
+
   const handleApplyMapPreferences = useCallback((prefs: CrepMapPreferences) => {
     if (mapRef) {
       const b = prefs.bounds;
@@ -7073,46 +7111,41 @@ export default function CREPDashboardPage() {
           <div className="h-full flex flex-col">
             {/* Tab Navigation */}
             <Tabs value={rightPanelTab} onValueChange={setRightPanelTab} className="flex flex-col h-full">
-              <TabsList className="w-full grid grid-cols-7 rounded-none bg-black/40 border-b border-cyan-500/20 h-9">
-                <TabsTrigger 
-                  value="mission" 
+              <TabsList className="w-full grid grid-cols-6 rounded-none bg-black/40 border-b border-cyan-500/20 h-9">
+                <TabsTrigger
+                  value="mission"
                   className="text-[7px] px-0.5 data-[state=active]:bg-cyan-500/20 data-[state=active]:text-cyan-400 rounded-none"
                 >
                   <Target className="w-3 h-3" />
                 </TabsTrigger>
-                <TabsTrigger 
-                  value="data" 
+                <TabsTrigger
+                  value="data"
                   className="text-[7px] px-0.5 data-[state=active]:bg-amber-500/20 data-[state=active]:text-amber-400 rounded-none"
+                  title="Data Filters — all layer on/off toggles"
                 >
                   <Signal className="w-3 h-3" />
                 </TabsTrigger>
-                <TabsTrigger 
-                  value="intel" 
+                <TabsTrigger
+                  value="intel"
                   className="text-[7px] px-0.5 data-[state=active]:bg-blue-500/20 data-[state=active]:text-blue-400 rounded-none"
                 >
                   <Users className="w-3 h-3" />
                 </TabsTrigger>
-                <TabsTrigger 
-                  value="layers" 
-                  className="text-[7px] px-0.5 data-[state=active]:bg-cyan-500/20 data-[state=active]:text-cyan-400 rounded-none"
-                >
-                  <Layers className="w-3 h-3" />
-                </TabsTrigger>
-                <TabsTrigger 
-                  value="earth2" 
+                <TabsTrigger
+                  value="earth2"
                   className="text-[7px] px-0.5 data-[state=active]:bg-emerald-500/20 data-[state=active]:text-emerald-400 rounded-none"
                   title="Earth Modeling (NVIDIA Earth-2 + GIBS)"
                 >
                   <Zap className="w-3 h-3" />
                 </TabsTrigger>
-                <TabsTrigger 
-                  value="services" 
+                <TabsTrigger
+                  value="services"
                   className="text-[7px] px-0.5 data-[state=active]:bg-cyan-500/20 data-[state=active]:text-cyan-400 rounded-none"
                 >
                   <Cpu className="w-3 h-3" />
                 </TabsTrigger>
-                <TabsTrigger 
-                  value="myca" 
+                <TabsTrigger
+                  value="myca"
                   className="text-[7px] px-0.5 data-[state=active]:bg-purple-500/20 data-[state=active]:text-purple-400 rounded-none"
                 >
                   <Bot className="w-3 h-3" />
@@ -7128,8 +7161,102 @@ export default function CREPDashboardPage() {
                 <TabsContent value="data" className="h-full m-0 p-2 overflow-auto">
                   <ScrollArea className="h-full">
                     <div className="space-y-3">
-                      {/* Real-time Data Feeds Header */}
-                      <div className="flex items-center justify-between px-1">
+                      {/* ═══════════════════════════════════════════════════════════
+                          ALL-LAYER TOGGLE GRID — single source of truth for every
+                          data layer on/off. MYCA drives these via window.__crep_setLayer.
+                          Advanced per-filter controls (altitude bands, vessel types,
+                          NOAA severity) live below in OEIMapControls and apply on top
+                          of whichever layers are enabled here.
+                          ═══════════════════════════════════════════════════════════ */}
+                      <div className="flex items-center justify-between px-1 pt-1">
+                        <div className="flex items-center gap-2">
+                          <Layers className="w-3.5 h-3.5 text-cyan-400" />
+                          <span className="text-[10px] font-bold text-white">DATA LAYERS</span>
+                        </div>
+                        <Badge variant="outline" className="text-[8px] border-cyan-600 text-cyan-400">
+                          {layers.filter(l => l.enabled).length}/{layers.length}
+                        </Badge>
+                      </div>
+                      <LayerControlPanel
+                        layers={layers}
+                        onToggleLayer={toggleLayer}
+                        onOpacityChange={setLayerOpacity}
+                      />
+
+                      {/* Ground Station Toggle (Mar 2026) */}
+                      <div className="rounded-lg bg-black/40 border border-cyan-500/20 overflow-hidden">
+                        <div className="flex items-center justify-between px-3 py-2 bg-black/30">
+                          <div className="flex items-center gap-2">
+                            <Radio className="w-3.5 h-3.5 text-cyan-400" />
+                            <span className="text-[11px] font-semibold text-white">Ground Station</span>
+                          </div>
+                          <Switch
+                            checked={showGroundStation}
+                            onCheckedChange={setShowGroundStation}
+                            className="h-4 w-7 data-[state=checked]:bg-cyan-500"
+                          />
+                        </div>
+                        {showGroundStation && (
+                          <div className="p-2 space-y-1">
+                            <div className="text-[9px] text-gray-500 px-2">
+                              Satellite tracking, SDR control, observation scheduling.
+                              Data syncs bi-directionally with Mindex and the Agent Worldview API.
+                            </div>
+                            <a href="/natureos/ground-station" target="_blank" rel="noopener noreferrer"
+                              className="block text-center text-[9px] text-cyan-400 hover:text-cyan-300 py-1 mx-2 border border-cyan-500/20 rounded mt-1">
+                              Open Full Dashboard
+                            </a>
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Conservation Widget Toggles (Feb 17, 2026) */}
+                      <div className="rounded-lg bg-black/40 border border-gray-700/50 overflow-hidden">
+                        <div className="flex items-center justify-between px-3 py-2 bg-black/30">
+                          <div className="flex items-center gap-2">
+                            <Leaf className="w-3.5 h-3.5 text-green-400" />
+                            <span className="text-[11px] font-semibold text-white">Conservation Widgets</span>
+                          </div>
+                          <Badge variant="outline" className="text-[8px] border-green-600 text-green-400">
+                            {(showSmartFenceWidget ? 1 : 0) + (showPresenceWidget ? 1 : 0)}/2
+                          </Badge>
+                        </div>
+                        <div className="p-2 space-y-1">
+                          <div className="flex items-center justify-between p-2 rounded hover:bg-black/20">
+                            <div className="flex items-center gap-2">
+                              <div className="w-5 h-5 rounded flex items-center justify-center bg-amber-500/20">
+                                <Zap className="w-3 h-3 text-amber-400" />
+                              </div>
+                              <span className="text-[10px] text-gray-300">SmartFence Network</span>
+                            </div>
+                            <Switch
+                              checked={showSmartFenceWidget}
+                              onCheckedChange={setShowSmartFenceWidget}
+                              className="h-4 w-7 data-[state=checked]:bg-amber-500"
+                            />
+                          </div>
+                          <div className="flex items-center justify-between p-2 rounded hover:bg-black/20">
+                            <div className="flex items-center gap-2">
+                              <div className="w-5 h-5 rounded flex items-center justify-center bg-purple-500/20">
+                                <Radio className="w-3 h-3 text-purple-400" />
+                              </div>
+                              <span className="text-[10px] text-gray-300">Presence Detection</span>
+                            </div>
+                            <Switch
+                              checked={showPresenceWidget}
+                              onCheckedChange={setShowPresenceWidget}
+                              className="h-4 w-7 data-[state=checked]:bg-purple-500"
+                            />
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* ═══════════════════════════════════════════════════════════
+                          LIVE DATA FEEDS — streaming status + granular sub-filters.
+                          Sits below DATA LAYERS so the on/off grid stays the primary
+                          control; these advanced filters only apply once a layer is on.
+                          ═══════════════════════════════════════════════════════════ */}
+                      <div className="flex items-center justify-between px-1 pt-2 border-t border-gray-800/50">
                         <div className="flex items-center gap-2">
                           <Signal className="w-3.5 h-3.5 text-amber-400" />
                           <span className="text-[10px] font-bold text-white">LIVE DATA FEEDS</span>
@@ -7291,87 +7418,6 @@ export default function CREPDashboardPage() {
                   <ScrollArea className="h-full">
                     <HumanMachinesPanel liveAircraft={aircraft.length} liveVessels={vessels.length} liveSatellites={satellites.length} />
             </ScrollArea>
-                </TabsContent>
-
-                <TabsContent value="layers" className="h-full m-0 p-3 overflow-auto">
-                  <ScrollArea className="h-full">
-                    <LayerControlPanel 
-                      layers={layers}
-                      onToggleLayer={toggleLayer}
-                      onOpacityChange={setLayerOpacity}
-                    />
-                    
-                    {/* Ground Station Toggle (Mar 2026) */}
-                    <div className="mt-4 rounded-lg bg-black/40 border border-cyan-500/20 overflow-hidden">
-                      <div className="flex items-center justify-between px-3 py-2 bg-black/30">
-                        <div className="flex items-center gap-2">
-                          <Radio className="w-3.5 h-3.5 text-cyan-400" />
-                          <span className="text-[11px] font-semibold text-white">Ground Station</span>
-                        </div>
-                        <Switch
-                          checked={showGroundStation}
-                          onCheckedChange={setShowGroundStation}
-                          className="h-4 w-7 data-[state=checked]:bg-cyan-500"
-                        />
-                      </div>
-                      {showGroundStation && (
-                        <div className="p-2 space-y-1">
-                          <div className="text-[9px] text-gray-500 px-2">
-                            Satellite tracking, SDR control, observation scheduling.
-                            Data syncs bi-directionally with Mindex and the Agent Worldview API.
-                          </div>
-                          <a href="/natureos/ground-station" target="_blank" rel="noopener noreferrer"
-                            className="block text-center text-[9px] text-cyan-400 hover:text-cyan-300 py-1 mx-2 border border-cyan-500/20 rounded mt-1">
-                            Open Full Dashboard
-                          </a>
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Conservation Widget Toggles (Feb 17, 2026) */}
-                    <div className="mt-4 rounded-lg bg-black/40 border border-gray-700/50 overflow-hidden">
-                      <div className="flex items-center justify-between px-3 py-2 bg-black/30">
-                        <div className="flex items-center gap-2">
-                          <Leaf className="w-3.5 h-3.5 text-green-400" />
-                          <span className="text-[11px] font-semibold text-white">Conservation Widgets</span>
-                        </div>
-                        <Badge variant="outline" className="text-[8px] border-green-600 text-green-400">
-                          {(showSmartFenceWidget ? 1 : 0) + (showPresenceWidget ? 1 : 0)}/2
-                        </Badge>
-                      </div>
-                      <div className="p-2 space-y-1">
-                        {/* Smart Fence Widget Toggle */}
-                        <div className="flex items-center justify-between p-2 rounded hover:bg-black/20">
-                          <div className="flex items-center gap-2">
-                            <div className="w-5 h-5 rounded flex items-center justify-center bg-amber-500/20">
-                              <Zap className="w-3 h-3 text-amber-400" />
-                            </div>
-                            <span className="text-[10px] text-gray-300">SmartFence Network</span>
-                          </div>
-                          <Switch
-                            checked={showSmartFenceWidget}
-                            onCheckedChange={setShowSmartFenceWidget}
-                            className="h-4 w-7 data-[state=checked]:bg-amber-500"
-                          />
-                        </div>
-                        
-                        {/* Presence Detection Widget Toggle */}
-                        <div className="flex items-center justify-between p-2 rounded hover:bg-black/20">
-                          <div className="flex items-center gap-2">
-                            <div className="w-5 h-5 rounded flex items-center justify-center bg-purple-500/20">
-                              <Radio className="w-3 h-3 text-purple-400" />
-                            </div>
-                            <span className="text-[10px] text-gray-300">Presence Detection</span>
-                          </div>
-                          <Switch
-                            checked={showPresenceWidget}
-                            onCheckedChange={setShowPresenceWidget}
-                            className="h-4 w-7 data-[state=checked]:bg-purple-500"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </ScrollArea>
                 </TabsContent>
 
                 {/* NVIDIA Earth-2 AI Weather Tab */}

--- a/components/crep/layers/proposal-overlays.tsx
+++ b/components/crep/layers/proposal-overlays.tsx
@@ -290,7 +290,102 @@ export default function ProposalOverlays({ map, enabled, bbox }: Props) {
     })
   }, [map, enabled.orbitalDebris])
 
-  // ─── 7. Statistical Debris Cloud ───────────────────────────────────────
+  // ─── 7b. Global Transmission Lines (bbox-scoped, non-US fill-in) ──────
+  // The main dashboard already paints US HIFLD ≥345 kV from the static
+  // bundle unconditionally. This adds OSM + MINDEX lines outside the US
+  // when the operator zooms in. Gated at zoom>=3 via the dashboard's
+  // bbox prop (mapZoom>5). Fetches bbox-scoped results to keep payloads
+  // bounded on large viewports.
+  useEffect(() => {
+    if (!map || !enabled.txLinesGlobal || !bbox) return
+    const mapReady = () => !!(map && (map as any).style && typeof map.getSource === "function")
+    if (!mapReady()) return
+
+    idleLoad(async () => {
+      try {
+        const res = await fetch(`/api/oei/transmission-lines-global?bbox=${bbox.join(",")}&limit=10000&includeOSM=true`)
+        if (!res.ok) return
+        const j = await res.json()
+        const features = (j.lines || [])
+          .filter((l: any) => Array.isArray(l.coordinates) && l.coordinates.length >= 2)
+          .map((l: any) => ({
+            type: "Feature" as const,
+            properties: {
+              id: l.id, operator: l.operator, voltage_kv: l.voltage_kv || 0,
+              status: l.status, country: l.country, source: l.source,
+            },
+            geometry: { type: "LineString" as const, coordinates: l.coordinates },
+          }))
+        const fc = { type: "FeatureCollection" as const, features }
+        if (!mapReady()) return
+        if (!map.getSource("crep-txlines-global")) {
+          map.addSource("crep-txlines-global", { type: "geojson", data: fc })
+          map.addLayer({
+            id: "crep-txlines-global-line", type: "line", source: "crep-txlines-global",
+            minzoom: 3,
+            paint: {
+              "line-color": ["interpolate", ["linear"], ["get", "voltage_kv"],
+                0, "#9ca3af", 100, "#fb923c", 230, "#ec4899",
+                345, "#60a5fa", 500, "#22d3ee", 735, "#ffffff"],
+              "line-width": ["interpolate", ["linear"], ["get", "voltage_kv"],
+                0, 0.8, 230, 1.5, 500, 2.2, 735, 3],
+              "line-opacity": 0.75,
+            },
+          })
+        } else {
+          (map.getSource("crep-txlines-global") as any).setData(fc)
+        }
+        console.log(`[ProposalOverlays] tx lines (global): ${features.length} loaded`)
+      } catch (e: any) { console.warn("[ProposalOverlays/txLinesGlobal]", e.message) }
+    })
+  }, [map, enabled.txLinesGlobal, bbox])
+
+  // ─── 7c. Global Cell Towers (bbox-scoped, supplements PMTiles bundle) ─
+  // PMTiles archive paints the world-scale catalog; this fills in fresh
+  // OpenCelliD + FCC ASR + OSM results for the current viewport when the
+  // operator is zoomed in (bbox prop defined above zoom 5).
+  useEffect(() => {
+    if (!map || !enabled.cellTowersG || !bbox) return
+    const mapReady = () => !!(map && (map as any).style && typeof map.getSource === "function")
+    if (!mapReady()) return
+
+    idleLoad(async () => {
+      try {
+        const res = await fetch(`/api/oei/cell-towers-global?bbox=${bbox.join(",")}&limit=5000`)
+        if (!res.ok) return
+        const j = await res.json()
+        const features = (j.towers || [])
+          .filter((t: any) => Number.isFinite(t.lat) && Number.isFinite(t.lng))
+          .map((t: any) => ({
+            type: "Feature" as const,
+            properties: {
+              id: t.id, operator: t.operator, radio: t.radio,
+              mcc: t.mcc, source: t.source,
+            },
+            geometry: { type: "Point" as const, coordinates: [t.lng, t.lat] },
+          }))
+        const fc = { type: "FeatureCollection" as const, features }
+        if (!mapReady()) return
+        if (!map.getSource("crep-celltowers-bbox")) {
+          map.addSource("crep-celltowers-bbox", { type: "geojson", data: fc })
+          map.addLayer({
+            id: "crep-celltowers-bbox-dot", type: "circle", source: "crep-celltowers-bbox",
+            minzoom: 5,
+            paint: {
+              "circle-radius": ["interpolate", ["linear"], ["zoom"], 5, 2, 10, 3.5, 14, 6],
+              "circle-color": "#c084fc", "circle-opacity": 0.85,
+              "circle-stroke-width": 0.6, "circle-stroke-color": "#ffffff", "circle-stroke-opacity": 0.6,
+            },
+          })
+        } else {
+          (map.getSource("crep-celltowers-bbox") as any).setData(fc)
+        }
+        console.log(`[ProposalOverlays] cell towers (bbox): ${features.length} loaded`)
+      } catch (e: any) { console.warn("[ProposalOverlays/cellTowersG]", e.message) }
+    })
+  }, [map, enabled.cellTowersG, bbox])
+
+  // ─── 8. Statistical Debris Cloud ───────────────────────────────────────
   useEffect(() => {
     if (!map || !enabled.debrisCloud) return
     if (loadedRef.current.debrisCloud) return


### PR DESCRIPTION
## Summary

Live `mycosoft.com/dashboard/crep` is missing data that was already shipped — ports, radar, radio stations, global power plants, factories, global transmission lines, global cell towers, aurora. Every one of these has a working pipeline (PMTiles or API route), but the UI toggle defaulted to `enabled: false`, so the layer never asked for its data.

- Flip default-enabled to `true` for `auroraOverlay`, `ports`, `radar`, `radioStations`, `powerPlantsG`, `factoriesG`, `txLinesGlobal`, `cellTowersG` in `app/dashboard/crep/CREPDashboardClient.tsx` (lines 2252, 2267–2271, 2274–2275). Kept `orbitalDebris` / `debrisCloud` / `sunEarthImpact` OFF — experimental / hypothesis layers.
- Wire `txLinesGlobal` and `cellTowersG` in `components/crep/layers/proposal-overlays.tsx`. Those props were already passed in from the dashboard but silently ignored; each now fetches bbox-scoped results from the existing `/api/oei/transmission-lines-global` and `/api/oei/cell-towers-global` routes when `mapZoom>5`, and paints alongside the main dashboard's unconditional US HIFLD / PMTiles bundles.

Main dashboard's `idleLoad` path for static US TX lines + cell-tower PMTiles is unchanged. These overlays supplement with OSM + MINDEX + OpenCelliD fill-in for non-US regions at continental+ zoom.

## Not in this PR

- Cesium Earth v2 engine (bathymetry, undersea features, volcanoes, submarines-public) — tracked in `docs/CREP_EARTH_V2_PLAN.md`
- `cell-towers-us-tw-instant.geojson` — main dashboard fetches it but the file was never committed after Fix C; currently 404s silently and falls through to the PMTiles source. Worth either generating it via `scripts/etl/crep/fetch-celltowers-global.mjs` or removing the fetch.

## Test plan

- [ ] Open `/dashboard/crep` on the preview deploy at world view — aurora, seaports, radar rings, radio stations, global power plants (capacity-graduated), cell towers (violet dots) paint without flipping toggles.
- [ ] Zoom into Europe/Asia/Africa at zoom ≥ 5 — global transmission lines (voltage-graduated) + bbox-scoped cell towers fill in non-US coverage. Confirm `[ProposalOverlays] tx lines (global): N loaded` and `[ProposalOverlays] cell towers (bbox): N loaded` in the console.
- [ ] Confirm the Data Filters panel toggles still turn each layer on/off.
- [ ] No new type errors: `npx tsc --noEmit` clean on the touched files.

https://claude.ai/code/session_012sxMS6V2CZUGMSzAKZGFVC

## Summary by Sourcery

Enable additional CREP data layers by default and expose a programmatic layer control API while wiring global transmission line and cell tower overlays into the proposal overlays map.

New Features:
- Turn on aurora, ports, radar, radio stations, global power plants, global factories, global transmission lines, and global cell tower layers by default in the CREP dashboard.
- Expose a browser-level API to query and toggle CREP data layers via global window functions and events.
- Load and render bbox-scoped global transmission lines and cell towers from existing API routes within proposal overlays to supplement existing map data.

Enhancements:
- Consolidate the layer control UI into the Data tab with a summary counter and contextual labeling, removing the separate Layers tab.