### PR TITLE
crep: fix ProjectNycDc + LiveTransit map-prop (sources were MISSING)

### DIFF
--- a/components/crep/layers/live-transit-layer.tsx
+++ b/components/crep/layers/live-transit-layer.tsx
@@ -113,8 +113,20 @@ export function LiveTransitLayer({ map, visible, bbox, pollMs = 15_000, onSelect
       map.on("mouseleave", `${SOURCE_ID}-dot`, () => { map.getCanvas().style.cursor = "" })
     }
 
-    if ((map as any).isStyleLoaded?.()) addLayers()
-    else map.once("load", addLayers)
+    // Apr 23, 2026 — robust readiness: `isStyleLoaded()` can return false
+    // even when the map is fully interactive (e.g. during incremental
+    // style diffs). `once("load")` never fires if the "load" event
+    // already passed before we attached. Try both styledata + load +
+    // idle events so whichever fires first wins, then one immediate
+    // attempt in case all three already fired.
+    let fired = false
+    const once = () => { if (fired) return; fired = true; addLayers() }
+    if ((map as any).isStyleLoaded?.()) once()
+    map.once("load", once)
+    map.once("styledata", once)
+    map.once("idle", once)
+    // Immediate attempt — addLayers is idempotent (guarded by getSource)
+    try { once() } catch { /* map not ready yet, handlers will catch */ }
 
     return () => {
       try {

--- a/components/crep/layers/project-nyc-dc-layer.tsx
+++ b/components/crep/layers/project-nyc-dc-layer.tsx
@@ -92,15 +92,32 @@ const makeCategories = (region: "nyc" | "dc"): RegionCategory[] => [
   { id: `${region}Inat` as keyof Enabled,          file: `/data/crep/${region}-inat.geojson`,            layerId: `crep-${region}-inat`,          sourceId: `crep-${region}-inat-src`,          label: "Nature observations (iNat)", color: "#84cc16", selectType: "inat-observation", minzoom: 7 },
 ]
 
+// Apr 23, 2026 — Morgan: "massivly missing nature data in nyc also".
+// Root cause found in browser audit: CREPDashboardClient passes the
+// MapLibre instance DIRECTLY (stored in state, not a ref) to this
+// component, but the component did `map?.current` which returns
+// `undefined` for a Map instance — so every useEffect bailed before
+// adding sources. The regression silently dropped all 12 baked NYC/DC
+// layers (hospitals, police, sewage, cells, AM/FM, military, DCs,
+// transit subway/rail, airports, gov/embassy, iNat) for NYC AND DC.
+// We now accept EITHER a Map instance OR a RefObject<Map>.
+type MapOrRef = MapLibreMap | React.RefObject<MapLibreMap | null> | null
+function resolveMap(m: MapOrRef): MapLibreMap | null {
+  if (!m) return null
+  if (typeof (m as any).getZoom === "function") return m as MapLibreMap
+  const current = (m as React.RefObject<MapLibreMap | null>).current
+  return current ?? null
+}
+
 export interface ProjectNycDcLayerProps {
-  map: React.RefObject<MapLibreMap | null>
+  map: MapOrRef
   enabled: Enabled
 }
 
 export default function ProjectNycDcLayer({ map, enabled }: ProjectNycDcLayerProps) {
   // Anchor + perimeter + POIs for BOTH projects
   useEffect(() => {
-    const m = map?.current
+    const m = resolveMap(map)
     if (!m) return
     let cancelled = false
     const projects = [
@@ -219,7 +236,7 @@ export default function ProjectNycDcLayer({ map, enabled }: ProjectNycDcLayerPro
 
   // Regional OSM layers (NYC + DC)
   useEffect(() => {
-    const m = map?.current
+    const m = resolveMap(map)
     if (!m) return
     let cancelled = false
     const all = [...makeCategories("nyc"), ...makeCategories("dc")]


### PR DESCRIPTION
## Summary
After PRs #116/#117/#118 deployed, in-browser verification found three sources **still MISSING** on the live map: \`crep-live-transit\`, \`crep-nyc-inat\`, \`crep-dc-inat\`. Two different root causes.

### Bug A — ProjectNycDcLayer prop mismatch
Component expects \`map: React.RefObject<MapLibreMap | null>\` and does \`map?.current\`, but \`CREPDashboardClient\` passes the Map instance directly (state). A Map has no \`.current\` so every \`useEffect\` early-returned. All **12 baked regional layers per region** silently failed: NYC hospitals / police / sewage / cells / AM-FM / military / data centers / transit subway / rail / airports / gov-embassy / iNat. Zero \`[CREP/NYC-DC]\` logs because we returned before the log.

**Fix**: \`resolveMap(m)\` helper accepts both shapes — Map instance OR RefObject — and returns the Map. Applied at both \`useEffect\` entry points.

### Bug B — LiveTransitLayer stuck on \`map.once('load')\`
The MapLibre \`load\` event had already fired by the time our component mounted (parent's other layers ran first). \`once\` attaches after the event, never fires. Source never created.

**Fix**: race-style readiness — \`isStyleLoaded()\` OR \`load\` OR \`styledata\` OR \`idle\`, whichever fires first runs \`addLayers\`. \`addLayers\` is idempotent (guarded by \`getSource\`), plus one immediate attempt.

## Evidence
Browser audit on prod after prior 3 PRs deployed, NYC z=11:
```
sources populated:
  crep-live-aircraft   ✓ (9 features, 5 rendered)
  crep-live-vessels    ✓ (45, 36)
  crep-live-satellites ✓ (27)
  crep-eagle-cams      ✓ (3417, 711 rendered)
sources MISSING:
  crep-live-transit
  crep-nyc-inat
  crep-dc-inat
```

## Test plan
- [ ] NYC z=11: \`crep-nyc-inat\` loads 10k green iNat dots, click → species popup.
- [ ] DC z=11: \`crep-dc-inat\` same.
- [ ] NYC z=11: \`crep-live-transit\` loads MTA subway + bus dots every 15s (~2600 vehicles).
- [ ] Console: see \`[CREP/NYC-DC] crep-nyc-inat: 10000 loaded\` and similar for all 12 regional layer ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix CREP NYC/DC regional and live transit map layers failing to load due to map instance handling and map readiness issues.

Bug Fixes:
- Allow the ProjectNycDcLayer to work with both MapLibre map instances and ref objects so NYC/DC baked layers load correctly.
- Make LiveTransitLayer add its sources once the map style is ready using multiple readiness signals instead of relying solely on a single load event.