### PR TITLE
crep: clickable iNat dots \u2192 species popup (+ show at metro zoom)

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -3508,6 +3508,42 @@ export default function CREPDashboardPage() {
     (window as any).__crep_selectAsset = (payload: any) => {
       if (!payload || payload.lat == null || payload.lng == null) return;
       lastEntityPickTimeRef.current = Date.now();
+      // Apr 23, 2026 — Morgan: "none of these green dots in dc are
+      // selectable i dont know what they are and i see no nature data".
+      // Baked iNat layers (crep-{region}-inat) were routing through
+      // __crep_selectAsset (generic infra widget) which just shows
+      // "asset" metadata — useless for a nature observation. When the
+      // selectType marks it as iNat, short-circuit to the species
+      // popup instead so the user gets photos, scientific name, source
+      // link, kingdom colour, grade, etc.
+      if (payload.type === "inat-observation") {
+        const p = payload.properties || {};
+        const obs: FungalObservation = {
+          id: payload.id ?? p.id,
+          latitude: payload.lat,
+          longitude: payload.lng,
+          species: p.species || p.commonName || p.scientificName || p.name || "Unknown",
+          taxon: p.taxon || {
+            id: Number(p.taxon_id) || 0,
+            name: p.scientificName || p.name || "Unknown",
+            preferred_common_name: p.commonName || p.species || undefined,
+            rank: p.rank || "species",
+          },
+          observed_on: p.observed_on || p.observedOn || p.timestamp || "",
+          quality_grade: p.quality_grade || p.grade || "research",
+          photos: Array.isArray(p.photos)
+            ? p.photos.map((u: any) => (typeof u === "string" ? { id: 0, url: u } : u))
+            : undefined,
+          source: p.source || "iNaturalist",
+          sourceUrl: p.sourceUrl || p.source_url || undefined,
+          user: p.observer || p.user || undefined,
+          location: p.placeGuess || p.location || undefined,
+          kingdom: p.kingdom || undefined,
+          iconicTaxon: p.iconicTaxon || p.kingdom || undefined,
+        };
+        setSelectedFungal(obs);
+        return;
+      }
       // Apr 22, 2026 — Morgan: "we dont need that ring at all anywhere".
       // The OpenGridWorks-style cyan highlight ring was firing on every
       // asset click and being misread as a "selecting…" state, especially
@@ -3522,10 +3558,18 @@ export default function CREPDashboardPage() {
         properties: payload.properties || {},
       });
     };
+    // Apr 23, 2026 — separate hook the baked iNat circle layers call
+    // directly (avoids going through __crep_selectAsset's shape check).
+    (window as any).__crep_selectFungal = (obs: FungalObservation) => {
+      if (!obs) return;
+      lastEntityPickTimeRef.current = Date.now();
+      setSelectedFungal(obs);
+    };
     return () => {
       try { delete (window as any).__crep_setLayer; } catch { /* noop */ }
       try { delete (window as any).__crep_layers; } catch { /* noop */ }
       try { delete (window as any).__crep_selectAsset; } catch { /* noop */ }
+      try { delete (window as any).__crep_selectFungal; } catch { /* noop */ }
     };
   }, [layers]);
 

--- a/components/crep/layers/project-nyc-dc-layer.tsx
+++ b/components/crep/layers/project-nyc-dc-layer.tsx
@@ -85,7 +85,11 @@ const makeCategories = (region: "nyc" | "dc"): RegionCategory[] => [
   // nature data icon in nyc or washington dc that is a huge violation
   // of our product fix that now"). 10k research-grade observations
   // per region; kingdom-colored dots, minzoom 10 to keep it legible.
-  { id: `${region}Inat` as keyof Enabled,          file: `/data/crep/${region}-inat.geojson`,            layerId: `crep-${region}-inat`,          sourceId: `crep-${region}-inat-src`,          label: "Nature observations (iNat)", color: "#84cc16", selectType: "inat-observation", minzoom: 10 },
+  // Apr 23, 2026 — minzoom lowered 10 → 7 so iNat density reads as a
+  // metro-scale overlay, not just neighbourhood-scale. 10k points per
+  // region × 2 regions = 20k; MapLibre's internal tile bin handles it
+  // fine at z≥7 viewport cull.
+  { id: `${region}Inat` as keyof Enabled,          file: `/data/crep/${region}-inat.geojson`,            layerId: `crep-${region}-inat`,          sourceId: `crep-${region}-inat-src`,          label: "Nature observations (iNat)", color: "#84cc16", selectType: "inat-observation", minzoom: 7 },
 ]
 
 export interface ProjectNycDcLayerProps {


### PR DESCRIPTION
## Summary
Morgan (DC screenshot at z~13): \"none of these green dots in dc are selectable i dont know what they are and i see no nature data\".

**Root cause** — the ~10k research-grade iNat dots on top of DC render from \`crep-dc-inat\` / \`crep-nyc-inat\` (MapLibre circle layers sourced from baked \`{region}-inat.geojson\`). Their click handlers dispatch to \`window.__crep_selectAsset\` with \`type: \"inat-observation\"\`, but that handler opened the generic InfraAssetWidget — which is perfect for a substation, useless for a species observation (no species name, photo, iNat link, kingdom tag).

**Fix** — in \`__crep_selectAsset\` when the payload is an iNat observation, reshape the properties into a \`FungalObservation\` and call \`setSelectedFungal\` so the rich species popup opens (photo + scientific name + kingdom colour + grade + observer + link to iNaturalist / GBIF / MINDEX). Plus a new direct hook \`__crep_selectFungal\` for any overlay that already owns the \`FungalObservation\`.

Also lowered the iNat layer \`minzoom\` from 10 → 7 so the density reads as a metro-scale overlay, not just neighbourhood.

## Test plan
- [ ] Hard-refresh \`/dashboard/crep\`, fly to DC (z~13). Click a green dot.
- [ ] Species popup opens next to the dot with the iNat common name, scientific name, grade badge, coords, observer, photo if any, and a link out to iNaturalist.
- [ ] Zoom out to z=7 (metro scale). Green dots still visible as a density field.
- [ ] Non-iNat layers (substations, hospitals, military) still open the InfraAssetWidget as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route CREP dashboard iNaturalist observation clicks to the rich species popup and expose iNat dots at a broader metro zoom level.

Bug Fixes:
- Ensure clicks on iNaturalist observation dots open a species observation popup instead of the generic infrastructure asset widget.

Enhancements:
- Add a dedicated global hook for selecting fungal observations directly from overlays.
- Lower the minimum zoom level for NYC/DC iNaturalist observation layers so their density is visible at metro scale.