### PR TITLE
crep: shared resolveInternalBaseUrl() for all server self-fetches

### DIFF
--- a/app/api/crep/mojave/route.ts
+++ b/app/api/crep/mojave/route.ts
@@ -40,6 +40,7 @@
  */
 
 import { NextResponse } from "next/server"
+import { resolveInternalBaseUrl } from "@/lib/internal-base-url"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -379,7 +380,7 @@ async function fetchNpsBoundary(): Promise<GeoJSON.Polygon | GeoJSON.MultiPolygo
 
 export async function GET(req: Request) {
   const started = Date.now()
-  const origin = new URL(req.url).origin
+  const origin = resolveInternalBaseUrl(new URL(req.url).origin)
 
   const [npsGeom, inatObs, ...obs] = await Promise.all([
     fetchNpsBoundary(),

--- a/app/api/crep/tijuana-estuary/route.ts
+++ b/app/api/crep/tijuana-estuary/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { readFileSync, existsSync } from "node:fs"
 import path from "node:path"
+import { resolveInternalBaseUrl } from "@/lib/internal-base-url"
 
 /**
  * Tijuana Estuary / Project Oyster — environmental data aggregator
@@ -231,7 +232,7 @@ export async function GET(req: NextRequest) {
   const tourism = TJ_OYSTER_TOURISM
   const sensors = TJ_OYSTER_SENSORS
   const heatmaps = TJ_OYSTER_HEATMAPS
-  const origin = new URL(req.url).origin
+  const origin = resolveInternalBaseUrl(new URL(req.url).origin)
   const inatObs = await fetchINatOysterPreloadedFirst(origin)
 
   // Perimeter + thesis anchor for Project Oyster widget

--- a/app/api/transit/all/route.ts
+++ b/app/api/transit/all/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import type { TransitVehicle } from "@/lib/transit/gtfs-realtime"
+import { resolveInternalBaseUrl } from "@/lib/internal-base-url"
 
 /**
  * Aggregate every connected transit agency into one GeoJSON FeatureCollection
@@ -46,12 +47,12 @@ const AGENCIES: AgencyDef[] = [
   { id: "dart", path: "/api/transit/dart" },
 ]
 
-async function fetchAgency(origin: string, def: AgencyDef, bbox: string | null): Promise<{ id: string; vehicles: TransitVehicle[]; ok: boolean; err?: string }> {
+async function fetchAgency(internalBase: string, def: AgencyDef, bbox: string | null): Promise<{ id: string; vehicles: TransitVehicle[]; ok: boolean; err?: string }> {
   if (def.keyEnv && !process.env[def.keyEnv]?.trim()) {
     return { id: def.id, vehicles: [], ok: false, err: `${def.keyEnv} not configured` }
   }
   try {
-    const url = `${origin}${def.path}${bbox ? `?bbox=${encodeURIComponent(bbox)}` : ""}`
+    const url = `${internalBase}${def.path}${bbox ? `?bbox=${encodeURIComponent(bbox)}` : ""}`
     const r = await fetch(url, { signal: AbortSignal.timeout(12_000), cache: "no-store" })
     if (!r.ok) return { id: def.id, vehicles: [], ok: false, err: `upstream ${r.status}` }
     const j = await r.json()
@@ -70,8 +71,8 @@ export async function GET(req: NextRequest) {
     ? AGENCIES.filter((a) => agenciesParam.includes(a.id))
     : AGENCIES
 
-  const origin = new URL(req.url).origin
-  const results = await Promise.all(defs.map((d) => fetchAgency(origin, d, bboxParam)))
+  const internalBase = resolveInternalBaseUrl(new URL(req.url).origin)
+  const results = await Promise.all(defs.map((d) => fetchAgency(internalBase, d, bboxParam)))
 
   // Dedupe by id across agencies (shouldn't overlap, but defensive)
   const seen = new Set<string>()

--- a/app/api/worldview/snapshot/route.ts
+++ b/app/api/worldview/snapshot/route.ts
@@ -34,6 +34,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { resolveMindexServerBaseUrl } from "@/lib/mindex-base-url"
 import { resolveMasServerBaseUrl } from "@/lib/mas-server-url"
+import { resolveInternalBaseUrl } from "@/lib/internal-base-url"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -62,7 +63,7 @@ export async function GET(req: NextRequest) {
   const started = Date.now()
   const project = (req.nextUrl.searchParams.get("project") || "global").toLowerCase()
 
-  const origin = new URL(req.url).origin
+  const origin = resolveInternalBaseUrl(new URL(req.url).origin)
 
   // Fan-out all fetches in parallel
   const [

--- a/app/api/worldview/stream/route.ts
+++ b/app/api/worldview/stream/route.ts
@@ -35,6 +35,7 @@
  */
 
 import { NextRequest } from "next/server"
+import { resolveInternalBaseUrl } from "@/lib/internal-base-url"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -72,7 +73,8 @@ export async function GET(req: NextRequest) {
 
       const tick = async () => {
         try {
-          const r = await fetch(`${origin}/api/worldview/snapshot?project=${encodeURIComponent(project)}`, {
+          const internalOrigin = resolveInternalBaseUrl(origin)
+          const r = await fetch(`${internalOrigin}/api/worldview/snapshot?project=${encodeURIComponent(project)}`, {
             signal: AbortSignal.timeout(20_000),
           })
           if (!r.ok) {

--- a/lib/internal-base-url.ts
+++ b/lib/internal-base-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical "self-fetch" base URL for server-side Next.js code.
+ *
+ * Apr 23, 2026 — Morgan: aggregators were returning 0 vehicles on prod
+ * even though the direct endpoints were live. Root cause: every server
+ * aggregator used `new URL(req.url).origin` which on prod resolves to
+ * `https://mycosoft.com`. The container self-fetching its own public
+ * origin bounces off Cloudflare → nginx → back to the same container
+ * and either TLS-handshake fails or 502s (one-hop server-to-server
+ * self-fetch on the public hostname is not a supported Cloudflare path).
+ *
+ * Solution: when running on the server, target the container's own
+ * `http://localhost:${PORT}` (same path Docker health checks use). In
+ * the browser, we still use the page origin.
+ *
+ * Env overrides:
+ *   INTERNAL_SELF_URL — explicit absolute URL for unusual deploys
+ *                       (e.g. behind a service mesh with a distinct internal
+ *                       address).
+ *   PORT              — the Node listener port (defaults to 3000).
+ */
+export function resolveInternalBaseUrl(requestOrigin?: string): string {
+  const explicit = process.env.INTERNAL_SELF_URL?.trim()
+  if (explicit) return explicit.replace(/\/$/, "")
+  if (typeof window === "undefined") {
+    // Vercel runs on random ports and handles self-fetch via
+    // the platform router — use the request origin there.
+    if (process.env.VERCEL) return requestOrigin || "https://localhost"
+    const port = process.env.PORT || "3000"
+    return `http://localhost:${port}`
+  }
+  return requestOrigin || ""
+}


### PR DESCRIPTION
## Summary
Post-PR #109 verification exposed that every server-side aggregator self-fetching via \`new URL(req.url).origin\` (= \`https://mycosoft.com\` on prod) bounces off Cloudflare → nginx → back to the same container and 502s. Fixes:

- **New:** \`lib/internal-base-url.ts\` — \`resolveInternalBaseUrl()\` helper. On the server returns \`http://localhost:\${PORT}\`; on Vercel / in the browser returns the real origin. Env override \`INTERNAL_SELF_URL\`.
- **Applied in:**
  - \`app/api/transit/all/route.ts\` — transit aggregator (was returning 0 vehicles)
  - \`app/api/worldview/snapshot/route.ts\` — worldview snapshot (was returning 0 live_entities)
  - \`app/api/worldview/stream/route.ts\` — SSE tick reads snapshot
  - \`app/api/crep/tijuana-estuary/route.ts\` — Project Oyster aggregator
  - \`app/api/crep/mojave/route.ts\` — Project Goffs aggregator

## Evidence pre-fix (prod after #109 landed)
- \`/api/transit/mta\` direct → **278 vehicles** ✓
- \`/api/transit/all\` → 0 vehicles, every agency \`fetch failed\` ✗
- \`/api/worldview/snapshot\` → \`mindex.reachable: true\` ✓ but \`live_entities.aircraft: 0\` ✗

## Test plan
- [ ] \`/api/transit/all\` returns vehicles from MTA, BART, MBTA, SEPTA, Metrolink.
- [ ] \`/api/worldview/snapshot\` shows non-zero \`live_entities\`.
- [ ] \`/api/crep/tijuana-estuary\` + \`/api/crep/mojave\` populate their summaries.
- [ ] CREP dashboard renders transit dots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)