### PR TITLE
crep(transit): Metrolink + DART now behind API keys (fix 404s)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -213,5 +213,9 @@ CTA_TRAIN_TRACKER_API_KEY=
 TRIMET_API_KEY=
 # Atlanta — MARTA GTFS-rt.
 MARTA_API_KEY=
-# No-key connectors (SEPTA / Amtrak plaintext / Metrolink / DART) need no env.
+# LA Metrolink — SimplifyTransit CDN, key required (register at metrolinktrains.com/about/gtfs/gtfs-rt-access/).
+METROLINK_API_KEY=
+# Dallas DART — Azure API Management gateway, subscription key header (register at dart.developer.azure-api.net/).
+DART_API_KEY=
+# No-key connectors (MTA / Amtrak plaintext / SEPTA) need no env.
 # -----------------------------------------------------------------------------

--- a/app/api/transit/all/route.ts
+++ b/app/api/transit/all/route.ts
@@ -43,8 +43,8 @@ const AGENCIES: AgencyDef[] = [
   { id: "marta", path: "/api/transit/marta", keyEnv: "MARTA_API_KEY" },
   { id: "amtrak", path: "/api/transit/amtrak" },
   { id: "septa", path: "/api/transit/septa" },
-  { id: "metrolink", path: "/api/transit/metrolink" },
-  { id: "dart", path: "/api/transit/dart" },
+  { id: "metrolink", path: "/api/transit/metrolink", keyEnv: "METROLINK_API_KEY" },
+  { id: "dart", path: "/api/transit/dart", keyEnv: "DART_API_KEY" },
 ]
 
 async function fetchAgency(internalBase: string, def: AgencyDef, bbox: string | null): Promise<{ id: string; vehicles: TransitVehicle[]; ok: boolean; err?: string }> {

--- a/app/api/transit/dart/route.ts
+++ b/app/api/transit/dart/route.ts
@@ -2,11 +2,13 @@ import { NextRequest, NextResponse } from "next/server"
 import { fetchVehiclePositions, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
 
 /**
- * DART (Dallas Area Rapid Transit) — GTFS-rt protobuf (open).
- * Covers bus + light rail (Red/Blue/Green/Orange) + TRE commuter rail.
+ * DART (Dallas Area Rapid Transit) — GTFS-rt protobuf.
  *
- * Feed URL — DART publishes via trackingmap.org aggregator (no key required);
- * the `?agency=DART` param filters to DART only.
+ * Apr 23, 2026 correction: DART moved its realtime feeds behind an Azure API
+ * Management gateway (https://dart.developer.azure-api.net/). The older
+ * `www.dart.org/transitdata/gtfsrt/vehiclepositions.pb` path returns 404.
+ * Subscription key required via header `Ocp-Apim-Subscription-Key` → env
+ * var DART_API_KEY.
  *
  * GET /api/transit/dart?bbox=w,s,e,n
  */
@@ -14,13 +16,15 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export async function GET(req: NextRequest) {
+  const key = process.env.DART_API_KEY?.trim()
+  if (!key) return NextResponse.json({ ok: false, error: "DART_API_KEY not configured" }, { status: 501 })
   const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
-  // Primary: DART's own GTFS-rt VP endpoint (OpenMobilityData mirror).
-  const url = "https://www.dart.org/transitdata/gtfsrt/vehiclepositions.pb"
+  const url = "https://dartgtfsrealtime.azure-api.net/vehiclepositions.pb"
   const result = await fetchVehiclePositions(url, {
     agency: "o-9vfh-dart",
     agency_name: "DART",
     vehicleType: "bus",
+    headers: { "Ocp-Apim-Subscription-Key": key },
   })
   const vehicles = cullVehiclesToBbox(result.vehicles, bbox)
   return NextResponse.json({

--- a/app/api/transit/metrolink/route.ts
+++ b/app/api/transit/metrolink/route.ts
@@ -2,8 +2,15 @@ import { NextRequest, NextResponse } from "next/server"
 import { fetchVehiclePositions, cullVehiclesToBbox } from "@/lib/transit/gtfs-realtime"
 
 /**
- * Metrolink (LA Commuter Rail) — GTFS-rt protobuf (open, no key).
- * Feed: https://metrolinktrains.com/advisories/gtfs/vehiclepositions.pb
+ * Metrolink (LA Commuter Rail) — GTFS-rt protobuf.
+ *
+ * Apr 23, 2026 correction: Metrolink's VehiclePositions feed requires an
+ * API key (registered at https://metrolinktrains.com/about/gtfs/gtfs-rt-access/).
+ * Previously the code hit `metrolinktrains.com/advisories/gtfs/vehiclepositions.pb`
+ * which returned 404. The right path is via SimplifyTransit's CDN once the
+ * key is issued. Env var: METROLINK_API_KEY.
+ * Alerts feed IS open at `https://cdn.simplifytransit.com/metrolink/alerts/service-alerts.pb`
+ * but we only care about positions here.
  *
  * GET /api/transit/metrolink?bbox=w,s,e,n
  */
@@ -11,8 +18,10 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export async function GET(req: NextRequest) {
+  const key = process.env.METROLINK_API_KEY?.trim()
+  if (!key) return NextResponse.json({ ok: false, error: "METROLINK_API_KEY not configured" }, { status: 501 })
   const bbox = parseBbox(req.nextUrl.searchParams.get("bbox"))
-  const url = "https://metrolinktrains.com/advisories/gtfs/vehiclepositions.pb"
+  const url = `https://api.simplifytransit.com/metrolink/vehicles/vehicles.pb?key=${encodeURIComponent(key)}`
   const result = await fetchVehiclePositions(url, {
     agency: "o-9q5-metrolink",
     agency_name: "Metrolink",


### PR DESCRIPTION
## Summary
Post-deploy verification of PR #109/#112 caught that two of the \"no-key\" agencies in the live-transit aggregator actually require auth now:

- **Metrolink** (LA Commuter Rail) — moved to SimplifyTransit's CDN. Register at https://metrolinktrains.com/about/gtfs/gtfs-rt-access/ → \`METROLINK_API_KEY\`.
- **DART** (Dallas) — moved to Azure API Management. Register at https://dart.developer.azure-api.net/ → \`DART_API_KEY\` (sent as \`Ocp-Apim-Subscription-Key\` header).

Both endpoints returned upstream 404 on prod. Fixed by requiring the env var and returning a clean 501 \`{ok:false, error:"… not configured"}\` when missing (same pattern as WMATA / 511-Bay / CTA / TriMet / MARTA).

## Why LA + Dallas were zero
\`/api/transit/all?bbox=<LA>\` returned 0 because Metrolink was the only LA-area agency in the registry and its upstream was 404. Same with DART for Dallas.

## Test plan
- [ ] Without keys set: \`/api/transit/all\` shows Metrolink + DART as \`ok:false, not configured\` (graceful, not \`fetch failed\`).
- [ ] With keys set on the VM: both return vehicle counts.

## Keys action for Morgan
Once you register at the two portals above, add the secrets to GitHub Actions / VM env:
  METROLINK_API_KEY, DART_API_KEY

Already-missing keys to also add (from Perplexity / your transit_api_keys.txt):
  WMATA_API_KEY, TRANSIT_511_API_KEY, CTA_TRAIN_TRACKER_API_KEY,
  TRIMET_API_KEY, MARTA_API_KEY, MBTA_API_KEY (optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Require API keys for Metrolink and DART transit feeds and update their upstream endpoints.

Bug Fixes:
- Prevent Metrolink and DART aggregations from failing with upstream 404s by treating missing API keys as not-configured (501) responses.

Enhancements:
- Add API key configuration metadata for Metrolink and DART to the aggregated transit agencies list.