### PR TITLE
crep: live transit layer + force LAN MINDEX on server (fix empty map)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,11 @@ NEXT_PUBLIC_MINDEX_API_URL=http://${MINDEX_VM_HOST:-localhost}:8000
 MINDEX_INTERNAL_TOKEN=
 # Feature flag: route /api/search to MINDEX /api/worldview/v1/search (per-user API keys)
 USE_WORLDVIEW_SEARCH=false
+# When set, `/api/crep/sdapcd/h2s/collect` requires Vercel cron header, `Authorization: Bearer <CRON_SECRET>`, or `?key=`.
+# Leave empty for local dev (open collect). Production (Docker / non-Vercel crons): set and pass `?key=` from cron.
+CRON_SECRET=
+# Base URL for `npm run ops:warm-eagle-mindex` (re-seed MINDEX `eagle.video_sources`). Default: http://127.0.0.1:3010
+EAGLE_WARM_BASE_URL=http://127.0.0.1:3010
 
 # -----------------------------------------------------------------------------
 # MycoBrain IoT
@@ -186,3 +191,27 @@ LOCAL_GPU_GATEWAY=http://localhost:7860
 # OLLAMA_MODEL=nemotron:70b
 # GPU_CLUSTER_URL=http://<gpu-cluster-ip>:8000
 # GPU_CLUSTER_NODES=4
+
+# -----------------------------------------------------------------------------
+# CREP Live Transit (Apr 23 2026 — Morgan: compete with google maps live traffic)
+# Each connector has a no-key fallback when possible. Keys below unlock the
+# protobuf/JSON vehicle-position feeds per agency. Store values in Vercel /
+# GitHub Actions secrets — NEVER commit the actual values.
+# -----------------------------------------------------------------------------
+# NYC — MTA (subway + LIRR + Metro-North + OBA bus). No key required.
+# Washington DC — WMATA. Header: api_key:
+WMATA_API_KEY=
+# SF Bay — 511 Regional aggregator (covers BART, Muni, AC, Caltrain, VTA, SamTrans, GF, SB…).
+TRANSIT_511_API_KEY=
+# Bay Area backup direct-BART key (optional; sandbox key ships in-code).
+BART_API_KEY=
+# Boston — MBTA. Optional key for higher rate limit. Open feed works without.
+MBTA_API_KEY=
+# Chicago — CTA Train Tracker. Bus Tracker key is separate and currently portal-down.
+CTA_TRAIN_TRACKER_API_KEY=
+# Portland — TriMet. Query-param appID.
+TRIMET_API_KEY=
+# Atlanta — MARTA GTFS-rt.
+MARTA_API_KEY=
+# No-key connectors (SEPTA / Amtrak plaintext / Metrolink / DART) need no env.
+# -----------------------------------------------------------------------------

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,7 @@
 #   CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET (Cloudflare Access Service Auth for SSH over tunnel)
 #   NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY
 #   NEXTAUTH_SECRET (production cookie signing — set a strong secret)
-#   Optional: SUPABASE_SERVICE_ROLE_KEY, MAS_API_URL, MINDEX_API_URL, OPENAI_API_KEY, wallet keys
+#   Optional: SUPABASE_SERVICE_ROLE_KEY, MAS_API_URL, MINDEX_API_URL, MINDEX_API_KEY, OPENAI_API_KEY, AIRNOW_API_KEY, wallet keys
 #   Optional: CLOUDFLARE_ZONE_ID, CLOUDFLARE_API_TOKEN (purge after deploy)
 #
 # CREP map/globe client tokens — inlined at `next build` time via Docker
@@ -390,7 +390,7 @@ jobs:
             set -e
             cd /opt/mycosoft/website
             touch .env
-            for var in NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY MYCOSOFT_SOL_WALLET MYCOSOFT_ETH_WALLET MYCOSOFT_BTC_WALLET MAS_API_URL MINDEX_API_URL OPENAI_API_KEY; do
+            for var in NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY MYCOSOFT_SOL_WALLET MYCOSOFT_ETH_WALLET MYCOSOFT_BTC_WALLET MAS_API_URL MINDEX_API_URL MINDEX_API_KEY OPENAI_API_KEY AIRNOW_API_KEY; do
               sed -i "/^${var}=/d" .env
             done
           ENVSCRIPT
@@ -404,7 +404,9 @@ jobs:
             echo 'MYCOSOFT_BTC_WALLET=${{ secrets.MYCOSOFT_BTC_WALLET }}' >> .env
             echo 'MAS_API_URL=${{ secrets.MAS_API_URL }}' >> .env
             echo 'MINDEX_API_URL=${{ secrets.MINDEX_API_URL }}' >> .env
+            echo 'MINDEX_API_KEY=${{ secrets.MINDEX_API_KEY }}' >> .env
             echo 'OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}' >> .env
+            echo 'AIRNOW_API_KEY=${{ secrets.AIRNOW_API_KEY }}' >> .env
             echo 'DATABASE_URL=postgresql://mycosoft:mycosoft@postgres:5432/mycosoft' >> .env
             echo "Env vars injected"
           ENVSCRIPT2
@@ -728,7 +730,7 @@ jobs:
             set -e
             cd /opt/mycosoft/website
             touch .env
-            for var in NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY MYCOSOFT_SOL_WALLET MYCOSOFT_ETH_WALLET MYCOSOFT_BTC_WALLET MAS_API_URL MINDEX_API_URL OPENAI_API_KEY; do
+            for var in NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY MYCOSOFT_SOL_WALLET MYCOSOFT_ETH_WALLET MYCOSOFT_BTC_WALLET MAS_API_URL MINDEX_API_URL MINDEX_API_KEY OPENAI_API_KEY AIRNOW_API_KEY; do
               sed -i "/^${var}=/d" .env
             done
           ENVSCRIPT
@@ -742,7 +744,9 @@ jobs:
             echo 'MYCOSOFT_BTC_WALLET=${{ secrets.MYCOSOFT_BTC_WALLET }}' >> .env
             echo 'MAS_API_URL=${{ secrets.MAS_API_URL }}' >> .env
             echo 'MINDEX_API_URL=${{ secrets.MINDEX_API_URL }}' >> .env
+            echo 'MINDEX_API_KEY=${{ secrets.MINDEX_API_KEY }}' >> .env
             echo 'OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}' >> .env
+            echo 'AIRNOW_API_KEY=${{ secrets.AIRNOW_API_KEY }}' >> .env
             echo 'DATABASE_URL=postgresql://mycosoft:mycosoft@postgres:5432/mycosoft' >> .env
           ENVSCRIPT2
 

--- a/.github/workflows/deploy-sandbox-production.yml
+++ b/.github/workflows/deploy-sandbox-production.yml
@@ -143,7 +143,7 @@ jobs:
               -e NEXTAUTH_URL="\${BASE_URL}" \
               -e NEXT_PUBLIC_SITE_URL="\${BASE_URL}" \
               -e MAS_API_URL=${MAS_API_URL:-http://localhost:8001} \
-              -e MINDEX_API_URL=${MINDEX_API_URL:-http://localhost:8000} \
+              -e MINDEX_API_URL=${MINDEX_API_URL:-http://192.168.0.189:8000} \
               -e MYCOBRAIN_SERVICE_URL=http://host.docker.internal:8003 \
               -e NEXT_PUBLIC_SUPABASE_URL="${NEXT_PUBLIC_SUPABASE_URL:-}" \
               -e NEXT_PUBLIC_SUPABASE_ANON_KEY="${NEXT_PUBLIC_SUPABASE_ANON_KEY:-}" \

--- a/.github/workflows/instant-deploy.yml
+++ b/.github/workflows/instant-deploy.yml
@@ -28,6 +28,12 @@
 # Use this workflow when you want to ship a known-good main commit without
 # waiting for the full lint + test + integration pipeline. Triggered from
 # the Actions tab → Instant Deploy → Run workflow.
+#
+# Production environment secrets (GitHub → Settings → Environments → production):
+#   MINDEX_API_URL=http://192.168.0.189:8000  (not localhost — web container has no MINDEX on :8000)
+#   MINDEX_API_KEY=… if MAS proxy requires it
+#   AIRNOW_API_KEY=… for /api/crep/airnow/* (optional; no key in repo)
+#   MAS_API_URL, NEXT_PUBLIC_*, etc. — see ci-cd.yml header
 
 name: Instant Deploy
 
@@ -179,7 +185,7 @@ jobs:
             set -e
             cd /opt/mycosoft/website
             touch .env
-            for var in NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY MYCOSOFT_SOL_WALLET MYCOSOFT_ETH_WALLET MYCOSOFT_BTC_WALLET MAS_API_URL MINDEX_API_URL OPENAI_API_KEY; do
+            for var in NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY MYCOSOFT_SOL_WALLET MYCOSOFT_ETH_WALLET MYCOSOFT_BTC_WALLET MAS_API_URL MINDEX_API_URL MINDEX_API_KEY OPENAI_API_KEY AIRNOW_API_KEY; do
               sed -i "/^${var}=/d" .env
             done
           ENVSCRIPT
@@ -193,7 +199,9 @@ jobs:
             echo 'MYCOSOFT_BTC_WALLET=${{ secrets.MYCOSOFT_BTC_WALLET }}' >> .env
             echo 'MAS_API_URL=${{ secrets.MAS_API_URL }}' >> .env
             echo 'MINDEX_API_URL=${{ secrets.MINDEX_API_URL }}' >> .env
+            echo 'MINDEX_API_KEY=${{ secrets.MINDEX_API_KEY }}' >> .env
             echo 'OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}' >> .env
+            echo 'AIRNOW_API_KEY=${{ secrets.AIRNOW_API_KEY }}' >> .env
             echo 'DATABASE_URL=postgresql://mycosoft:mycosoft@postgres:5432/mycosoft' >> .env
           ENVSCRIPT2
 

--- a/.github/workflows/network-diagnostics.yml
+++ b/.github/workflows/network-diagnostics.yml
@@ -192,8 +192,8 @@ jobs:
             echo ""
 
             echo "--- MINDEX VM (${MINDEX_VM_HOST}) ---"
-            check_http "MINDEX API"       "${MINDEX_API_URL:-http://localhost:8000}"
-            check_http "MINDEX Health"    "${MINDEX_API_URL:-http://localhost:8000}/health"
+            check_http "MINDEX API"       "${MINDEX_API_URL:-http://192.168.0.189:8000}"
+            check_http "MINDEX Health"    "${MINDEX_API_URL:-http://192.168.0.189:8000}/health"
             echo ""
 
             echo "--- In-Stack Services ---"

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -400,7 +400,7 @@ const ALL_DATABASES: DatabaseInfo[] = [
     tables: 47,
     records: 156847,
     description: 'Master fungal species database with geospatial data',
-    link: 'http://localhost:8000'
+    link: 'http://192.168.0.189:8000'
   },
   { 
     name: 'Supabase Cloud', 

--- a/app/api/ancestry/data-quality/route.ts
+++ b/app/api/ancestry/data-quality/route.ts
@@ -5,8 +5,9 @@
  */
 
 import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 export interface DataQualityStats {

--- a/app/api/ancestry/route.ts
+++ b/app/api/ancestry/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 interface MINDEXTaxon {

--- a/app/api/ancestry/taxonomy/[rank]/[name]/route.ts
+++ b/app/api/ancestry/taxonomy/[rank]/[name]/route.ts
@@ -10,9 +10,10 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 const INAT = "https://api.inaturalist.org/v1"
-const MINDEX = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX = resolveMindexServerBaseUrl()
 
 const RANK_ORDER = ["kingdom", "phylum", "class", "order", "family", "genus", "species"] as const
 type Rank = typeof RANK_ORDER[number]

--- a/app/api/compounds/simulate/route.ts
+++ b/app/api/compounds/simulate/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 /**
  * Compound Simulation API - Real MINDEX Integration

--- a/app/api/compounds/species/[id]/route.ts
+++ b/app/api/compounds/species/[id]/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 /**
  * Compounds by species API - Server-side proxy to MINDEX.
  * NO client env vars needed; MINDEX_API_URL is server-only.
  */
-const MINDEX_API_URL =
-  process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
-const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
+const MINDEX_API_KEY = process.env.MINDEX_API_KEY?.trim() || ""
 
 export async function GET(
   request: NextRequest,
@@ -20,11 +20,10 @@ export async function GET(
 
   try {
     const url = `${MINDEX_API_URL}/api/mindex/compounds/for-taxon/${taxonId}`
+    const headers: Record<string, string> = { "Content-Type": "application/json" }
+    if (MINDEX_API_KEY) headers["X-API-Key"] = MINDEX_API_KEY
     const res = await fetch(url, {
-      headers: {
-        "X-API-Key": MINDEX_API_KEY,
-        "Content-Type": "application/json",
-      },
+      headers,
       next: { revalidate: 300 },
     })
 

--- a/app/api/crep/fungal/route.ts
+++ b/app/api/crep/fungal/route.ts
@@ -23,6 +23,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import bboxPolygon from "@turf/bbox-polygon"
 import area from "@turf/area"
 import { logDataCollection, logAPIError } from "@/lib/oei/mindex-logger"
@@ -31,7 +32,7 @@ import { ingestBatchToMINDEX } from "@/lib/crep/species-catalog"
 const INATURALIST_API = "https://api.inaturalist.org/v1"
 const GBIF_API = "https://api.gbif.org/v1"
 // MINDEX runs on port 8000 (Docker container)
-const MINDEX_API = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API = resolveMindexServerBaseUrl()
 
 const EXTERNAL_API_TIMEOUT_MS = 10000 // 10s per request
 const EXTERNAL_API_MAX_RETRIES = 2

--- a/app/api/crep/nature-stream/route.ts
+++ b/app/api/crep/nature-stream/route.ts
@@ -25,13 +25,14 @@
  */
 
 import { NextRequest } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 export const runtime = "nodejs"
 export const maxDuration = 300 // 5 min connection lifetime, then client reconnects
 
 const INAT_API = "https://api.inaturalist.org/v1"
-const MINDEX_API = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 const POLL_MS = 60_000 // 1 minute
 const HEARTBEAT_MS = 30_000 // 30s

--- a/app/api/crep/services/route.ts
+++ b/app/api/crep/services/route.ts
@@ -7,7 +7,9 @@
  * @route GET /api/crep/services
  */
 
-import { NextResponse } from "next/server";
+import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
+import { resolveMasServerBaseUrl } from "@/lib/mas-server-url"
 
 interface ServiceStatus {
   name: string;
@@ -18,8 +20,8 @@ interface ServiceStatus {
 }
 
 const SERVICES = [
-  { name: "MINDEX", url: process.env.MINDEX_API_URL || "http://localhost:8000", healthPath: "/api/mindex/health" },
-  { name: "MAS Orchestrator", url: process.env.MAS_API_URL || "http://localhost:8001", healthPath: "/health" },
+  { name: "MINDEX", url: resolveMindexServerBaseUrl(), healthPath: "/api/mindex/health" },
+  { name: "MAS Orchestrator", url: resolveMasServerBaseUrl(), healthPath: "/health" },
   { name: "n8n Workflows", url: process.env.N8N_URL || "http://localhost:5678", healthPath: "/healthz" },
   { name: "Redis", url: process.env.REDIS_URL || "http://localhost:6379", healthPath: "", ping: true },
   { name: "Qdrant Vector DB", url: process.env.QDRANT_URL || "http://localhost:6333", healthPath: "/healthz" },

--- a/app/api/devices/discover/route.ts
+++ b/app/api/devices/discover/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
@@ -14,7 +15,7 @@ export const dynamic = "force-dynamic"
  */
 export async function GET() {
   const mycoBrainUrl = process.env.MYCOBRAIN_SERVICE_URL || process.env.MYCOBRAIN_API_URL || "http://localhost:8003"
-  const mindexUrl = process.env.MINDEX_API_URL || "http://localhost:8000"
+  const mindexUrl = resolveMindexServerBaseUrl()
   const masUrl = process.env.MAS_API_URL || "http://localhost:8001"
   
   try {

--- a/app/api/fci/devices/route.ts
+++ b/app/api/fci/devices/route.ts
@@ -8,8 +8,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/fci/gfst/route.ts
+++ b/app/api/fci/gfst/route.ts
@@ -7,8 +7,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 // Fallback GFST patterns if MINDEX is unavailable
 const FALLBACK_GFST_PATTERNS = [

--- a/app/api/fci/notes/route.ts
+++ b/app/api/fci/notes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 interface FCINoteRequest {

--- a/app/api/fci/patterns/route.ts
+++ b/app/api/fci/patterns/route.ts
@@ -8,8 +8,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/fci/telemetry/route.ts
+++ b/app/api/fci/telemetry/route.ts
@@ -8,8 +8,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/gateway/mindex/route.ts
+++ b/app/api/gateway/mindex/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 /**

--- a/app/api/genetics/[speciesId]/[region]/route.ts
+++ b/app/api/genetics/[speciesId]/[region]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 /**
  * Genetic Sequence Download API
@@ -9,7 +10,7 @@ import { NextRequest, NextResponse } from "next/server"
 const VALID_REGIONS = ["ITS", "LSU", "SSU", "TEF1", "RPB1", "RPB2", "FASTA"] as const
 type GeneticRegion = (typeof VALID_REGIONS)[number]
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 interface GeneticSequence {

--- a/app/api/genetics/[speciesId]/route.ts
+++ b/app/api/genetics/[speciesId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 /**
  * List available genetic sequences for a species.
@@ -6,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server"
  * Returns empty regions when none available.
  */
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 // Region metadata for display (used only when we have real sequences)

--- a/app/api/grounding/route.ts
+++ b/app/api/grounding/route.ts
@@ -7,9 +7,10 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 const MAS_API_URL = process.env.MAS_API_URL || "http://localhost:8001"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY
 
 interface GroundingStatus {

--- a/app/api/growth/predict/route.ts
+++ b/app/api/growth/predict/route.ts
@@ -11,8 +11,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 // Species-specific growth parameters (from scientific literature)

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
@@ -102,7 +103,7 @@ export async function GET() {
   // Check MINDEX API connectivity
   try {
     const mindexStart = Date.now()
-    const mindexUrl = process.env.MINDEX_API_URL || "http://localhost:8000"
+    const mindexUrl = resolveMindexServerBaseUrl()
     const mindexResponse = await fetch(`${mindexUrl}/api/v1/taxon/stats`, { 
       signal: AbortSignal.timeout(3000) 
     }).catch(() => null)

--- a/app/api/mas/voice/orchestrator/route.ts
+++ b/app/api/mas/voice/orchestrator/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import { MycaNLQEngine, type NLQResponse } from "@/lib/services/myca-nlq"
 import { createClient } from "@/lib/supabase/server"
 import { voiceLimiter, getClientIP, rateLimitResponse } from "@/lib/rate-limiter"
@@ -20,7 +21,7 @@ import { evaluateGovernance, type AvaniEvaluation } from "@/lib/services/avani-g
 const MAS_API_URL = process.env.MAS_API_URL || "http://localhost:8001"
 
 // MINDEX API (port 8000) - for data-aware fallback when consciousness fails
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 // n8n Webhooks
 const N8N_URL = process.env.N8N_URL || "http://localhost:5678"

--- a/app/api/mindex/genome-tracks/route.ts
+++ b/app/api/mindex/genome-tracks/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 export async function GET(request: Request) {

--- a/app/api/mindex/graft/route.ts
+++ b/app/api/mindex/graft/route.ts
@@ -14,11 +14,12 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 export const maxDuration = 15
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 // =============================================================================
 // TYPES

--- a/app/api/mindex/observations/route.ts
+++ b/app/api/mindex/observations/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 const INATURALIST_API = "https://api.inaturalist.org/v1"
 const GBIF_API = "https://api.gbif.org/v1"
@@ -159,11 +160,7 @@ async function fetchGBIFObservations(
 
 // Check MINDEX API (VM 189:8000 or local)
 async function fetchLocalMINDEX(limit: number): Promise<Observation[]> {
-  const mindexUrl =
-    process.env.MINDEX_API_URL ||
-    process.env.MINDEX_API_BASE_URL ||
-    process.env.MINDEX_DATABASE_URL ||
-    "http://localhost:8000"
+  const mindexUrl = process.env.MINDEX_DATABASE_URL || resolveMindexServerBaseUrl()
 
   try {
     const url = mindexUrl.includes("/api/") ? `${mindexUrl}/observations` : `${mindexUrl}/api/mindex/observations`

--- a/app/api/mindex/playback/route.ts
+++ b/app/api/mindex/playback/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 // Data types available for playback
 const PLAYBACK_TYPES = [

--- a/app/api/mindex/proxy/[source]/route.ts
+++ b/app/api/mindex/proxy/[source]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 /**
  * MINDEX Cache Proxy — Unified data access for all CREP map layers
@@ -22,12 +23,14 @@ import { NextRequest, NextResponse } from "next/server"
  * (/api/oei/*, /api/crep/*, /api/natureos/*) but data won't be persisted.
  */
 
-const MINDEX_URL =
-  process.env.MINDEX_API_URL ||
-  process.env.NEXT_PUBLIC_MINDEX_URL ||
-  "http://192.168.0.189:8000"
+const MINDEX_URL = resolveMindexServerBaseUrl()
+const MINDEX_API_KEY = process.env.MINDEX_API_KEY?.trim() || ""
 
-const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
+function mindexHeaders(): HeadersInit {
+  const h: Record<string, string> = { Accept: "application/json" }
+  if (MINDEX_API_KEY) h["X-API-Key"] = MINDEX_API_KEY
+  return h
+}
 
 /** Map source names to MINDEX earth/map/bbox layer names */
 const SOURCE_TO_MINDEX_LAYER: Record<string, string> = {
@@ -118,7 +121,7 @@ export async function GET(
     const res = await fetch(mindexUrl, {
       cache: "no-store",
       signal: AbortSignal.timeout(30000),
-      headers: { Accept: "application/json", "X-API-Key": MINDEX_API_KEY },
+      headers: mindexHeaders(),
     })
 
     if (res.ok) {
@@ -228,12 +231,11 @@ export async function POST(
   const valid = entities.filter(e => e.lat != null && e.lng != null)
 
   try {
+    const ingestHeaders: Record<string, string> = { "Content-Type": "application/json" }
+    if (MINDEX_API_KEY) ingestHeaders["X-API-Key"] = MINDEX_API_KEY
     const res = await fetch(`${MINDEX_URL}/api/mindex/earth/ingest`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": MINDEX_API_KEY,
-      },
+      headers: ingestHeaders,
       body: JSON.stringify({
         source,
         layer: mindexLayer,

--- a/app/api/mindex/registry/devices/route.ts
+++ b/app/api/mindex/registry/devices/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 // Mycosoft device types
 const DEVICE_TYPES = [

--- a/app/api/mindex/registry/events/route.ts
+++ b/app/api/mindex/registry/events/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 // Event types tracked in the registry
 const EVENT_TYPES = [

--- a/app/api/mindex/telemetry/route.ts
+++ b/app/api/mindex/telemetry/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import { recordUsageFromRequest } from "@/lib/usage/record-api-usage"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || ""
 
 /**

--- a/app/api/mindex/telemetry/samples/route.ts
+++ b/app/api/mindex/telemetry/samples/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || ""
 
 export async function GET(request: NextRequest) {

--- a/app/api/mycobrain/[port]/diagnostics/route.ts
+++ b/app/api/mycobrain/[port]/diagnostics/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
 const MYCOBRAIN_SERVICE_URL = process.env.MYCOBRAIN_SERVICE_URL || "http://localhost:8003"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 // Send command to board and get response
 async function sendBoardCommand(deviceId: string, cmd: string): Promise<string | null> {

--- a/app/api/mycobrain/[port]/peripherals/route.ts
+++ b/app/api/mycobrain/[port]/peripherals/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
 const MYCOBRAIN_SERVICE_URL = process.env.MYCOBRAIN_SERVICE_URL || "http://localhost:8003"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 /**
  * Known I2C device addresses

--- a/app/api/mycobrain/[port]/register/route.ts
+++ b/app/api/mycobrain/[port]/register/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
 const MYCOBRAIN_SERVICE_URL = process.env.MYCOBRAIN_SERVICE_URL || "http://localhost:8003"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const NATUREOS_API_URL = process.env.NATUREOS_API_URL || "http://localhost:3000/api/natureos"
 const MAS_ORCHESTRATOR_URL = process.env.MAS_ORCHESTRATOR_URL || "http://localhost:8001"
 

--- a/app/api/mycobrain/[port]/telemetry/route.ts
+++ b/app/api/mycobrain/[port]/telemetry/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import { createHash, randomUUID } from "crypto"
 
 export const dynamic = "force-dynamic"
 
 const MYCOBRAIN_SERVICE_URL = process.env.MYCOBRAIN_SERVICE_URL || "http://localhost:8003"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || ""
 
 function buildEnvelopeFromTelemetry(deviceId: string, entries: TelemetryEntry[]) {

--- a/app/api/natureos/activity-topology/route.ts
+++ b/app/api/natureos/activity-topology/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import type { ActivityNode, ActivityConnection, ActivityTopologyData } from "@/components/mas/topology/activity-types"
 
 export const dynamic = "force-dynamic"
 
 const MAS_API_URL = process.env.MAS_API_URL || process.env.NEXT_PUBLIC_MAS_API_URL || "http://localhost:8001"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const N8N_URL = process.env.N8N_URL || process.env.N8N_WEBHOOK_URL?.replace(/\/webhook.*$/, "") || "http://localhost:5678"
 const HEALTH_TIMEOUT_MS = 4000
 

--- a/app/api/natureos/devices/mycobrain/route.ts
+++ b/app/api/natureos/devices/mycobrain/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
 const MYCOBRAIN_SERVICE_URL = process.env.MYCOBRAIN_SERVICE_URL || "http://localhost:8765"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 /**
  * GET /api/natureos/devices/mycobrain

--- a/app/api/natureos/devices/telemetry/route.ts
+++ b/app/api/natureos/devices/telemetry/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
 // Fetch real device telemetry from MycoBrain, MINDEX, and network
 async function fetchRealDeviceTelemetry() {
   const mycoBrainUrl = process.env.MYCOBRAIN_SERVICE_URL || "http://localhost:8765"
-  const mindexUrl = process.env.MINDEX_API_URL || "http://localhost:8000"
+  const mindexUrl = resolveMindexServerBaseUrl()
   
   try {
     const devices: any[] = []

--- a/app/api/natureos/mindex/compounds/route.ts
+++ b/app/api/natureos/mindex/compounds/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
-const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
+const MINDEX_API_KEY = process.env.MINDEX_API_KEY?.trim() || ""
 
 /**
  * MINDEX Compounds API Proxy
@@ -12,11 +13,10 @@ const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
  */
 export async function GET() {
   try {
+    const headers: Record<string, string> = { "Content-Type": "application/json" }
+    if (MINDEX_API_KEY) headers["X-API-Key"] = MINDEX_API_KEY
     const response = await fetch(`${MINDEX_API_URL}/api/mindex/compounds`, {
-      headers: {
-        "X-API-Key": MINDEX_API_KEY,
-        "Content-Type": "application/json",
-      },
+      headers,
       next: { revalidate: 300 }, // Cache for 5 minutes
     })
 

--- a/app/api/natureos/mindex/etl-status/route.ts
+++ b/app/api/natureos/mindex/etl-status/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 export async function GET(request: NextRequest) {

--- a/app/api/natureos/mindex/genes/[species]/route.ts
+++ b/app/api/natureos/mindex/genes/[species]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 /**
  * MINDEX Gene Annotations API
@@ -19,7 +20,7 @@ interface Gene {
   go_terms?: string[]
 }
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 export async function GET(

--- a/app/api/natureos/mindex/ledger/route.ts
+++ b/app/api/natureos/mindex/ledger/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 export async function GET(request: NextRequest) {

--- a/app/api/natureos/mindex/mwave/route.ts
+++ b/app/api/natureos/mindex/mwave/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 export async function GET(request: NextRequest) {

--- a/app/api/natureos/mindex/phylogeny/route.ts
+++ b/app/api/natureos/mindex/phylogeny/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 /**
  * MINDEX Phylogeny Data API
@@ -19,7 +20,7 @@ interface PhylogenyNode {
   genome_available?: boolean
 }
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 function flattenTree(

--- a/app/api/natureos/mindex/sync/route.ts
+++ b/app/api/natureos/mindex/sync/route.ts
@@ -5,8 +5,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 export const dynamic = "force-dynamic"

--- a/app/api/natureos/mindex/taxa/[id]/route.ts
+++ b/app/api/natureos/mindex/taxa/[id]/route.ts
@@ -6,8 +6,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 export const dynamic = "force-dynamic"

--- a/app/api/natureos/nlm-training/route.ts
+++ b/app/api/natureos/nlm-training/route.ts
@@ -10,9 +10,10 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 const MAS_API_URL = process.env.MAS_API_URL || "http://localhost:8001"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 async function safeFetch(url: string, options?: RequestInit & { timeout?: number }) {
   const timeout = options?.timeout ?? 8000

--- a/app/api/natureos/shell/mindex/route.ts
+++ b/app/api/natureos/shell/mindex/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_BASE_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 /**

--- a/app/api/search/chat/route.ts
+++ b/app/api/search/chat/route.ts
@@ -5,12 +5,13 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import { searchLimiter, getClientIP, rateLimitResponse } from "@/lib/rate-limiter"
 import { evaluateGovernance } from "@/lib/services/avani-governance"
 import { callMASSearchExecute, mapMASResponseToUnified } from "@/lib/search/mas-search-proxy"
 
 const MAS_API_URL = process.env.MAS_API_URL || "http://localhost:8001"
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const USE_MAS_SEARCH = process.env.USE_MAS_SEARCH !== "false"
 
 interface ChatRequest {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import { searchFungi } from "@/lib/services/inaturalist"
 import { searchElsevierArticles } from "@/lib/services/elsevier"
 import type { SearchResult } from "@/types/search"
@@ -8,7 +9,7 @@ import { searchExpandedMushrooms } from "@/lib/data/top-mushrooms-expanded"
 import { searchTracker } from "@/lib/services/search-tracker"
 import { recordUsageFromRequest } from "@/lib/usage/record-api-usage"
 
-const MINDEX_BASE = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_BASE = resolveMindexServerBaseUrl()
 const USE_WORLDVIEW_SEARCH = process.env.USE_WORLDVIEW_SEARCH === "true"
 
 interface SpeciesMappingEntry {

--- a/app/api/search/trends/route.ts
+++ b/app/api/search/trends/route.ts
@@ -6,10 +6,11 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 interface TrendingTopic {
   topic: string

--- a/app/api/search/unified-v2/route.ts
+++ b/app/api/search/unified-v2/route.ts
@@ -8,6 +8,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import { searchLimiter, getClientIP, rateLimitResponse } from "@/lib/rate-limiter"
 import { recordUsageFromRequest } from "@/lib/usage/record-api-usage"
 import { callMASSearchExecute, mapMASResponseToUnified } from "@/lib/search/mas-search-proxy"
@@ -21,7 +22,7 @@ export const maxDuration = 30
 // CONFIGURATION
 // =============================================================================
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MAS_API_URL = process.env.MAS_API_URL || "http://localhost:8001"
 const USE_MAS_SEARCH = process.env.USE_MAS_SEARCH !== "false"
 const INATURALIST_API = "https://api.inaturalist.org/v1"

--- a/app/api/search/unified/route.ts
+++ b/app/api/search/unified/route.ts
@@ -8,6 +8,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import { recordUsageFromRequest } from "@/lib/usage/record-api-usage"
 import { searchFungi, searchTaxa } from "@/lib/services/inaturalist"
 import {
@@ -22,7 +23,7 @@ import { searchEarthIntelligence, detectEarthDomains } from "@/lib/search/earth-
 
 export const dynamic = "force-dynamic"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const USE_MAS_SEARCH = process.env.USE_MAS_SEARCH !== "false"
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY
 

--- a/app/api/transit/511-bay/route.ts
+++ b/app/api/transit/511-bay/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchMultipleFeeds, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * 511 SF Bay Area — aggregated feed for 45+ operators.
+ *
+ * One TRANSIT_511_API_KEY covers Muni (SF), AC Transit, BART, Caltrain,
+ * VTA, SamTrans, Golden Gate ferry/bus, SF Bay Ferry, and 37 others.
+ *
+ * GET /api/transit/511-bay?bbox=w,s,e,n&operators=SF,AC,CT
+ *   operators (default: SF,AC,BA,CT,SC,SM,GF,SB) — comma-separated ids
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const DEFAULT_OPS = ["SF", "AC", "BA", "CT", "SC", "SM", "GF", "SB"]
+
+// Rough mapping of operator_id → vehicle_type for coloring the CREP layer
+const OP_TYPE: Record<string, "bus" | "rail" | "subway" | "ferry" | "tram"> = {
+  SF: "bus",  // Muni (mixed — but dominantly bus; light-rail Muni Metro gets filtered by route)
+  AC: "bus",
+  BA: "subway",
+  CT: "rail", // Caltrain
+  SC: "bus",  // VTA (mixed with light rail)
+  SM: "bus",  // SamTrans
+  GF: "ferry",
+  SB: "ferry",
+  WC: "bus",
+  UN: "bus",
+}
+
+export async function GET(req: NextRequest) {
+  const key = process.env.TRANSIT_511_API_KEY?.trim()
+  if (!key) return NextResponse.json({ ok: false, error: "TRANSIT_511_API_KEY not configured" }, { status: 501 })
+
+  const ops = (req.nextUrl.searchParams.get("operators") || DEFAULT_OPS.join(","))
+    .split(",").map((s) => s.trim().toUpperCase()).filter(Boolean)
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+
+  const feeds = ops.map((op) => ({
+    url: `http://api.511.org/transit/vehiclepositions?api_key=${encodeURIComponent(key)}&agency=${encodeURIComponent(op)}`,
+    vehicleType: OP_TYPE[op] || "bus" as const,
+  }))
+
+  const result = await fetchMultipleFeeds(feeds, {
+    agency: "o-9q9-511-sfbay",
+    agency_name: "511 SF Bay",
+  })
+  const vehicles = cullVehiclesToBbox(result.vehicles, bbox)
+
+  return NextResponse.json({
+    ok: result.ok,
+    agency: "511 SF Bay",
+    operators_requested: ops,
+    vehicles_total: result.vehicles.length,
+    vehicles_in_bbox: vehicles.length,
+    vehicles,
+    generated_at: result.generated_at,
+    error: result.error,
+  }, { headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30" } })
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/all/route.ts
+++ b/app/api/transit/all/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { TransitVehicle } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * Aggregate every connected transit agency into one GeoJSON FeatureCollection
+ * so the CREP map layer can consume a single source of truth. Each agency is
+ * fetched in parallel; a failing agency does not break the aggregate.
+ *
+ * GET /api/transit/all?bbox=w,s,e,n&agencies=mta,wmata,septa
+ *   bbox     optional viewport filter (applied AFTER the per-agency fetch
+ *            so we can cache per-agency and cull per request).
+ *   agencies comma-separated subset; omit for all known agencies.
+ *
+ * Response:
+ *   {
+ *     type: "FeatureCollection",
+ *     features: [{ type:"Feature", geometry:{type:"Point",coordinates:[lng,lat]},
+ *                  properties:{ id, agency, agency_name, route_id, vehicle_type,
+ *                               bearing, speed_mps, timestamp, ... } }, ...],
+ *     agencies: [{ id, vehicles, ok }],
+ *     vehicles_total, vehicles_in_bbox, generated_at, errors
+ *   }
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+interface AgencyDef {
+  id: string
+  path: string // absolute path used for origin-fetch
+  keyEnv?: string // env var required to include (skip if unset)
+}
+
+// Order matters for the map layer legend; earliest wins on dedupe by id.
+const AGENCIES: AgencyDef[] = [
+  { id: "mta", path: "/api/transit/mta" },
+  { id: "wmata", path: "/api/transit/wmata", keyEnv: "WMATA_API_KEY" },
+  { id: "bart", path: "/api/transit/bart" },
+  { id: "mbta", path: "/api/transit/mbta" },
+  { id: "511-bay", path: "/api/transit/511-bay", keyEnv: "TRANSIT_511_API_KEY" },
+  { id: "cta-train", path: "/api/transit/cta-train", keyEnv: "CTA_TRAIN_TRACKER_API_KEY" },
+  { id: "trimet", path: "/api/transit/trimet", keyEnv: "TRIMET_API_KEY" },
+  { id: "marta", path: "/api/transit/marta", keyEnv: "MARTA_API_KEY" },
+  { id: "amtrak", path: "/api/transit/amtrak" },
+  { id: "septa", path: "/api/transit/septa" },
+  { id: "metrolink", path: "/api/transit/metrolink" },
+  { id: "dart", path: "/api/transit/dart" },
+]
+
+async function fetchAgency(origin: string, def: AgencyDef, bbox: string | null): Promise<{ id: string; vehicles: TransitVehicle[]; ok: boolean; err?: string }> {
+  if (def.keyEnv && !process.env[def.keyEnv]?.trim()) {
+    return { id: def.id, vehicles: [], ok: false, err: `${def.keyEnv} not configured` }
+  }
+  try {
+    const url = `${origin}${def.path}${bbox ? `?bbox=${encodeURIComponent(bbox)}` : ""}`
+    const r = await fetch(url, { signal: AbortSignal.timeout(12_000), cache: "no-store" })
+    if (!r.ok) return { id: def.id, vehicles: [], ok: false, err: `upstream ${r.status}` }
+    const j = await r.json()
+    const vehicles: TransitVehicle[] = Array.isArray(j?.vehicles) ? j.vehicles : []
+    return { id: def.id, vehicles, ok: true }
+  } catch (err: any) {
+    return { id: def.id, vehicles: [], ok: false, err: err?.message || "fetch failed" }
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const bboxParam = req.nextUrl.searchParams.get("bbox")
+  const agenciesParam = (req.nextUrl.searchParams.get("agencies") || "")
+    .split(",").map((s) => s.trim().toLowerCase()).filter(Boolean)
+  const defs = agenciesParam.length
+    ? AGENCIES.filter((a) => agenciesParam.includes(a.id))
+    : AGENCIES
+
+  const origin = new URL(req.url).origin
+  const results = await Promise.all(defs.map((d) => fetchAgency(origin, d, bboxParam)))
+
+  // Dedupe by id across agencies (shouldn't overlap, but defensive)
+  const seen = new Set<string>()
+  const features: any[] = []
+  let vehiclesTotal = 0
+  const agencySummary: Array<{ id: string; vehicles: number; ok: boolean; err?: string }> = []
+
+  for (const r of results) {
+    agencySummary.push({ id: r.id, vehicles: r.vehicles.length, ok: r.ok, err: r.err })
+    for (const v of r.vehicles) {
+      if (seen.has(v.id)) continue
+      seen.add(v.id)
+      features.push({
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [v.lng, v.lat] },
+        properties: {
+          id: v.id,
+          agency: v.agency,
+          agency_name: v.agency_name,
+          route_id: v.route_id,
+          route_short_name: v.route_short_name,
+          trip_id: v.trip_id,
+          vehicle_id: v.vehicle_id,
+          bearing: v.bearing,
+          speed_mps: v.speed_mps,
+          timestamp: v.timestamp,
+          vehicle_type: v.vehicle_type || "other",
+          occupancy: v.occupancy,
+          current_status: v.current_status,
+          stop_id: v.stop_id,
+        },
+      })
+      vehiclesTotal++
+    }
+  }
+
+  const errors = agencySummary.filter((a) => !a.ok).map((a) => `${a.id}: ${a.err}`)
+  return NextResponse.json({
+    type: "FeatureCollection",
+    features,
+    agencies: agencySummary,
+    vehicles_total: vehiclesTotal,
+    vehicles_in_bbox: vehiclesTotal, // per-agency already culled by bbox
+    generated_at: new Date().toISOString(),
+    errors: errors.length ? errors : undefined,
+  }, { headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30" } })
+}

--- a/app/api/transit/amtrak/route.ts
+++ b/app/api/transit/amtrak/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { TransitVehicle } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * Amtrak national live train positions — Apr 23, 2026.
+ *
+ * Amtrak doesn't publish a developer API. Their Track-A-Train web app
+ * fetches a JSON list (undocumented, stable since 2018). The response
+ * is base64-AES encrypted; the decryption key rotates in the page
+ * bundle. For Phase 1 we serve the raw RoutesList.v.json feed (which
+ * IS plaintext — a directory of routes + train numbers), and call the
+ * decryption in Phase 2 once the key-rotation helper lands.
+ *
+ * GET /api/transit/amtrak?bbox=w,s,e,n
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(req: NextRequest) {
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+  try {
+    // RoutesList.v.json is plaintext and gives us the current roster of
+    // active trains — that's enough to surface "how many Amtrak trains
+    // are running now" on the dashboard even before we add the position
+    // decryptor.
+    const url = "https://maps.amtrak.com/rttl/js/RoutesList.v.json"
+    const r = await fetch(url, {
+      headers: { "User-Agent": "Mycosoft-CREP-Transit/1.0" },
+      signal: AbortSignal.timeout(10_000),
+      cache: "no-store",
+    })
+    if (!r.ok) return NextResponse.json({ ok: false, error: `upstream ${r.status}` }, { status: 502 })
+    const data = await r.json()
+
+    // data shape varies; handle both list-of-trains AND map-of-routes.
+    const vehicles: TransitVehicle[] = []
+    let activeTrains = 0
+    if (Array.isArray(data)) {
+      // List of trains with lat/lon (rare plaintext format)
+      for (const t of data) {
+        const lat = Number(t?.lat ?? t?.Lat), lng = Number(t?.lon ?? t?.Lon)
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue
+        activeTrains++
+        vehicles.push({
+          id: `amtrak:${t.TrainNum || t.tn || t.id}`,
+          agency: "o-9-amtrak",
+          agency_name: "Amtrak",
+          route_id: t.RouteName || t.route || undefined,
+          trip_id: `amtrak-${t.TrainNum || t.tn}`,
+          vehicle_id: String(t.TrainNum || t.tn || ""),
+          lat, lng,
+          bearing: Number.isFinite(Number(t.heading)) ? Number(t.heading) : undefined,
+          speed_mps: Number.isFinite(Number(t.Velocity)) ? Number(t.Velocity) * 0.44704 : undefined,
+          timestamp: t.LastValTS ? Date.parse(t.LastValTS) : Date.now(),
+          vehicle_type: "rail",
+        })
+      }
+    }
+
+    const filtered = bbox && vehicles.length
+      ? vehicles.filter((v) => v.lng >= bbox[0] && v.lng <= bbox[2] && v.lat >= bbox[1] && v.lat <= bbox[3])
+      : vehicles
+
+    return NextResponse.json({
+      ok: true, agency: "Amtrak", agency_onestop: "o-9-amtrak",
+      vehicles_total: vehicles.length, vehicles_in_bbox: filtered.length,
+      vehicles: filtered, generated_at: new Date().toISOString(),
+      note: vehicles.length === 0
+        ? "Plaintext route list received; encrypted position feed requires Phase-2 decryption (amtrak-py pattern). Routes + train numbers returned in raw but we dropped non-geo entries."
+        : undefined,
+      // Carry metadata so callers can render the route directory even when positions aren't decoded
+      route_catalog_size: Array.isArray(data) ? data.length : Object.keys(data || {}).length,
+    }, { headers: { "Cache-Control": "public, s-maxage=30, stale-while-revalidate=60" } })
+  } catch (err: any) {
+    return NextResponse.json({ ok: false, error: err?.message || "fetch failed" }, { status: 502 })
+  }
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/bart/route.ts
+++ b/app/api/transit/bart/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { TransitVehicle } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * BART — SF Bay Area rapid transit.
+ *
+ * BART doesn't publish GTFS-realtime protobuf. Their live-train API is
+ * JSON (ETD = estimated times of departure). We derive approximate vehicle
+ * positions by joining station coords with live train ETDs so the CREP map
+ * can still animate dots.
+ *
+ * GET /api/transit/bart?bbox=w,s,e,n
+ *
+ * Uses BART_API_KEY env var. `MW9S-E7SL-26DU-VV8V` is BART's longstanding
+ * public sandbox key — we fall back to it when the env key is missing so
+ * the endpoint still works at dev time (BART explicitly allows sandbox key
+ * use for prototyping).
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const SANDBOX_FALLBACK = "MW9S-E7SL-26DU-VV8V"
+
+// BART station coords (canonical subset — used when ETD doesn't carry lat/lng)
+const STATIONS: Record<string, { name: string; lat: number; lng: number }> = {
+  "12TH": { name: "12th St Oakland", lat: 37.8034, lng: -122.2720 },
+  "16TH": { name: "16th St Mission", lat: 37.7654, lng: -122.4194 },
+  "19TH": { name: "19th St Oakland", lat: 37.8084, lng: -122.2687 },
+  "24TH": { name: "24th St Mission", lat: 37.7523, lng: -122.4184 },
+  "ANTC": { name: "Antioch", lat: 37.9955, lng: -121.7805 },
+  "ASHB": { name: "Ashby", lat: 37.8528, lng: -122.2697 },
+  "BALB": { name: "Balboa Park", lat: 37.7217, lng: -122.4473 },
+  "BAYF": { name: "Bay Fair", lat: 37.6970, lng: -122.1266 },
+  "BERY": { name: "Berryessa/North San Jose", lat: 37.3683, lng: -121.8743 },
+  "CAST": { name: "Castro Valley", lat: 37.6906, lng: -122.0757 },
+  "CIVC": { name: "Civic Center/UN Plaza", lat: 37.7795, lng: -122.4136 },
+  "COLM": { name: "Colma", lat: 37.6843, lng: -122.4661 },
+  "COLS": { name: "Coliseum", lat: 37.7537, lng: -122.1976 },
+  "CONC": { name: "Concord", lat: 37.9738, lng: -122.0295 },
+  "DALY": { name: "Daly City", lat: 37.7063, lng: -122.4691 },
+  "DBRK": { name: "Downtown Berkeley", lat: 37.8700, lng: -122.2683 },
+  "DELN": { name: "El Cerrito del Norte", lat: 37.9253, lng: -122.3168 },
+  "DUBL": { name: "Dublin/Pleasanton", lat: 37.7017, lng: -121.9004 },
+  "EMBR": { name: "Embarcadero", lat: 37.7929, lng: -122.3974 },
+  "FRMT": { name: "Fremont", lat: 37.5577, lng: -121.9765 },
+  "FTVL": { name: "Fruitvale", lat: 37.7748, lng: -122.2241 },
+  "GLEN": { name: "Glen Park", lat: 37.7331, lng: -122.4336 },
+  "HAYW": { name: "Hayward", lat: 37.6694, lng: -122.0876 },
+  "LAFY": { name: "Lafayette", lat: 37.8933, lng: -122.1247 },
+  "LAKE": { name: "Lake Merritt", lat: 37.7974, lng: -122.2655 },
+  "MCAR": { name: "MacArthur", lat: 37.8285, lng: -122.2670 },
+  "MLBR": { name: "Millbrae", lat: 37.5997, lng: -122.3873 },
+  "MLPT": { name: "Milpitas", lat: 37.4102, lng: -121.8924 },
+  "MONT": { name: "Montgomery St", lat: 37.7892, lng: -122.4015 },
+  "NBRK": { name: "North Berkeley", lat: 37.8740, lng: -122.2833 },
+  "NCON": { name: "North Concord/Martinez", lat: 38.0031, lng: -122.0246 },
+  "OAKL": { name: "Oakland Intl Airport", lat: 37.7134, lng: -122.2124 },
+  "ORIN": { name: "Orinda", lat: 37.8787, lng: -122.1838 },
+  "PCTR": { name: "Pittsburg Center", lat: 38.0169, lng: -121.8899 },
+  "PITT": { name: "Pittsburg/Bay Point", lat: 38.0189, lng: -121.9457 },
+  "PHIL": { name: "Pleasant Hill/Contra Costa Centre", lat: 37.9286, lng: -122.0561 },
+  "POWL": { name: "Powell St", lat: 37.7844, lng: -122.4080 },
+  "RICH": { name: "Richmond", lat: 37.9368, lng: -122.3530 },
+  "ROCK": { name: "Rockridge", lat: 37.8443, lng: -122.2515 },
+  "SANL": { name: "San Leandro", lat: 37.7227, lng: -122.1610 },
+  "SBRN": { name: "San Bruno", lat: 37.6376, lng: -122.4160 },
+  "SFIA": { name: "San Francisco Intl Airport", lat: 37.6156, lng: -122.3929 },
+  "SHAY": { name: "South Hayward", lat: 37.6348, lng: -122.0575 },
+  "SSAN": { name: "South San Francisco", lat: 37.6642, lng: -122.4437 },
+  "UCTY": { name: "Union City", lat: 37.5912, lng: -122.0174 },
+  "WARM": { name: "Warm Springs/South Fremont", lat: 37.5026, lng: -121.9395 },
+  "WCRK": { name: "Walnut Creek", lat: 37.9055, lng: -122.0676 },
+  "WDUB": { name: "West Dublin/Pleasanton", lat: 37.6996, lng: -121.9282 },
+  "WOAK": { name: "West Oakland", lat: 37.8050, lng: -122.2946 },
+}
+
+export async function GET(req: NextRequest) {
+  const key = (process.env.BART_API_KEY?.trim()) || SANDBOX_FALLBACK
+  const bboxStr = req.nextUrl.searchParams.get("bbox")
+  const bbox = parseBbox(bboxStr)
+
+  try {
+    const url = `https://api.bart.gov/api/etd.aspx?cmd=etd&orig=ALL&key=${encodeURIComponent(key)}&json=y`
+    const r = await fetch(url, { signal: AbortSignal.timeout(10_000), cache: "no-store" })
+    if (!r.ok) return NextResponse.json({ ok: false, error: `upstream ${r.status}` }, { status: 502 })
+    const j = await r.json()
+    const stations: any[] = j?.root?.station || []
+    const vehicles: TransitVehicle[] = []
+    for (const s of stations) {
+      const abbr = s.abbr
+      const meta = STATIONS[abbr]
+      if (!meta) continue
+      const etds: any[] = s.etd || []
+      for (const etd of etds) {
+        const est: any[] = etd.estimate || []
+        for (const e of est) {
+          const mins = Number(e.minutes)
+          if (!Number.isFinite(mins) && e.minutes !== "Leaving") continue
+          // Derive an approximate "leaving X in N minutes" vehicle at the station
+          vehicles.push({
+            id: `bart:${abbr}:${etd.destination}:${e.minutes}:${e.platform || "?"}`,
+            agency: "o-9q9-bart",
+            agency_name: "BART",
+            route_id: etd.abbreviation || undefined,
+            trip_id: `bart-${abbr}-${etd.destination}`,
+            lat: meta.lat,
+            lng: meta.lng,
+            timestamp: Date.now(),
+            vehicle_type: "rail",
+            current_status: mins === 0 || e.minutes === "Leaving" ? "STOPPED_AT" : "INCOMING_AT",
+            stop_id: abbr,
+            // Use route color + destination as metadata
+          })
+        }
+      }
+    }
+    const filtered = bbox
+      ? vehicles.filter((v) => v.lng >= bbox[0] && v.lng <= bbox[2] && v.lat >= bbox[1] && v.lat <= bbox[3])
+      : vehicles
+
+    return NextResponse.json({
+      ok: true,
+      agency: "BART",
+      agency_onestop: "o-9q9-bart",
+      vehicles_total: vehicles.length,
+      vehicles_in_bbox: filtered.length,
+      vehicles: filtered,
+      generated_at: new Date().toISOString(),
+      note: "BART doesn't expose GTFS-rt protobuf; this endpoint derives vehicle-like dots from ETDs.",
+    }, { headers: { "Cache-Control": "public, s-maxage=15, stale-while-revalidate=30" } })
+  } catch (err: any) {
+    return NextResponse.json({ ok: false, error: err?.message || "fetch failed" }, { status: 502 })
+  }
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/cta-train/route.ts
+++ b/app/api/transit/cta-train/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { TransitVehicle } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * CTA — Chicago "L" train tracker.
+ *
+ * CTA exposes a JSON "ttpositions" endpoint — one request per line.
+ * We pull all 8 lines in parallel, normalize to TransitVehicle.
+ *
+ * GET /api/transit/cta-train?bbox=w,s,e,n&routes=red,blue,brn
+ *   routes (default = all): red, blue, brn (Brown), g (Green),
+ *                           org (Orange), p (Purple), pink, y (Yellow)
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const LINES = ["red", "blue", "brn", "g", "org", "p", "pink", "y"] as const
+
+export async function GET(req: NextRequest) {
+  const key = process.env.CTA_TRAIN_TRACKER_API_KEY?.trim()
+  if (!key) return NextResponse.json({ ok: false, error: "CTA_TRAIN_TRACKER_API_KEY not configured" }, { status: 501 })
+
+  const routesParam = (req.nextUrl.searchParams.get("routes") || "")
+    .split(",").map((s) => s.trim().toLowerCase()).filter(Boolean)
+  const routes = routesParam.length ? routesParam.filter((r) => (LINES as readonly string[]).includes(r)) : LINES
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+
+  const fetches = await Promise.all(
+    routes.map(async (rt) => {
+      try {
+        const url = `http://lapi.transitchicago.com/api/1.0/ttpositions.aspx?key=${encodeURIComponent(key)}&rt=${encodeURIComponent(rt)}&outputType=JSON`
+        const r = await fetch(url, { signal: AbortSignal.timeout(8_000), cache: "no-store" })
+        if (!r.ok) return { route: rt, trains: [] as any[] }
+        const j = await r.json()
+        const trains: any[] = j?.ctatt?.route?.[0]?.train || []
+        return { route: rt, trains }
+      } catch { return { route: rt, trains: [] as any[] } }
+    })
+  )
+
+  const vehicles: TransitVehicle[] = []
+  for (const { route, trains } of fetches) {
+    for (const t of trains) {
+      const lat = Number(t.lat), lng = Number(t.lon)
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue
+      vehicles.push({
+        id: `cta:${t.rn || `${route}-${t.nextStaId || ""}-${t.arrT || ""}`}`,
+        agency: "o-dp3-cta",
+        agency_name: "CTA",
+        route_id: route.toUpperCase(),
+        trip_id: t.destNm ? `cta-${route}-${t.destNm}` : undefined,
+        vehicle_id: t.rn ? String(t.rn) : undefined,
+        lat, lng,
+        bearing: typeof t.heading === "number" ? Number(t.heading) : undefined,
+        timestamp: Date.now(),
+        vehicle_type: "subway",
+        current_status: t.isApp === "1" ? "INCOMING_AT" : "IN_TRANSIT_TO",
+        stop_id: t.nextStaId ? String(t.nextStaId) : undefined,
+      })
+    }
+  }
+
+  const filtered = bbox
+    ? vehicles.filter((v) => v.lng >= bbox[0] && v.lng <= bbox[2] && v.lat >= bbox[1] && v.lat <= bbox[3])
+    : vehicles
+
+  return NextResponse.json({
+    ok: true,
+    agency: "CTA Train",
+    agency_onestop: "o-dp3-cta",
+    routes_requested: routes,
+    vehicles_total: vehicles.length,
+    vehicles_in_bbox: filtered.length,
+    vehicles: filtered,
+    generated_at: new Date().toISOString(),
+  }, { headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30" } })
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/dart/route.ts
+++ b/app/api/transit/dart/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchVehiclePositions, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * DART (Dallas Area Rapid Transit) — GTFS-rt protobuf (open).
+ * Covers bus + light rail (Red/Blue/Green/Orange) + TRE commuter rail.
+ *
+ * Feed URL — DART publishes via trackingmap.org aggregator (no key required);
+ * the `?agency=DART` param filters to DART only.
+ *
+ * GET /api/transit/dart?bbox=w,s,e,n
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(req: NextRequest) {
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+  // Primary: DART's own GTFS-rt VP endpoint (OpenMobilityData mirror).
+  const url = "https://www.dart.org/transitdata/gtfsrt/vehiclepositions.pb"
+  const result = await fetchVehiclePositions(url, {
+    agency: "o-9vfh-dart",
+    agency_name: "DART",
+    vehicleType: "bus",
+  })
+  const vehicles = cullVehiclesToBbox(result.vehicles, bbox)
+  return NextResponse.json({
+    ok: result.ok, agency: "DART", agency_onestop: "o-9vfh-dart",
+    vehicles_total: result.vehicles.length, vehicles_in_bbox: vehicles.length,
+    vehicles, generated_at: result.generated_at, error: result.error,
+  }, { headers: { "Cache-Control": "public, s-maxage=15, stale-while-revalidate=45" } })
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/marta/route.ts
+++ b/app/api/transit/marta/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchVehiclePositions, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * MARTA (Atlanta) live vehicle positions. GTFS-rt protobuf.
+ *
+ * GET /api/transit/marta?bbox=w,s,e,n
+ *
+ * Requires MARTA_API_KEY. MARTA activates keys within 24h of issue.
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(req: NextRequest) {
+  const key = process.env.MARTA_API_KEY?.trim()
+  // MARTA's .pb endpoint accepts the apiKey as a query param OR no param.
+  const url = key
+    ? `https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb?apiKey=${encodeURIComponent(key)}`
+    : `https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb`
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+  const result = await fetchVehiclePositions(url, {
+    agency: "o-dn5-marta",
+    agency_name: "MARTA",
+  })
+  const vehicles = cullVehiclesToBbox(result.vehicles, bbox)
+  return NextResponse.json({
+    ok: result.ok, agency: "MARTA", agency_onestop: "o-dn5-marta",
+    vehicles_total: result.vehicles.length, vehicles_in_bbox: vehicles.length,
+    vehicles, generated_at: result.generated_at, error: result.error,
+  }, { headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30" } })
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/mbta/route.ts
+++ b/app/api/transit/mbta/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchVehiclePositions, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * MBTA (Boston) live vehicle positions — Apr 23, 2026
+ *
+ * MBTA exposes GTFS-rt protobuf openly on cdn.mbta.com (no key needed
+ * for .pb feeds — the key only raises rate limits on the REST layer).
+ * We use the open .pb endpoint directly for vehicle positions.
+ *
+ * GET /api/transit/mbta?bbox=w,s,e,n
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const VP_FEED = "https://cdn.mbta.com/realtime/VehiclePositions.pb"
+
+export async function GET(req: NextRequest) {
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+  // Pass the key as x-api-key if available — raises our rate limit on
+  // the v3 REST layer (harmless on the .pb endpoint).
+  const headers: Record<string, string> = {}
+  const key = process.env.MBTA_API_KEY?.trim()
+  if (key) headers["x-api-key"] = key
+
+  const result = await fetchVehiclePositions(VP_FEED, {
+    agency: "o-drt-mbta",
+    agency_name: "MBTA",
+    headers,
+  })
+  const vehicles = cullVehiclesToBbox(result.vehicles, bbox)
+
+  return NextResponse.json({
+    ok: result.ok,
+    agency: "MBTA",
+    agency_onestop: "o-drt-mbta",
+    vehicles_total: result.vehicles.length,
+    vehicles_in_bbox: vehicles.length,
+    vehicles,
+    generated_at: result.generated_at,
+    error: result.error,
+  }, { headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30" } })
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/metrolink/route.ts
+++ b/app/api/transit/metrolink/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchVehiclePositions, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * Metrolink (LA Commuter Rail) — GTFS-rt protobuf (open, no key).
+ * Feed: https://metrolinktrains.com/advisories/gtfs/vehiclepositions.pb
+ *
+ * GET /api/transit/metrolink?bbox=w,s,e,n
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(req: NextRequest) {
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+  const url = "https://metrolinktrains.com/advisories/gtfs/vehiclepositions.pb"
+  const result = await fetchVehiclePositions(url, {
+    agency: "o-9q5-metrolink",
+    agency_name: "Metrolink",
+    vehicleType: "rail",
+  })
+  const vehicles = cullVehiclesToBbox(result.vehicles, bbox)
+  return NextResponse.json({
+    ok: result.ok, agency: "Metrolink", agency_onestop: "o-9q5-metrolink",
+    vehicles_total: result.vehicles.length, vehicles_in_bbox: vehicles.length,
+    vehicles, generated_at: result.generated_at, error: result.error,
+  }, { headers: { "Cache-Control": "public, s-maxage=15, stale-while-revalidate=45" } })
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/mta/route.ts
+++ b/app/api/transit/mta/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchMultipleFeeds, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * MTA live vehicle positions — Apr 23, 2026
+ *
+ * Covers NYC subway (all 8 line groups), LIRR, Metro-North, and bus.
+ * No API key required — MTA opened the gate in 2023.
+ *
+ * GET /api/transit/mta?bbox=-74.05,40.70,-73.90,40.90&modes=subway,bus
+ *
+ * modes (comma-separated, default = all):
+ *   subway  8 NYCT subway feeds (ACE, BDFM, G, JZ, NQRW, L, 1234567, SI)
+ *   lirr    Long Island Rail Road
+ *   mnr     Metro-North
+ *   bus     OBA NYCT Bus (all 5 boroughs via gtfsrt.prod.obanyc.com)
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const SUBWAY_FEEDS = [
+  "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace",
+  "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-bdfm",
+  "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-g",
+  "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-jz",
+  "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-nqrw",
+  "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-l",
+  "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs",        // 1-7
+  "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-si",      // Staten Island
+]
+const LIRR_FEED = "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/lirr%2Fgtfs-lirr"
+const MNR_FEED = "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/mnr%2Fgtfs-mnr"
+const BUS_FEED = "http://gtfsrt.prod.obanyc.com/vehiclePositions"
+
+export async function GET(req: NextRequest) {
+  const modes = (req.nextUrl.searchParams.get("modes") || "subway,lirr,mnr,bus")
+    .split(",").map((s) => s.trim().toLowerCase())
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+
+  const feeds: Array<{ url: string; vehicleType?: "subway" | "rail" | "bus" }> = []
+  if (modes.includes("subway")) {
+    for (const url of SUBWAY_FEEDS) feeds.push({ url, vehicleType: "subway" })
+  }
+  if (modes.includes("lirr")) feeds.push({ url: LIRR_FEED, vehicleType: "rail" })
+  if (modes.includes("mnr")) feeds.push({ url: MNR_FEED, vehicleType: "rail" })
+  if (modes.includes("bus")) feeds.push({ url: BUS_FEED, vehicleType: "bus" })
+
+  const result = await fetchMultipleFeeds(feeds, {
+    agency: "o-dr5r-mta",
+    agency_name: "MTA",
+  })
+  const vehicles = cullVehiclesToBbox(result.vehicles, bbox)
+
+  return NextResponse.json({
+    ok: result.ok,
+    agency: "MTA",
+    agency_onestop: "o-dr5r-mta",
+    modes_requested: modes,
+    feed_count: feeds.length,
+    vehicles_total: result.vehicles.length,
+    vehicles_in_bbox: vehicles.length,
+    vehicles,
+    generated_at: result.generated_at,
+    error: result.error,
+  }, {
+    headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30" },
+  })
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  if (parts.length !== 4 || !parts.every(Number.isFinite)) return null
+  return [parts[0], parts[1], parts[2], parts[3]]
+}

--- a/app/api/transit/septa/route.ts
+++ b/app/api/transit/septa/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { TransitVehicle } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * SEPTA (Philadelphia) — bus + trolley + Regional Rail + Broad/Market-Frankford.
+ *
+ * SEPTA exposes a JSON bus/trolley tracker at septa.org (no key). Trains have
+ * a separate `TrainView` JSON. We aggregate both here.
+ *
+ * GET /api/transit/septa?bbox=w,s,e,n&modes=bus,rail
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(req: NextRequest) {
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+  const modesParam = (req.nextUrl.searchParams.get("modes") || "bus,rail")
+    .split(",").map((s) => s.trim().toLowerCase()).filter(Boolean)
+  const wantBus = modesParam.includes("bus")
+  const wantRail = modesParam.includes("rail")
+
+  const [bus, rail] = await Promise.all([
+    wantBus ? fetchBusTrolley() : Promise.resolve([] as TransitVehicle[]),
+    wantRail ? fetchTrainView() : Promise.resolve([] as TransitVehicle[]),
+  ])
+
+  const vehicles = [...bus, ...rail]
+  const filtered = bbox
+    ? vehicles.filter((v) => v.lng >= bbox[0] && v.lng <= bbox[2] && v.lat >= bbox[1] && v.lat <= bbox[3])
+    : vehicles
+
+  return NextResponse.json({
+    ok: true, agency: "SEPTA", agency_onestop: "o-dr4e-septa",
+    modes_requested: modesParam,
+    vehicles_total: vehicles.length, vehicles_in_bbox: filtered.length,
+    vehicles: filtered, generated_at: new Date().toISOString(),
+  }, { headers: { "Cache-Control": "public, s-maxage=15, stale-while-revalidate=45" } })
+}
+
+async function fetchBusTrolley(): Promise<TransitVehicle[]> {
+  try {
+    // SEPTA's TransitView returns all bus/trolley positions
+    const url = "https://www3.septa.org/api/TransitViewAll/index.php"
+    const r = await fetch(url, { signal: AbortSignal.timeout(10_000), cache: "no-store" })
+    if (!r.ok) return []
+    const j = await r.json()
+    // Shape: { "routes": [ { "<route>": [ {...vehicle...}, ... ] } ] }
+    const out: TransitVehicle[] = []
+    const routes: any[] = Array.isArray(j?.routes) ? j.routes : []
+    for (const routeWrap of routes) {
+      for (const [routeId, vehicles] of Object.entries(routeWrap)) {
+        if (!Array.isArray(vehicles)) continue
+        for (const v of vehicles as any[]) {
+          const lat = Number(v.lat), lng = Number(v.lng)
+          if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue
+          out.push({
+            id: `septa-bus:${v.VehicleID}`,
+            agency: "o-dr4e-septa",
+            agency_name: "SEPTA",
+            route_id: String(routeId),
+            route_short_name: String(routeId),
+            trip_id: v.trip ? String(v.trip) : undefined,
+            vehicle_id: String(v.VehicleID),
+            lat, lng,
+            bearing: Number.isFinite(Number(v.heading)) ? Number(v.heading) : undefined,
+            timestamp: v.Offset_sec ? Date.now() - Number(v.Offset_sec) * 1000 : Date.now(),
+            vehicle_type: v.mode === "Trolley" ? "tram" : "bus",
+          })
+        }
+      }
+    }
+    return out
+  } catch { return [] }
+}
+
+async function fetchTrainView(): Promise<TransitVehicle[]> {
+  try {
+    // Regional Rail + MFL + BSL live train positions
+    const url = "https://www3.septa.org/api/TrainView/index.php"
+    const r = await fetch(url, { signal: AbortSignal.timeout(10_000), cache: "no-store" })
+    if (!r.ok) return []
+    const j = await r.json()
+    // Shape: [ { "lat":..., "lon":..., "trainno":..., "service":..., "nextstop":..., "line":... }, ... ]
+    const arr: any[] = Array.isArray(j) ? j : []
+    return arr.map((t) => {
+      const lat = Number(t.lat), lng = Number(t.lon)
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+      return {
+        id: `septa-rail:${t.trainno}`,
+        agency: "o-dr4e-septa",
+        agency_name: "SEPTA",
+        route_id: t.line || undefined,
+        route_short_name: t.line || undefined,
+        trip_id: `septa-${t.trainno}`,
+        vehicle_id: String(t.trainno),
+        lat, lng,
+        bearing: Number.isFinite(Number(t.heading)) ? Number(t.heading) : undefined,
+        timestamp: Date.now(),
+        vehicle_type: "rail" as const,
+        stop_id: t.nextstop ? String(t.nextstop) : undefined,
+      } as TransitVehicle
+    }).filter((v): v is TransitVehicle => v !== null)
+  } catch { return [] }
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/trimet/route.ts
+++ b/app/api/transit/trimet/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { TransitVehicle } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * TriMet (Portland) live vehicle positions.
+ *
+ * GET /api/transit/trimet?bbox=w,s,e,n
+ *
+ * TriMet exposes a JSON endpoint directly — no protobuf needed.
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(req: NextRequest) {
+  const key = process.env.TRIMET_API_KEY?.trim()
+  if (!key) return NextResponse.json({ ok: false, error: "TRIMET_API_KEY not configured" }, { status: 501 })
+
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+  try {
+    const url = `https://developer.trimet.org/ws/v2/vehicles?appID=${encodeURIComponent(key)}`
+    const r = await fetch(url, { signal: AbortSignal.timeout(10_000), cache: "no-store" })
+    if (!r.ok) return NextResponse.json({ ok: false, error: `upstream ${r.status}` }, { status: 502 })
+    const j = await r.json()
+    const items: any[] = j?.resultSet?.vehicle || []
+    const vehicles: TransitVehicle[] = items
+      .filter((v) => Number.isFinite(Number(v.latitude)) && Number.isFinite(Number(v.longitude)))
+      .map((v) => ({
+        id: `trimet:${v.vehicleID}`,
+        agency: "o-c20-trimet",
+        agency_name: "TriMet",
+        route_id: v.signMessage ? String(v.routeNumber || "") : String(v.routeNumber || ""),
+        route_short_name: v.signMessage,
+        vehicle_id: String(v.vehicleID),
+        lat: Number(v.latitude),
+        lng: Number(v.longitude),
+        bearing: Number.isFinite(Number(v.bearing)) ? Number(v.bearing) : undefined,
+        speed_mps: Number.isFinite(Number(v.speed)) ? Number(v.speed) * 0.44704 : undefined, // mph→m/s
+        timestamp: v.time ? Number(v.time) : Date.now(),
+        vehicle_type: v.type === "rail" ? "rail" : "bus",
+      }))
+    const filtered = bbox
+      ? vehicles.filter((v) => v.lng >= bbox[0] && v.lng <= bbox[2] && v.lat >= bbox[1] && v.lat <= bbox[3])
+      : vehicles
+    return NextResponse.json({
+      ok: true, agency: "TriMet", agency_onestop: "o-c20-trimet",
+      vehicles_total: vehicles.length, vehicles_in_bbox: filtered.length,
+      vehicles: filtered, generated_at: new Date().toISOString(),
+    }, { headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30" } })
+  } catch (err: any) {
+    return NextResponse.json({ ok: false, error: err?.message || "fetch failed" }, { status: 502 })
+  }
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/transit/wmata/route.ts
+++ b/app/api/transit/wmata/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchMultipleFeeds, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
+
+/**
+ * WMATA (DC Metro + Metrobus) live vehicle positions — Apr 23, 2026.
+ *
+ * GET /api/transit/wmata?bbox=w,s,e,n&modes=rail,bus
+ *
+ * Requires WMATA_API_KEY in env (primary) + optional WMATA_API_KEY_SECONDARY
+ * (falls through on 429 or 5xx). Returns 501 when unset.
+ */
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const RAIL_VP = "https://api.wmata.com/gtfs/rail-gtfsrt-vehiclepositions.pb"
+const BUS_VP  = "https://api.wmata.com/gtfs/bus-gtfsrt-vehiclepositions.pb"
+
+export async function GET(req: NextRequest) {
+  const key = process.env.WMATA_API_KEY?.trim()
+  if (!key) return NextResponse.json({ ok: false, error: "WMATA_API_KEY not configured" }, { status: 501 })
+
+  const modes = (req.nextUrl.searchParams.get("modes") || "rail,bus")
+    .split(",").map((s) => s.trim().toLowerCase())
+  const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
+
+  const feeds: Array<{ url: string; vehicleType?: "rail" | "bus" }> = []
+  if (modes.includes("rail")) feeds.push({ url: RAIL_VP, vehicleType: "rail" })
+  if (modes.includes("bus")) feeds.push({ url: BUS_VP, vehicleType: "bus" })
+
+  const result = await fetchMultipleFeeds(feeds, {
+    agency: "o-dqc-wmata",
+    agency_name: "WMATA",
+    headers: { api_key: key },
+  })
+  const vehicles = cullVehiclesToBbox(result.vehicles, bbox)
+
+  return NextResponse.json({
+    ok: result.ok,
+    agency: "WMATA",
+    agency_onestop: "o-dqc-wmata",
+    modes_requested: modes,
+    vehicles_total: result.vehicles.length,
+    vehicles_in_bbox: vehicles.length,
+    vehicles,
+    generated_at: result.generated_at,
+    error: result.error,
+  }, {
+    headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30" },
+  })
+}
+
+function parseBbox(s: string | null): [number, number, number, number] | null {
+  if (!s) return null
+  const parts = s.split(",").map(Number)
+  return parts.length === 4 && parts.every(Number.isFinite) ? [parts[0], parts[1], parts[2], parts[3]] as [number, number, number, number] : null
+}

--- a/app/api/worldview/snapshot/route.ts
+++ b/app/api/worldview/snapshot/route.ts
@@ -32,12 +32,14 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
+import { resolveMasServerBaseUrl } from "@/lib/mas-server-url"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
-const MINDEX_URL = process.env.MINDEX_API_URL || "http://192.168.0.189:8000"
-const MAS_URL = process.env.MAS_URL || "http://192.168.0.188:8001"
+const MINDEX_URL = resolveMindexServerBaseUrl()
+const MAS_URL = resolveMasServerBaseUrl()
 
 // Safe-fetch helper: returns null on error, never throws.
 async function safeJson(url: string, timeoutMs = 8000): Promise<any | null> {

--- a/app/api/worldview/v1/health/route.ts
+++ b/app/api/worldview/v1/health/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
+import { resolveMasServerBaseUrl } from "@/lib/mas-server-url"
 
 /**
  * Worldview v1 — liveness check. Free, no auth.
@@ -10,8 +12,8 @@ export const dynamic = "force-dynamic"
 
 export async function GET() {
   const started = Date.now()
-  const mindexUrl = process.env.MINDEX_API_URL || "http://192.168.0.189:8000"
-  const masUrl = process.env.MAS_URL || "http://192.168.0.188:8001"
+  const mindexUrl = resolveMindexServerBaseUrl()
+  const masUrl = resolveMasServerBaseUrl()
 
   const [mindex, mas] = await Promise.all([
     headReachable(`${mindexUrl}/health`),

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -313,6 +313,7 @@ import ProjectNycDcLayer from "@/components/crep/layers/project-nyc-dc-layer";
 // Mojave National Preserve + Goffs, CA (MYCOSOFT project site) — Apr 21, 2026
 // NPS boundary + wilderness POIs + ASOS/RAWS climate + iNat obs.
 import MojavePreserveLayer from "@/components/crep/layers/mojave-preserve-layer";
+import { LiveTransitLayer } from "@/components/crep/layers/live-transit-layer";
 import MojaveSiteWidget from "@/components/crep/mojave/MojaveSiteWidget";
 const ServicesPanelLive = dynamic(() => import("@/components/crep/panels/services-panel-live"), { ssr: false });
 import ViewportStats from "@/components/crep/stats/viewport-stats";
@@ -2376,6 +2377,13 @@ export default function CREPDashboardPage() {
     { id: "submarineCables", name: "Submarine Cables", category: "telecom", icon: <Cable className="w-3 h-3" />, enabled: true, opacity: 0.8, color: "#06b6d4", description: "Undersea fiber optic cables" },
     { id: "dataCenters", name: "Data Centers", category: "telecom", icon: <Server className="w-3 h-3" />, enabled: true, opacity: 0.9, color: "#7c3aed", description: "Data centers worldwide from OSM" },
     { id: "cellTowers", name: "Cell Towers", category: "telecom", icon: <Radio className="w-3 h-3" />, enabled: true, opacity: 0.7, color: "#8b5cf6", description: "Cellular tower locations" },
+    // ═══════════════════════════════════════════════════════════════════════
+    // LIVE TRANSIT — Apr 23 2026, Morgan: "compete with google maps live
+    // traffic public transportation". Polls /api/transit/all every 15 s,
+    // aggregated feed from MTA/WMATA/BART/MBTA/511-Bay/CTA/TriMet/MARTA/
+    // Amtrak/SEPTA/Metrolink/DART. Colored by vehicle_type.
+    // ═══════════════════════════════════════════════════════════════════════
+    { id: "liveTransit", name: "Live Transit (Trains/Buses)", category: "infrastructure", icon: <Navigation className="w-3 h-3" />, enabled: true, opacity: 0.9, color: "#3b82f6", description: "Live US transit: MTA, WMATA, BART, MBTA, Bay Area 511, CTA, TriMet, MARTA, Amtrak, SEPTA, Metrolink, DART" },
     // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
     // NVIDIA EARTH-2 AI WEATHER LAYERS
     // Advanced AI-powered weather forecasting from NVIDIA Earth-2 platform
@@ -8937,6 +8945,15 @@ export default function CREPDashboardPage() {
               "massive amount of missing data from ... whitehouse and dc
               ... fly to and layers of details perimeters and special
               icon locations for dc and new york". */}
+          {/* Live Transit — Apr 23 2026 (Morgan: "still no trains rendering").
+              Aggregates MTA/WMATA/BART/MBTA/511-Bay/CTA/TriMet/MARTA/Amtrak/
+              SEPTA/Metrolink/DART into a single MapLibre circle layer. */}
+          <LiveTransitLayer
+            map={mapRef}
+            visible={layers.find(l => l.id === "liveTransit")?.enabled ?? true}
+            bbox={mapBounds ? [mapBounds.west, mapBounds.south, mapBounds.east, mapBounds.north] : null}
+          />
+
           <ProjectNycDcLayer
             map={mapRef}
             enabled={{

--- a/app/defense/fusarium/page.tsx
+++ b/app/defense/fusarium/page.tsx
@@ -40,6 +40,13 @@ const fusariumComponents = [
     features: ["Real-time threat map", "Alert prioritization", "Mission planning integration", "Multi-echelon access"]
   },
   {
+    name: "Eagle Eye (CREP layers)",
+    description:
+      "Dual-plane video intelligence inside CREP: registry-backed cameras plus connector-sourced feeds. Enable Eagle Eye in the CREP layer panel. Coverage depends on MINDEX seeding and public connectors—not every map marker guarantees a playable live stream.",
+    icon: Eye,
+    features: ["MINDEX-backed sources when seeded", "Live connector fan-out when cache is cold", "Honest UX: stream availability varies by source"]
+  },
+  {
     name: "Mushroom1-D",
     description: "Defense-variant platform with enhanced comms, encrypted telemetry, and tactical integration. $10,000",
     icon: Radar,
@@ -259,6 +266,9 @@ export default function FusariumPage() {
             <h2 className="text-4xl font-bold mb-4">CREP Dashboard</h2>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
               Common Relevant Environmental Picture - the tactical interface for environmental intelligence.
+            </p>
+            <p className="text-base text-muted-foreground max-w-2xl mx-auto mt-4">
+              Eagle Eye video layers run in the same CREP dashboard: open CREP and use the layer panel to toggle Eagle Eye. Feeds are sourced from the Eagle registry and public connectors where available—availability is data-dependent, not universal live video everywhere.
             </p>
           </div>
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -21,6 +21,20 @@ import {
   Database, Bot, Loader2, Check, History, RefreshCw 
 } from "lucide-react"
 
+const REF_PUBLIC_SITE =
+  (typeof process !== "undefined" && process.env.NEXT_PUBLIC_BASE_URL) ||
+  "http://192.168.0.187:3000"
+const REF_MAS =
+  (typeof process !== "undefined" && process.env.NEXT_PUBLIC_MAS_API_URL) ||
+  "http://192.168.0.188:8001"
+const REF_MINDEX =
+  (typeof process !== "undefined" && process.env.NEXT_PUBLIC_MINDEX_API_URL) ||
+  "http://192.168.0.189:8000"
+const REF_N8N =
+  (typeof process !== "undefined" && process.env.NEXT_PUBLIC_N8N_URL) || "http://192.168.0.188:5678"
+const REF_MYCOBRAIN =
+  (typeof process !== "undefined" && process.env.NEXT_PUBLIC_MYCOBRAIN_URL) || "http://192.168.0.187:8003"
+
 export default function ProfilePage() {
   const { setTheme, resolvedTheme } = useTheme()
   const { user, loading: authLoading, signOut } = useSupabaseUser()
@@ -687,11 +701,11 @@ export default function ProfilePage() {
                 <CardContent>
                   <div className="space-y-3">
                     {[
-                      { name: "Website", status: "online", url: "localhost:3000" },
-                      { name: "MAS API", status: "online", url: "localhost:8000" },
-                      { name: "N8N Workflows", status: "online", url: "localhost:5678" },
-                      { name: "MycoBrain Service", status: "online", url: "localhost:8765" },
-                      { name: "MINDEX Database", status: "online", url: "localhost:5432" },
+                      { name: "Website (sandbox ref)", status: "online", url: REF_PUBLIC_SITE },
+                      { name: "MAS API", status: "online", url: REF_MAS },
+                      { name: "N8N (MAS VM)", status: "online", url: REF_N8N },
+                      { name: "MycoBrain (sandbox)", status: "online", url: REF_MYCOBRAIN },
+                      { name: "MINDEX API", status: "online", url: REF_MINDEX },
                     ].map(service => (
                       <div key={service.name} className="flex items-center justify-between p-2 rounded-lg bg-muted/50">
                         <div className="flex items-center gap-2">

--- a/components/crep/layers/live-transit-layer.tsx
+++ b/components/crep/layers/live-transit-layer.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+/**
+ * Live Transit Layer — Apr 23, 2026
+ *
+ * Morgan: "compete with google maps live traffic public transportation".
+ * Morgan (urgent): "i also do not see any trains rendering moving on any
+ * tracks iun any city".
+ *
+ * Renders live vehicle positions from every transit agency we connect to
+ * (MTA, WMATA, BART, MBTA, 511 SF Bay, CTA, TriMet, MARTA, Amtrak, SEPTA,
+ * Metrolink, DART) as MapLibre native circle layers. Polls
+ * `/api/transit/all?bbox=...` every 15 s with the current viewport.
+ *
+ * Separate layers per vehicle_type so we can color + size each independently:
+ *   subway   — bright blue, small dot
+ *   rail     — cyan, slightly larger
+ *   bus      — green, small dot
+ *   tram     — emerald, small dot
+ *   ferry    — indigo, slightly larger
+ *   other    — gray, small dot
+ *
+ * The hover popup shows: agency, route_short_name, vehicle_id, occupancy,
+ * current_status, last-seen age.
+ */
+
+import { useEffect, useRef } from "react"
+import type maplibregl from "maplibre-gl"
+
+const SOURCE_ID = "crep-live-transit"
+const TYPE_COLORS: Record<string, string> = {
+  subway: "#3b82f6",   // blue-500
+  rail: "#06b6d4",     // cyan-500
+  bus: "#10b981",      // emerald-500
+  tram: "#14b8a6",     // teal-500
+  ferry: "#6366f1",    // indigo-500
+  other: "#9ca3af",    // gray-400
+}
+
+interface Props {
+  map: maplibregl.Map | null
+  visible: boolean
+  bbox?: [number, number, number, number] | null
+  /** ms between polls. Default 15_000 */
+  pollMs?: number
+  onSelect?: (props: any) => void
+}
+
+export function LiveTransitLayer({ map, visible, bbox, pollMs = 15_000, onSelect }: Props) {
+  const selectRef = useRef(onSelect)
+  useEffect(() => { selectRef.current = onSelect }, [onSelect])
+
+  // ── source + layers once map is ready ──────────────────────────────
+  useEffect(() => {
+    if (!map) return
+    const emptyFC: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] }
+
+    const addLayers = () => {
+      if (map.getSource(SOURCE_ID)) return
+      map.addSource(SOURCE_ID, { type: "geojson", data: emptyFC })
+
+      // ── Halo glow (below dots) ────────────────────────────────────
+      map.addLayer({
+        id: `${SOURCE_ID}-glow`, type: "circle", source: SOURCE_ID,
+        paint: {
+          "circle-radius": [
+            "interpolate", ["linear"], ["zoom"],
+            4, 2, 8, 4, 12, 8, 16, 14,
+          ],
+          "circle-color": [
+            "match", ["coalesce", ["get", "vehicle_type"], "other"],
+            "subway", TYPE_COLORS.subway,
+            "rail", TYPE_COLORS.rail,
+            "bus", TYPE_COLORS.bus,
+            "tram", TYPE_COLORS.tram,
+            "ferry", TYPE_COLORS.ferry,
+            TYPE_COLORS.other,
+          ],
+          "circle-opacity": 0.25,
+          "circle-blur": 0.9,
+        },
+      })
+
+      // ── Solid dot ─────────────────────────────────────────────────
+      map.addLayer({
+        id: `${SOURCE_ID}-dot`, type: "circle", source: SOURCE_ID,
+        paint: {
+          "circle-radius": [
+            "interpolate", ["linear"], ["zoom"],
+            4, 1.5, 8, 2.5, 12, 4, 16, 7,
+          ],
+          "circle-color": [
+            "match", ["coalesce", ["get", "vehicle_type"], "other"],
+            "subway", TYPE_COLORS.subway,
+            "rail", TYPE_COLORS.rail,
+            "bus", TYPE_COLORS.bus,
+            "tram", TYPE_COLORS.tram,
+            "ferry", TYPE_COLORS.ferry,
+            TYPE_COLORS.other,
+          ],
+          "circle-stroke-color": "#ffffff",
+          "circle-stroke-width": 1,
+          "circle-opacity": 1,
+        },
+      })
+
+      // Click → bubble up to parent so it can open the vehicle widget
+      map.on("click", `${SOURCE_ID}-dot`, (e: any) => {
+        const f = e.features?.[0]
+        if (f && selectRef.current) selectRef.current(f.properties)
+      })
+      map.on("mouseenter", `${SOURCE_ID}-dot`, () => { map.getCanvas().style.cursor = "pointer" })
+      map.on("mouseleave", `${SOURCE_ID}-dot`, () => { map.getCanvas().style.cursor = "" })
+    }
+
+    if ((map as any).isStyleLoaded?.()) addLayers()
+    else map.once("load", addLayers)
+
+    return () => {
+      try {
+        if (map.getLayer(`${SOURCE_ID}-dot`)) map.removeLayer(`${SOURCE_ID}-dot`)
+        if (map.getLayer(`${SOURCE_ID}-glow`)) map.removeLayer(`${SOURCE_ID}-glow`)
+        if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID)
+      } catch { /* torn down */ }
+    }
+  }, [map])
+
+  // ── visibility toggle ─────────────────────────────────────────────
+  useEffect(() => {
+    if (!map) return
+    const apply = () => {
+      const v = visible ? "visible" : "none"
+      for (const id of [`${SOURCE_ID}-dot`, `${SOURCE_ID}-glow`]) {
+        try { if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", v) } catch {}
+      }
+    }
+    if ((map as any).isStyleLoaded?.()) apply()
+    else map.once("load", apply)
+  }, [map, visible])
+
+  // ── poll /api/transit/all ─────────────────────────────────────────
+  useEffect(() => {
+    if (!map || !visible) return
+    let cancelled = false
+    let intervalId: any = null
+
+    const bboxStr = bbox ? bbox.join(",") : ""
+
+    const poll = async () => {
+      if (cancelled) return
+      try {
+        const url = `/api/transit/all${bboxStr ? `?bbox=${encodeURIComponent(bboxStr)}` : ""}`
+        const r = await fetch(url, { signal: AbortSignal.timeout(15_000), cache: "no-store" })
+        if (!r.ok || cancelled) return
+        const j = await r.json()
+        if (cancelled) return
+        const src = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined
+        if (!src) return
+        src.setData({
+          type: "FeatureCollection",
+          features: Array.isArray(j?.features) ? j.features : [],
+        })
+        if (typeof window !== "undefined") {
+          ;(window as any).__crep_last_transit_count = j?.vehicles_total ?? j?.features?.length ?? 0
+        }
+      } catch {
+        // Silent — transient failure, try next tick.
+      }
+    }
+
+    poll()
+    intervalId = setInterval(() => {
+      if (typeof document !== "undefined" && document.hidden) return
+      poll()
+    }, pollMs)
+
+    return () => { cancelled = true; if (intervalId) clearInterval(intervalId) }
+  }, [map, visible, bbox, pollMs])
+
+  return null
+}

--- a/docker-compose.production.blue-green.yml
+++ b/docker-compose.production.blue-green.yml
@@ -74,7 +74,7 @@ services:
       - OLLAMA_BASE_URL=http://ollama:11434
       - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.3}
       - MAS_API_URL=${MAS_API_URL:-http://localhost:8001}
-      - MINDEX_API_URL=${MINDEX_API_URL:-http://localhost:8000}
+      - MINDEX_API_URL=${MINDEX_API_URL:-http://192.168.0.189:8000}
       - N8N_URL=${N8N_URL:-http://n8n:5678}
       - NEMOCLAW_GATEWAY_URL=${NEMOCLAW_GATEWAY_URL:-http://192.168.0.123:18789}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
@@ -133,7 +133,7 @@ services:
       - OLLAMA_BASE_URL=http://ollama:11434
       - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.3}
       - MAS_API_URL=${MAS_API_URL:-http://localhost:8001}
-      - MINDEX_API_URL=${MINDEX_API_URL:-http://localhost:8000}
+      - MINDEX_API_URL=${MINDEX_API_URL:-http://192.168.0.189:8000}
       - N8N_URL=${N8N_URL:-http://n8n:5678}
       - NEMOCLAW_GATEWAY_URL=${NEMOCLAW_GATEWAY_URL:-http://192.168.0.123:18789}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -82,7 +82,7 @@ services:
       - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.3}
       # MAS Orchestrator (cross-VM, may be unreachable through tunnel)
       - MAS_API_URL=${MAS_API_URL:-${MAS_API_URL:-http://localhost:8001}}
-      - MINDEX_API_URL=${MINDEX_API_URL:-${MINDEX_API_URL:-http://localhost:8000}}
+      - MINDEX_API_URL=${MINDEX_API_URL:-http://192.168.0.189:8000}
       - N8N_URL=${N8N_URL:-http://n8n:5678}
       # NemoClaw Gateway (Jetson with NVIDIA Nemotron for on-site AI)
       - NEMOCLAW_GATEWAY_URL=${NEMOCLAW_GATEWAY_URL:-http://192.168.0.123:18789}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - NODE_ENV=production
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=redis://redis:6379
-      - MINDEX_API_URL=${MINDEX_API_URL:-${MINDEX_API_URL:-http://localhost:8000}}
+      - MINDEX_API_URL=${MINDEX_API_URL:-http://192.168.0.189:8000}
       # Ollama runs in-stack — always reachable as LLM fallback
       - OLLAMA_BASE_URL=http://ollama:11434
       - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.3}
@@ -40,7 +40,7 @@ services:
       - XAI_API_KEY=${XAI_API_KEY:-}
       - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY:-}
       # MAS Orchestrator
-      - MAS_API_URL=${MAS_API_URL:-${MAS_API_URL:-http://localhost:8001}}
+      - MAS_API_URL=${MAS_API_URL:-http://192.168.0.188:8001}
       - N8N_URL=${N8N_URL:-http://n8n:5678}
       # Supabase — server-side key for protected operations (anon key is baked into the build)
       - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY:-}

--- a/env.local.example
+++ b/env.local.example
@@ -22,6 +22,10 @@ MINDEX_API_KEY=local-dev-key
 # MINDEX_DATABASE_URL=postgresql://user:pass@localhost:5432/mindex  # Optional direct DB access
 
 # =============================================================================
+# AirNow (optional — CREP / live AQI; request key at https://docs.airnowapi.org/)
+# Production: set AIRNOW_API_KEY in GitHub Environments → production (never commit real keys)
+# AIRNOW_API_KEY=
+
 # MYCORRHIZAE PROTOCOL (Required for MINDEX streaming/publish)
 # =============================================================================
 # For dev/sandbox: get keys from internal keys API (see docs/DEV_SANDBOX_KEYS_FLOW_FEB06_2026.md)

--- a/hooks/useAgentMemory.ts
+++ b/hooks/useAgentMemory.ts
@@ -7,7 +7,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import useSWR from 'swr';
 
-const MAS_API_BASE = process.env.NEXT_PUBLIC_MAS_API_URL || 'http://localhost:8000';
+const MAS_API_BASE = process.env.NEXT_PUBLIC_MAS_API_URL || "http://localhost:8001";
 
 // ============================================
 // TYPES

--- a/lib/crep/inat-etl.ts
+++ b/lib/crep/inat-etl.ts
@@ -28,8 +28,10 @@
  *   - scripts/inat-backfill.ts (long-running bulk backfill)
  */
 
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
+
 const INAT_API = "https://api.inaturalist.org/v1"
-const MINDEX_API = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 const PAGE_SIZE = 200 // iNat max

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -5,6 +5,8 @@
  * Supports MINDEX, NatureOS, MYCA MAS, Ledger, and M-Wave integrations
  */
 
+import { resolveMindexServerBaseUrl } from "./mindex-base-url"
+
 export const env = {
   // NatureOS API Configuration (legacy - for backward compatibility)
   natureosApiUrl: process.env.NEXT_PUBLIC_API_URL || "https://api.mycosoft.org/v1",
@@ -12,7 +14,7 @@ export const env = {
   // MINDEX API Configuration (canonical data layer)
   // Use MINDEX_API_URL from .env.local, fallback to MINDEX_API_BASE_URL or VM default
   // MINDEX runs on MINDEX_HOST:8000 (dedicated database VM)
-  mindexApiBaseUrl: process.env.MINDEX_API_URL || process.env.MINDEX_API_BASE_URL || process.env.NEXT_PUBLIC_MINDEX_URL || "http://localhost:8000",
+  mindexApiBaseUrl: resolveMindexServerBaseUrl(),
   mindexApiKey: process.env.MINDEX_API_KEY || "", // Server-only — must be set via env
   // Internal token for MINDEX admin/internal endpoints (/api/mindex/internal/...)
   // Shared secret between website and MINDEX backend — bypasses public API rate limits

--- a/lib/mas-server-url.ts
+++ b/lib/mas-server-url.ts
@@ -1,6 +1,10 @@
 /**
  * Canonical MAS orchestrator base URL for server-side Next.js (API routes, RSC).
- * Default: MAS VM 192.168.0.188:8001. Loopback in production is rewritten (Docker-safe).
+ * Default: MAS VM 192.168.0.188:8001. Loopback on the server is rewritten so a
+ * misset / missing env var can't knock live CREP off the LAN MAS.
+ *
+ * Escape hatch for local dev: `ALLOW_LOOPBACK_MAS=1` keeps http://localhost:8001
+ * when the operator really is running MAS on their laptop.
  */
 const MAS_VM_LAN = "http://192.168.0.188:8001"
 
@@ -23,8 +27,10 @@ export function resolveMasServerBaseUrl(): string {
   if (!fromEnv || fromEnv.startsWith("/")) {
     return MAS_VM_LAN
   }
-  let base = fromEnv.replace(/\/$/, "")
-  if (process.env.NODE_ENV === "production" && isLoopbackMasUrl(base)) {
+  const base = fromEnv.replace(/\/$/, "")
+  const isServer = typeof window === "undefined"
+  const allowLoopback = process.env.ALLOW_LOOPBACK_MAS === "1"
+  if (isServer && !allowLoopback && isLoopbackMasUrl(base)) {
     return MAS_VM_LAN
   }
   return base

--- a/lib/mindex-base-url.ts
+++ b/lib/mindex-base-url.ts
@@ -1,10 +1,26 @@
 /**
  * Canonical MINDEX base URL for server-side Next.js (API routes, RSC, Route Handlers).
  *
- * The MINDEX API runs on the MINDEX VM at 192.168.0.189:8000. Website Docker containers
- * on the production host must not use http://localhost:8000 (nothing binds there inside the
- * app container) — a mis-set MINDEX_API_URL secret caused live CREP/Worldview to see
- * mindex as down while MAS on the LAN was fine.
+ * The MINDEX API runs on the MINDEX VM at 192.168.0.189:8000. Website Docker
+ * containers on the production host must not use http://localhost:8000 —
+ * nothing binds there inside the app container. A mis-set MINDEX_API_URL
+ * secret, or a container where NODE_ENV was never propagated to production,
+ * caused live CREP/Worldview to see MINDEX as down while MAS on the LAN was
+ * fine.
+ *
+ * Apr 23, 2026 — Morgan: "no satelites planes inaturalist nature events
+ * vessles nothing is showing up on the fucking map". Root cause verified on
+ * prod: `worldview/snapshot` returned `mindex.url:"http://localhost:8000"`
+ * even though the website container was otherwise healthy. The earlier
+ * NODE_ENV === "production" gate let the loopback slip through whenever the
+ * container shell didn't set NODE_ENV (Next.js standalone doesn't always
+ * propagate it when Docker starts `node server.js` directly). This file
+ * now remaps loopback on any server-side call — the only legitimate
+ * loopback MINDEX is a dev laptop running `mindex-api` locally, and that
+ * path still works because `typeof window === "undefined"` is the only
+ * "server" signal we check (dev servers run outside the browser too, but
+ * they opt in by setting `MINDEX_API_URL=http://localhost:8000` and
+ * `ALLOW_LOOPBACK_MINDEX=1`).
  */
 const MINDEX_VM_LAN = "http://192.168.0.189:8000"
 
@@ -18,10 +34,19 @@ function isLoopbackMindexUrl(url: string): boolean {
 }
 
 /**
- * Resolves the MINDEX API base URL. In production, `http://localhost:8000` (or 127.0.0.1)
- * is treated as a misconfiguration and replaced with the LAN MINDEX VM URL so the site
- * reaches the real service without requiring an emergency secret edit.
- * In development, loopback is allowed for a locally run MINDEX.
+ * Resolves the MINDEX API base URL.
+ *
+ * Precedence:
+ *   1. MINDEX_API_URL / MINDEX_API_BASE_URL / NEXT_PUBLIC_MINDEX_* env var
+ *   2. If the env value is loopback AND we're on the server AND the dev
+ *      escape hatch `ALLOW_LOOPBACK_MINDEX=1` is NOT set → remap to LAN VM
+ *   3. Empty or a /api-prefixed client path → LAN VM
+ *
+ * The loopback remap used to be gated on `NODE_ENV === "production"`, but
+ * production containers don't always set NODE_ENV, so loopback values were
+ * leaking through and breaking live data. The gate is now `window !== undefined`
+ * (i.e. we're NOT in the browser): client bundles may legitimately point at
+ * `/api/mindex` for proxying, server code must point at the LAN VM.
  */
 export function resolveMindexServerBaseUrl(): string {
   const fromEnv =
@@ -37,9 +62,14 @@ export function resolveMindexServerBaseUrl(): string {
     return MINDEX_VM_LAN
   }
 
-  let base = fromEnv.replace(/\/$/, "")
+  const base = fromEnv.replace(/\/$/, "")
 
-  if (process.env.NODE_ENV === "production" && isLoopbackMindexUrl(base)) {
+  // Server-side loopback is almost always a misconfiguration on the deploy VM.
+  // Escape hatch for local dev: set `ALLOW_LOOPBACK_MINDEX=1` to allow
+  // `http://localhost:8000` to pass through (dev box running mindex locally).
+  const isServer = typeof window === "undefined"
+  const allowLoopback = process.env.ALLOW_LOOPBACK_MINDEX === "1"
+  if (isServer && !allowLoopback && isLoopbackMindexUrl(base)) {
     return MINDEX_VM_LAN
   }
   return base

--- a/lib/mindex-internal.ts
+++ b/lib/mindex-internal.ts
@@ -12,7 +12,9 @@
  * March 19, 2026 — Segregated public/internal API migration
  */
 
-const MINDEX_BASE = process.env.MINDEX_API_URL || "http://localhost:8000"
+import { resolveMindexServerBaseUrl } from "./mindex-base-url"
+
+const MINDEX_BASE = resolveMindexServerBaseUrl()
 const MINDEX_INTERNAL_TOKEN = process.env.MINDEX_INTERNAL_TOKEN || process.env.INTERNAL_API_SECRET
 
 /**

--- a/lib/oei/mindex-logger.ts
+++ b/lib/oei/mindex-logger.ts
@@ -14,7 +14,9 @@
  * - Source attribution
  */
 
-const MINDEX_API = process.env.MINDEX_API_URL || 'http://localhost:8000';
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
+
+const MINDEX_API = resolveMindexServerBaseUrl()
 const BATCH_SIZE = 100;
 const FLUSH_INTERVAL = 10_000; // 10 seconds
 

--- a/lib/search/earth-search-connectors.ts
+++ b/lib/search/earth-search-connectors.ts
@@ -30,6 +30,7 @@ import type {
   SpaceWeatherResult,
   CameraResult,
 } from "./unified-search-sdk"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 /** Collapse duplicate EONET rows (different id strings) or same lat/lng/title/time from multiple sources. */
 function deduplicateEarthEvents(events: EventResult[]): EventResult[] {
@@ -555,50 +556,82 @@ export async function searchSpaceWeather(query: string, origin: string, _limit =
 }
 
 // ---------------------------------------------------------------------------
-// 10. CCTV & Webcams (Static Mocks / Aggregator Fallbacks)
+// 10. CCTV & Webcams — MINDEX Eagle Eye (eagle.video_sources via unified-search)
 // ---------------------------------------------------------------------------
 
 const CAMERA_KEYWORDS = [
   "camera", "cctv", "webcam", "livestream", "live stream", "traffic cam"
 ]
 
+const MINDEX_BASE = resolveMindexServerBaseUrl()
+
+const MINDEX_INTERNAL_TOKEN =
+  process.env.MINDEX_INTERNAL_TOKEN ||
+  (process.env.MINDEX_INTERNAL_TOKENS || "").split(",")[0].trim() ||
+  ""
+
+const MINDEX_API_KEY = process.env.MINDEX_API_KEY || ""
+
+function mindexAuthHeaders(): Record<string, string> {
+  if (MINDEX_INTERNAL_TOKEN) return { "X-Internal-Token": MINDEX_INTERNAL_TOKEN }
+  if (MINDEX_API_KEY) return { "X-API-Key": MINDEX_API_KEY }
+  return {}
+}
+
 export function isCamerasQuery(query: string): boolean {
   const q = query.toLowerCase()
   return CAMERA_KEYWORDS.some(kw => q.includes(kw))
 }
 
+function mapEagleUnifiedRowToCamera(row: Record<string, unknown>): CameraResult | null {
+  const lat = Number(row.lat)
+  const lng = Number(row.lng)
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  const props = (row.properties as Record<string, unknown> | undefined) || {}
+  const streamUrl =
+    (props.stream_url as string | undefined) ||
+    (props.embed_url as string | undefined) ||
+    (props.media_url as string | undefined)
+  const name = String(row.name || row.id || "Video source")
+  return {
+    id: String(row.id),
+    title: name,
+    location: `${lat.toFixed(2)}, ${lng.toFixed(2)}`,
+    lat,
+    lng,
+    type: "webcam",
+    status: "live",
+    source: String(row.source || "eagle.video_sources"),
+    streamUrl: streamUrl || undefined,
+  }
+}
+
+/** Fluid Search / earth intelligence: real Eagle rows from MINDEX unified-search (types=eagle_video). */
 export async function searchCameras(query: string, limit = 10): Promise<CameraResult[]> {
   try {
-    // Return curated high-quality live streams for demo/fallback purposes
-    const MOCK_CAMERAS: CameraResult[] = [
-      {
-        id: "cam-iss", title: "ISS Live Stream", location: "Low Earth Orbit", lat: 0, lng: 0, type: "satellite", status: "live", source: "NASA",
-        streamUrl: "https://www.youtube.com/embed/86YLFOog4GM?autoplay=1&mute=1"
-      },
-      {
-        id: "cam-ts", title: "Times Square Live", location: "New York, USA", lat: 40.7580, lng: -73.9855, type: "cctv", status: "live", source: "EarthCam",
-        streamUrl: "https://www.youtube.com/embed/1-iS7LArMPA?autoplay=1&mute=1"
-      },
-      {
-        id: "cam-tyo", title: "Tokyo Shibuya Crossing", location: "Tokyo, Japan", lat: 35.6595, lng: 139.7001, type: "traffic", status: "live", source: "Shibuya Cam",
-        streamUrl: "https://www.youtube.com/embed/HpdO5Kq3o7Y?autoplay=1&mute=1"
-      },
-      {
-        id: "cam-reyk", title: "Reykjavik Volcano", location: "Reykjavik, Iceland", lat: 63.8933, lng: -22.2729, type: "webcam", status: "live", source: "LiveFromIceland",
-        streamUrl: "https://www.youtube.com/embed/80CGkH0gXVE?autoplay=1&mute=1"
-      }
-    ]
-    
-    // Filter down based on query, or return all if broad
-    const q = query.toLowerCase()
-    let results = MOCK_CAMERAS
-    
-    if (q.includes("new york") || q.includes("ny")) results = MOCK_CAMERAS.filter(c => c.id === "cam-ts")
-    else if (q.includes("tokyo") || q.includes("japan")) results = MOCK_CAMERAS.filter(c => c.id === "cam-tyo")
-    else if (q.includes("space") || q.includes("iss") || q.includes("orbit")) results = MOCK_CAMERAS.filter(c => c.id === "cam-iss")
-    else if (q.includes("volcano") || q.includes("iceland")) results = MOCK_CAMERAS.filter(c => c.id === "cam-reyk")
-
-    return results.slice(0, limit)
+    if (!MINDEX_INTERNAL_TOKEN && !MINDEX_API_KEY) return []
+    const qRaw = query.trim()
+    const q = qRaw.length >= 2 ? qRaw : "camera"
+    const cap = Math.min(Math.max(limit, 1), 100)
+    const qp = new URLSearchParams({
+      q,
+      types: "eagle_video",
+      limit: String(cap),
+    })
+    const res = await fetch(`${MINDEX_BASE}/api/mindex/unified-search?${qp}`, {
+      signal: AbortSignal.timeout(15_000),
+      headers: { Accept: "application/json", ...mindexAuthHeaders() },
+    })
+    if (!res.ok) return []
+    const j = (await res.json()) as { results?: Record<string, unknown[]> }
+    const rows = j?.results?.eagle_video || []
+    const out: CameraResult[] = []
+    for (const row of rows) {
+      const c = mapEagleUnifiedRowToCamera(row as Record<string, unknown>)
+      if (c) out.push(c)
+      if (out.length >= cap) break
+    }
+    return out
   } catch {
     return []
   }
@@ -641,10 +674,10 @@ export function detectEarthDomains(query: string): EarthSearchDomains {
  * Falls through to external APIs if MINDEX returns nothing.
  */
 async function searchMindexEarth(query: string, limit: number): Promise<Record<string, unknown[]> | null> {
-  const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+  const mindexBase = resolveMindexServerBaseUrl()
   try {
     const res = await safeFetch(
-      `${MINDEX_API_URL}/api/search/earth?q=${encodeURIComponent(query)}&limit=${limit}`,
+      `${mindexBase}/api/search/earth?q=${encodeURIComponent(query)}&limit=${limit}`,
       6000
     )
     if (!res) return null
@@ -729,8 +762,7 @@ export async function searchEarthIntelligence(
       promises.cameras,
     ])
 
-  const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
-  
+  const mindexIngestBase = resolveMindexServerBaseUrl()
   // Background ingestion: "scrape that live data and put it in MINDEX"
   if (!mindexEarth && Object.keys(domains).some(d => domains[d as keyof EarthSearchDomains])) {
     const payload: Record<string, any> = {
@@ -739,7 +771,7 @@ export async function searchEarthIntelligence(
     // Only send non-empty arrays
     const validPayload = Object.fromEntries(Object.entries(payload).filter(([_, v]) => v && v.length > 0))
     if (Object.keys(validPayload).length > 0) {
-      fetch(`${MINDEX_API_URL}/api/search/earth/ingest`, {
+      fetch(`${mindexIngestBase}/api/search/earth/ingest`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(validPayload),

--- a/lib/services/mindex-api.ts
+++ b/lib/services/mindex-api.ts
@@ -3,7 +3,9 @@
  * Interface to the MYCA biological data warehouse
  */
 
-const MINDEX_URL = process.env.NEXT_PUBLIC_MINDEX_URL || process.env.MINDEX_API_URL || 'http://localhost:8000'
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
+
+const MINDEX_URL = resolveMindexServerBaseUrl()
 
 export interface QueryResult {
   rows: Record<string, unknown>[]

--- a/lib/services/mindex-service.ts
+++ b/lib/services/mindex-service.ts
@@ -7,9 +7,10 @@
  */
 
 import { cache } from "react"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 
 // MINDEX API Configuration
-const MINDEX_API_URL = process.env.MINDEX_API_URL || "http://localhost:8000"
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 // Types matching MINDEX API responses

--- a/lib/services/nlq-connectors/mindex-connector.ts
+++ b/lib/services/nlq-connectors/mindex-connector.ts
@@ -6,7 +6,9 @@
 import type { Intent } from "../myca-nlq"
 import type { BaseConnector, ConnectorOptions, ConnectorResult } from "./base-connector"
 
-const MINDEX_API_URL = process.env.MINDEX_API_URL || process.env.NEXT_PUBLIC_MINDEX_URL || "http://localhost:8000"
+import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
+
+const MINDEX_API_URL = resolveMindexServerBaseUrl()
 
 export class MindexConnector implements BaseConnector {
   readonly name = "MINDEX Database"

--- a/lib/transit/gtfs-realtime.ts
+++ b/lib/transit/gtfs-realtime.ts
@@ -1,0 +1,164 @@
+/**
+ * GTFS-Realtime decoder + shared transit utilities — Apr 23, 2026
+ *
+ * Morgan: "every single ... public transportation public transit for
+ * the map". Shared decoder the per-agency connectors import.
+ *
+ * Uses the canonical `gtfs-realtime-bindings` npm package to decode
+ * the protobuf feeds. Normalizes vehicle positions into a single shape
+ * that Worldview consumers + CREP map layer can render without knowing
+ * which agency the feed came from.
+ */
+
+// gtfs-realtime-bindings ships its own .d.ts in recent versions; keep the
+// raw default import without @ts-expect-error to survive type-check.
+import GtfsRealtimeBindings from "gtfs-realtime-bindings"
+
+export interface TransitVehicle {
+  /** Globally-unique id: "<agency>:<vehicle_id_or_trip_id>" */
+  id: string
+  /** Agency onestop id (o-dr5r-mta, o-dqc-wmata, o-c20-trimet, etc.) */
+  agency: string
+  agency_name?: string
+  route_id?: string
+  route_short_name?: string
+  trip_id?: string
+  vehicle_id?: string
+  lat: number
+  lng: number
+  bearing?: number          // degrees 0-360
+  speed_mps?: number        // meters/sec
+  timestamp: number         // epoch ms
+  occupancy?: string        // EMPTY / MANY_SEATS_AVAILABLE / FEW_SEATS_AVAILABLE / STANDING / FULL
+  stop_id?: string
+  current_status?: string   // INCOMING_AT / STOPPED_AT / IN_TRANSIT_TO
+  vehicle_type?: "bus" | "rail" | "subway" | "ferry" | "tram" | "other"
+}
+
+export interface TransitFeedResult {
+  ok: boolean
+  agency: string
+  vehicles: TransitVehicle[]
+  generated_at: string
+  upstream_count: number
+  error?: string
+}
+
+/**
+ * Fetch + decode a GTFS-realtime VehiclePositions feed. Returns the
+ * normalized vehicles array.
+ */
+export async function fetchVehiclePositions(
+  url: string,
+  opts: {
+    agency: string
+    agency_name?: string
+    headers?: Record<string, string>
+    vehicleType?: TransitVehicle["vehicle_type"]
+    timeoutMs?: number
+  },
+): Promise<TransitFeedResult> {
+  const timeoutMs = opts.timeoutMs ?? 10_000
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "Mycosoft-CREP-Transit/1.0", ...(opts.headers || {}) },
+      signal: AbortSignal.timeout(timeoutMs),
+      cache: "no-store",
+    })
+    if (!res.ok) {
+      return { ok: false, agency: opts.agency, vehicles: [], generated_at: new Date().toISOString(), upstream_count: 0, error: `upstream ${res.status}` }
+    }
+    const buf = Buffer.from(await res.arrayBuffer())
+    const FeedMessage = (GtfsRealtimeBindings as any).transit_realtime.FeedMessage
+    const msg = FeedMessage.decode(buf)
+    const entities = msg.entity || []
+    const vehicles: TransitVehicle[] = []
+    for (const ent of entities) {
+      const v = ent.vehicle
+      if (!v?.position) continue
+      const pos = v.position
+      const lat = Number(pos.latitude)
+      const lng = Number(pos.longitude)
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue
+      const id = `${opts.agency}:${v.vehicle?.id || v.trip?.tripId || ent.id}`
+      const trip = v.trip
+      const occupancyEnum = v.occupancyStatus
+      const statusEnum = v.currentStatus
+      vehicles.push({
+        id,
+        agency: opts.agency,
+        agency_name: opts.agency_name,
+        route_id: trip?.routeId,
+        trip_id: trip?.tripId,
+        vehicle_id: v.vehicle?.id,
+        lat,
+        lng,
+        bearing: typeof pos.bearing === "number" ? pos.bearing : undefined,
+        speed_mps: typeof pos.speed === "number" ? pos.speed : undefined,
+        timestamp: v.timestamp ? Number(v.timestamp) * 1000 : Date.now(),
+        occupancy: occupancyEnum != null ? OCCUPANCY_ENUM[occupancyEnum] : undefined,
+        stop_id: v.stopId,
+        current_status: statusEnum != null ? STATUS_ENUM[statusEnum] : undefined,
+        vehicle_type: opts.vehicleType,
+      })
+    }
+    return {
+      ok: true,
+      agency: opts.agency,
+      vehicles,
+      generated_at: new Date().toISOString(),
+      upstream_count: entities.length,
+    }
+  } catch (err: any) {
+    return { ok: false, agency: opts.agency, vehicles: [], generated_at: new Date().toISOString(), upstream_count: 0, error: err?.message || "fetch failed" }
+  }
+}
+
+// GTFS-realtime enum mappings
+const OCCUPANCY_ENUM: Record<number, string> = {
+  0: "EMPTY", 1: "MANY_SEATS_AVAILABLE", 2: "FEW_SEATS_AVAILABLE",
+  3: "STANDING_ROOM_ONLY", 4: "CRUSHED_STANDING_ROOM_ONLY",
+  5: "FULL", 6: "NOT_ACCEPTING_PASSENGERS",
+}
+const STATUS_ENUM: Record<number, string> = {
+  0: "INCOMING_AT", 1: "STOPPED_AT", 2: "IN_TRANSIT_TO",
+}
+
+/**
+ * Concurrency-limited fetch of multiple GTFS-rt feeds.
+ * Useful for agencies with one key but many feeds (MTA NYC has 8 subway lines).
+ */
+export async function fetchMultipleFeeds(
+  feeds: Array<{ url: string; vehicleType?: TransitVehicle["vehicle_type"] }>,
+  shared: Omit<Parameters<typeof fetchVehiclePositions>[1], "vehicleType">,
+): Promise<TransitFeedResult> {
+  const results = await Promise.all(
+    feeds.map((f) => fetchVehiclePositions(f.url, { ...shared, vehicleType: f.vehicleType })),
+  )
+  const allVehicles: TransitVehicle[] = []
+  const errors: string[] = []
+  let upstream = 0
+  for (const r of results) {
+    allVehicles.push(...r.vehicles)
+    upstream += r.upstream_count
+    if (!r.ok && r.error) errors.push(r.error)
+  }
+  return {
+    ok: errors.length < feeds.length, // ok if ANY feed succeeded
+    agency: shared.agency,
+    vehicles: allVehicles,
+    generated_at: new Date().toISOString(),
+    upstream_count: upstream,
+    error: errors.length ? errors.join("; ") : undefined,
+  }
+}
+
+/** Viewport cull for transit vehicles — drops anything outside bbox. */
+export function cullVehiclesToBbox(
+  vehicles: TransitVehicle[],
+  bbox: [number, number, number, number] | null,
+): TransitVehicle[] {
+  if (!bbox) return vehicles
+  const [w, s, e, n] = bbox
+  return vehicles.filter((v) => v.lng >= w && v.lng <= e && v.lat >= s && v.lat <= n)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
         "geist": "^1.3.1",
         "gosling.js": "^1.0.7",
         "graphql": "^16.13.0",
+        "gtfs-realtime-bindings": "^1.1.1",
         "higlass": "^2.1.9",
         "hls.js": "^1.6.16",
         "imagesloaded": "^5.0.0",
@@ -10002,6 +10003,18 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
     "node_modules/@langchain/community": {
       "version": "0.3.59",
       "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.59.tgz",
@@ -19335,6 +19348,12 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
@@ -19369,6 +19388,16 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -19377,6 +19406,12 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -23574,7 +23609,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -23609,7 +23643,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -24466,6 +24499,12 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
     "node_modules/bn.js": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
@@ -24894,6 +24933,18 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -29393,7 +29444,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -30708,6 +30758,15 @@
       "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
       "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
+    "node_modules/gtfs-realtime-bindings": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gtfs-realtime-bindings/-/gtfs-realtime-bindings-1.1.1.tgz",
+      "integrity": "sha512-+k8+/MmiBmUUWlASs4CeTkV+Qyz/FgbZxXdg9rDU62XRfJOpRaRe+nKWCGKse965jffVZ0tIu1K+R7hRvjSLfQ==",
+      "dependencies": {
+        "protobufjs": "^7.1.2",
+        "protobufjs-cli": "^1.0.2"
+      }
+    },
     "node_modules/h3-js": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
@@ -31919,7 +31978,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -33503,11 +33561,58 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "license": "MIT"
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdoc/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
@@ -33933,6 +34038,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
+    },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
     },
     "node_modules/klaw-sync": {
       "version": "6.0.0",
@@ -34493,6 +34607,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/load-script": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-2.0.0.tgz",
@@ -34542,9 +34665,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -34919,6 +35042,45 @@
         "pbf": "bin/pbf"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -34927,6 +35089,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/martinez-polygon-clipping": {
@@ -35314,6 +35488,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -36043,6 +36223,18 @@
       "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-3.0.0.tgz",
       "integrity": "sha512-siX3YCG7N2HnmN1xMH3cK4JkUZJhbkhRFJL+G5N1vH0mh1t5088rJknIoqDFWDIU6NPGvRRgLnYW3ZHjSMEBLA==",
       "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/mobx": {
       "version": "6.15.0",
@@ -38635,6 +38827,195 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/protobufjs-cli": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.2.0.tgz",
+      "integrity": "sha512-+YvqJEmsmZHGzE5j0tvEzFeHm0sX7pzRFpyj7+GazhkS4Y0r+jgbioVvFxxSWIlPzUel/lxeOnLChBmV8NmyHA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "escodegen": "^1.13.0",
+        "espree": "^9.0.0",
+        "estraverse": "^5.1.0",
+        "glob": "^8.0.0",
+        "jsdoc": "^4.0.0",
+        "minimist": "^1.2.0",
+        "semver": "^7.1.2",
+        "tmp": "^0.2.1",
+        "uglify-js": "^3.7.7"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "protobufjs": "^7.0.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/escodegen/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/protobufjs-cli/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/protobufjs/node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -38675,6 +39056,15 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -39827,6 +40217,15 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -41388,7 +41787,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -41980,7 +42378,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -42985,13 +43382,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -43017,6 +43418,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.25.0",
@@ -45360,6 +45767,12 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "license": "Apache-2.0"
     },
     "node_modules/xmldom": {
       "version": "0.1.31",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "geist": "^1.3.1",
     "gosling.js": "^1.0.7",
     "graphql": "^16.13.0",
+    "gtfs-realtime-bindings": "^1.1.1",
     "higlass": "^2.1.9",
     "hls.js": "^1.6.16",
     "imagesloaded": "^5.0.0",

--- a/scripts/patch-mindex-imports.mjs
+++ b/scripts/patch-mindex-imports.mjs
@@ -1,0 +1,46 @@
+/**
+ * Follow-up to patch-mindex-localhost-fallbacks.mjs — insert the missing
+ * `import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"`
+ * line in any file that calls the function but doesn't import it.
+ *
+ * The earlier patcher had a test that never added the import because the
+ * just-replaced symbol was already in the file string. This script guards
+ * on the import line literally.
+ */
+import fs from "fs"
+import path from "path"
+import { fileURLToPath } from "url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.join(__dirname, "..")
+
+function walk(dir, out = []) {
+  for (const name of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, name.name)
+    if (name.isDirectory()) {
+      if (name.name === "node_modules" || name.name === ".next") continue
+      walk(p, out)
+    } else if (/\.(ts|tsx)$/.test(name.name)) out.push(p)
+  }
+  return out
+}
+
+const importLine = 'import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"\n'
+let patched = 0
+
+for (const file of walk(root)) {
+  const rel = path.relative(root, file).replace(/\\/g, "/")
+  if (rel === "lib/mindex-base-url.ts") continue
+  if (rel.startsWith("scripts/")) continue
+  let s = fs.readFileSync(file, "utf8")
+  if (!s.includes("resolveMindexServerBaseUrl(")) continue
+  if (s.includes('from "@/lib/mindex-base-url"')) continue
+  const m = s.match(/^import[^\n]*\n/m)
+  if (!m) continue
+  const idx = s.indexOf(m[0]) + m[0].length
+  s = s.slice(0, idx) + importLine + s.slice(idx)
+  fs.writeFileSync(file, s)
+  patched++
+  console.log("patched", rel)
+}
+console.log("total patched:", patched)

--- a/scripts/patch-mindex-localhost-fallbacks.mjs
+++ b/scripts/patch-mindex-localhost-fallbacks.mjs
@@ -1,0 +1,89 @@
+/**
+ * One-shot: replace MINDEX || "http://localhost:8000" patterns with resolveMindexServerBaseUrl().
+ * Run: node scripts/patch-mindex-localhost-fallbacks.mjs
+ */
+import fs from "fs"
+import path from "path"
+import { fileURLToPath } from "url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.join(__dirname, "..")
+
+const skip = new Set([
+  "lib/mindex-base-url.ts",
+  "scripts/patch-mindex-localhost-fallbacks.mjs",
+])
+
+function walk(dir, out = []) {
+  for (const name of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, name.name)
+    if (name.isDirectory()) {
+      if (name.name === "node_modules" || name.name === ".next") continue
+      walk(p, out)
+    } else if (/\.(ts|tsx)$/.test(name.name)) out.push(p)
+  }
+  return out
+}
+
+const patterns = [
+  [
+    /const MINDEX_API_URL = process\.env\.MINDEX_API_URL \|\| "http:\/\/localhost:8000"/g,
+    'const MINDEX_API_URL = resolveMindexServerBaseUrl()',
+  ],
+  [
+    /const MINDEX_API = process\.env\.MINDEX_API_URL \|\| "http:\/\/localhost:8000"/g,
+    'const MINDEX_API = resolveMindexServerBaseUrl()',
+  ],
+  [
+    /const MINDEX_BASE = process\.env\.MINDEX_API_URL \|\| "http:\/\/localhost:8000"/g,
+    'const MINDEX_BASE = resolveMindexServerBaseUrl()',
+  ],
+  [
+    /const MINDEX = process\.env\.MINDEX_API_URL \|\| "http:\/\/localhost:8000"/g,
+    'const MINDEX = resolveMindexServerBaseUrl()',
+  ],
+  [
+    /const MINDEX_API_URL = process\.env\.MINDEX_API_BASE_URL \|\| "http:\/\/localhost:8000"/g,
+    'const MINDEX_API_URL = resolveMindexServerBaseUrl()',
+  ],
+  [
+    /const MINDEX_API_URL = process\.env\.MINDEX_API_URL \|\| process\.env\.MINDEX_API_BASE_URL \|\| "http:\/\/localhost:8000"/g,
+    'const MINDEX_API_URL = resolveMindexServerBaseUrl()',
+  ],
+]
+
+const importLine = 'import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"\n'
+
+function rel(p) {
+  return path.relative(root, p).replace(/\\/g, "/")
+}
+
+let n = 0
+for (const file of walk(root)) {
+  const r = rel(file)
+  if (skip.has(r)) continue
+  let s = fs.readFileSync(file, "utf8")
+  if (!s.includes("localhost:8000")) continue
+  // Only MINDEX-related lines (not MAS hook)
+  if (r.includes("useAgentMemory")) continue
+  let changed = false
+  for (const [re, rep] of patterns) {
+    const next = s.replace(re, rep)
+    if (next !== s) {
+      s = next
+      changed = true
+    }
+  }
+  if (!changed) continue
+  if (!s.includes("resolveMindexServerBaseUrl")) {
+    // insert after first import block
+    const firstImport = s.indexOf("import ")
+    if (firstImport === -1) continue
+    const lineEnd = s.indexOf("\n", firstImport)
+    s = s.slice(0, lineEnd + 1) + importLine + s.slice(lineEnd + 1)
+  }
+  fs.writeFileSync(file, s)
+  n++
+  console.log("patched", r)
+}
+console.log("done", n, "files")


### PR DESCRIPTION
## Summary
- **Fixes empty CREP map on prod** — `resolveMindexServerBaseUrl()` no longer gates loopback→LAN remap on `NODE_ENV==='production'`. Server-side code always remaps `http://localhost:8000` to `192.168.0.189:8000` unless the operator opts in with `ALLOW_LOOPBACK_MINDEX=1`. Same treatment for MAS via `ALLOW_LOOPBACK_MAS=1`.
- **Live transit**: 12 agency connectors (MTA, WMATA, BART, MBTA, 511 Bay, CTA, TriMet, MARTA, Amtrak, SEPTA, Metrolink, DART) + `/api/transit/all` aggregator + new MapLibre layer wired into CREP dashboard. Competes with Google Maps live transit — polls every 15 s, colored by vehicle type.
- Docker compose default flipped from loopback to LAN so missing secret can't knock MINDEX off again.
- `.env.example` documents all transit key names — values stay in GitHub Actions / VM secrets, never in code.

## Why
Morgan: "no satelites planes inaturalist nature events vessles nothing is showing up on the fucking map audit that all now", "i also do not see any trains rendering moving on any tracks iun any city".

Production snapshot on prod showed \`mindex.url: http://localhost:8000, reachable: false\` even after the last deploy. Individual endpoints (\`/api/oei/flightradar24\`, \`/api/oei/aisstream\`) returned live data, but every MINDEX-backed aggregator saw MINDEX as down — container NODE_ENV wasn't propagated so loopback values leaked through the resolver.

## Test plan
- [ ] Post-deploy: \`/api/worldview/snapshot\` returns \`mindex.url: http://192.168.0.189:8000, reachable: true\`.
- [ ] \`/api/transit/all?bbox=-74.3,40.5,-73.7,40.9\` returns \`features: [...]\` with NYC subway/LIRR vehicles.
- [ ] Open \`/dashboard/crep\`: NYC view shows blue subway dots, DC orange WMATA dots, SF mixed Muni/BART/ferry.
- [ ] Each agency degrades gracefully when key is missing (no 500s, just \`{ok:false, error:"... not configured"}\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a unified live transit aggregation layer to the CREP dashboard and harden MINDEX/MAS connectivity by remapping localhost URLs to LAN hosts across server-side code and infrastructure.

New Features:
- Introduce a live transit MapLibre layer in the CREP dashboard backed by a new /api/transit/all aggregator and multiple agency-specific transit connectors.
- Integrate Eagle Eye CCTV search with MINDEX unified-search instead of static mock cameras.

Bug Fixes:
- Ensure server-side MINDEX and MAS calls no longer fall back to localhost in production-like environments by remapping loopback URLs to LAN VM addresses with opt-in dev escape hatches.
- Fix production CREP and Worldview seeing MINDEX as down due to missing NODE_ENV or misconfigured MINDEX_API_URL by routing through a canonical MINDEX base URL resolver.

Enhancements:
- Standardize server-side MINDEX access through resolveMindexServerBaseUrl across APIs, services, health checks, and ETL utilities.
- Update profile and CREP service status views to reference real LAN endpoints instead of localhost placeholders.
- Improve Eagle Eye and Fusarium documentation to explain MINDEX-backed video layers and their availability constraints.

Build:
- Add gtfs-realtime-bindings dependency for decoding GTFS-realtime protobuf feeds.
- Wire MINDEX_API_KEY and AIRNOW_API_KEY into CI/CD and deployment workflows and adjust Docker compose defaults to prefer LAN MINDEX/MAS URLs over localhost.

CI:
- Extend CI/CD and instant-deploy workflows to propagate MINDEX_API_KEY and AIRNOW_API_KEY into the runtime .env files and document required production secrets.

Deployment:
- Update production and sandbox Docker Compose configurations to default MINDEX and MAS URLs to LAN VM addresses instead of localhost to prevent empty maps when secrets are missing.

Documentation:
- Document Eagle Eye CREP video layers and clarify how to enable and interpret them on the Fusarium defense page.

Chores:
- Add maintenance scripts to automatically patch legacy MINDEX localhost URL fallbacks and missing imports to the new base URL resolver.
- Adjust internal admin and diagnostics views to reference canonical LAN endpoints for MINDEX and related services.