### PR TITLE
crep(eagle-eye): refetch on bbox change + consume pending baked FC

### DIFF
--- a/components/crep/layers/eagle-eye-overlay.tsx
+++ b/components/crep/layers/eagle-eye-overlay.tsx
@@ -90,13 +90,21 @@ export default function EagleEyeOverlay({ map, enabled, bbox }: Props) {
       if (camsTimerRef.current) { clearInterval(camsTimerRef.current); camsTimerRef.current = null }
       return
     }
-    if (loadedRef.current.cams) {
-      try {
-        for (const id of ids) if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", "visible")
-      } catch { /* ignore */ }
-      return
-    }
-    loadedRef.current.cams = true
+    // Apr 23, 2026 — Morgan: "eagle eye shows nothign get that working now
+    // i see no social media youtube shinobi nps usgs no sensors nothing as
+    // im over san diego". Root cause: the previous `loadedRef.current.cams`
+    // short-circuit returned on every bbox change after the first mount,
+    // so the initial fetch's bbox was the ONLY bbox ever queried. Panning
+    // to SD, NYC, anywhere else never triggered a new /api/eagle/sources
+    // call and the layer stayed stale.
+    //
+    // New contract: `loadedRef.current.cams` tracks whether the SOURCE +
+    // LAYERS have been created (addSource / addLayer must only run once
+    // per map lifetime). Every bbox / toggle change still calls
+    // fetchAndPaint which refreshes the source data.
+    try {
+      for (const id of ids) if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", "visible")
+    } catch { /* ignore */ }
 
     // Apr 22, 2026 — Morgan: "cameras are PERMANENT assets ... the icon
     // of camera should be hard coded in map unless update shows its gone".
@@ -247,7 +255,21 @@ export default function EagleEyeOverlay({ map, enabled, bbox }: Props) {
           }))
         const fc = { type: "FeatureCollection" as const, features }
         if (!map.getSource("crep-eagle-cams")) {
-          map.addSource("crep-eagle-cams", { type: "geojson", data: fc, generateId: true })
+          // Apr 23, 2026 — pre-seed with the baked-registry FC if
+          // paintBakedRegistry already stashed one (previously it stashed
+          // on __crepEaglePendingFc but nothing consumed it, so the
+          // baked-registry features were silently lost on first mount).
+          const pending = (map as any).__crepEaglePendingFc
+          let initialFc = fc
+          if (pending?.features?.length) {
+            const merged = new Map<string, any>()
+            for (const f of pending.features) if (f?.properties?.id) merged.set(String(f.properties.id), f)
+            for (const f of fc.features) if (f?.properties?.id) merged.set(String(f.properties.id), f)
+            initialFc = { type: "FeatureCollection" as const, features: Array.from(merged.values()) }
+            delete (map as any).__crepEaglePendingFc
+          }
+          map.addSource("crep-eagle-cams", { type: "geojson", data: initialFc, generateId: true })
+          loadedRef.current.cams = true
           map.addLayer({
             id: "crep-eagle-cams-halo",
             type: "circle",


### PR DESCRIPTION
## Summary
Morgan (San Diego view): \"eagle eye shows nothign get that working now i see no social media youtube shinobi nps usgs no sensors nothing as im over san diego\".

Backend verified OK — \`/api/eagle/sources?bbox=<SD>\` returns **214 sources** (caltrans 190, alertwildfire 2, hpwren 1, cbp 4, earthcam 1, navy 3, sdapcd 5, project_oyster 3, ibwc 1, sandiego_deh 3, noaa_trnerr 1). The frontend wasn't fetching them.

Two bugs, both in \`components/crep/layers/eagle-eye-overlay.tsx\`:

### Bug 1 — loadedRef short-circuited every bbox change
Effect deps include \`bbox\`, so pans re-run the effect. But \`if (loadedRef.current.cams) return\` early-exited after the first fetch. Whatever bbox the very first fetch saw became the only bbox ever queried. Pan to San Diego → effect re-runs → early-exit → no SD fetch.

**Fix**: track \`loadedRef.current.cams\` strictly as a \"source + layers created\" flag (those only happen once), and set it AFTER addSource. Every bbox change now calls \`fetchAndPaint\` end-to-end and setData's the source with the new bbox's features.

### Bug 2 — paintBakedRegistry stashed pending FC but nothing consumed it
On first mount the baked registry (\`eagle-cameras-registry\` + \`manual-seed\` + \`nyc-dc-seed\`) has ~3,900 curated cameras with canonical lat/lng + provider. Loading it is ~50 ms. It wrote to \`(map as any).__crepEaglePendingFc\` but the addSource path never read it back, silently losing the instant paint.

**Fix**: when \`addSource\` runs, check \`__crepEaglePendingFc\`, merge with the API features by id (API wins — fresher), clear the stash.

## Test plan
- [ ] Pan from continent view to San Diego: within 5 s, 200+ cyan/amber/violet camera dots appear (Caltrans amber, EarthCam violet, CBP/Navy/HPWREN cyan, etc.).
- [ ] Pan to NYC → baked NYC seed + live API merge.
- [ ] Zoom / pan between metros rapidly — each bbox gets its own fetch (visible in DevTools Network).
- [ ] No duplicate \`addSource\` errors on repeated re-renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure eagle-eye camera overlays refresh correctly on bbox changes and initialize with baked camera data when available.

Bug Fixes:
- Allow eagle-eye camera data to be refetched and repainted on every bbox or toggle change instead of short-circuiting after the first load.
- Consume and merge pending baked camera FeatureCollections when creating the eagle-eye source so pre-seeded cameras appear immediately.