### PR TITLE
crep(eagle-eye): allow NYC DOT TMC cams as 511ny fallback

### DIFF
--- a/app/api/eagle/cam-image/route.ts
+++ b/app/api/eagle/cam-image/route.ts
@@ -64,6 +64,13 @@ const ALLOW_HOSTS = new Set([
   "chart.maryland.gov",
   "ddot.dc.gov",
   "dc.gov",
+  // Apr 23, 2026 — NYC DOT TMC cams (city-run, independent of NYSDOT
+  // 511ny.org). Added as a fallback because 511ny.org has been down for
+  // hours today returning HTTP 404 for every camera. NYC DOT's own
+  // system at webcams.nyctmc.org covers ~750 cams across all 5 boroughs,
+  // bridges, tunnels, highways. JPEG-per-cam (same format as state feeds).
+  "webcams.nyctmc.org",
+  "nyctmc.org",
   // MTA / Amtrak (for still-frames from subway / train cams)
   "web.mta.info",
   "mta.info",

--- a/components/crep/eagle-eye/VideoWallWidget.tsx
+++ b/components/crep/eagle-eye/VideoWallWidget.tsx
@@ -632,6 +632,11 @@ export default function VideoWallWidget() {
       // MDOT CHART: chart.maryland.gov/video/video.asp?feed=XX → /video/VideoStill.asp?feed=XX
       m = /chart\.maryland\.gov\/video\/video\.asp\?feed=(\w+)/i.exec(embed)
       if (m) return `/api/eagle/cam-image?url=${encodeURIComponent(`https://chart.maryland.gov/video/VideoStill.asp?feed=${m[1]}`)}`
+      // Apr 23, 2026 — NYC DOT TMC. Two URL shapes observed in the wild:
+      //   viewer: https://webcams.nyctmc.org/map/camera/{uuid}
+      //   image : https://webcams.nyctmc.org/api/cameras/{uuid}/image
+      m = /webcams\.nyctmc\.org\/(?:map\/camera|api\/cameras)\/([a-f0-9-]{36})/i.exec(embed)
+      if (m) return `/api/eagle/cam-image?url=${encodeURIComponent(`https://webcams.nyctmc.org/api/cameras/${m[1]}/image`)}`
       return null
     }
 


### PR DESCRIPTION
## Summary
Morgan: \"not one nysdot camera actually works\". Verified — 511ny.org is returning HTTP 404 for every camera right now (direct curl confirmed on 3344, 3388, etc.). 858 registered NYSDOT cams in our MINDEX are dead icons until they come back.

NYC DOT runs its **own** camera system at \`webcams.nyctmc.org\` — ~750 cameras across all 5 boroughs, bridges, tunnels, highways. Independent of the state 511ny feed.

## Changes
- \`app/api/eagle/cam-image/route.ts\` — add \`webcams.nyctmc.org\` + \`nyctmc.org\` to proxy allowlist
- \`components/crep/eagle-eye/VideoWallWidget.tsx\` — \`deriveStateDotSnapshot()\` rewrites two NYC TMC URL shapes:
  - viewer: \`https://webcams.nyctmc.org/map/camera/{uuid}\`
  - direct: \`https://webcams.nyctmc.org/api/cameras/{uuid}/image\`
  Both resolve to the canonical image URL via our proxy.

## Follow-ups (separate tasks)
- Cursor bakes \`public/data/crep/eagle-cameras-nyctmc.geojson\` registry with the 750 camera UUIDs + coordinates
- MINDEX Eagle Eye ingester fans out to \`webcams.nyctmc.org/api/cameras\` for live status polling
- Adds provider color entry (\`nyctmc: \"#fbbf24\"\` or similar) to the overlay legend

## Test plan
- [ ] \`/api/eagle/cam-image?url=https%3A%2F%2Fwebcams.nyctmc.org%2Fapi%2Fcameras%2F{uuid}%2Fimage\` returns a JPEG (once a UUID is known).
- [ ] Clicking a TMC-derived camera tile in the video wall shows the live-refreshing still.
- [ ] Non-NYC cams still route through their existing paths (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for NYC DOT TMC traffic cameras as a fallback image source for Eagle Eye when NYSDOT 511 feeds are unavailable.

New Features:
- Support NYC DOT TMC camera hosts in the Eagle cam-image proxy allowlist to fetch still images.
- Normalize NYC DOT TMC viewer and image URLs in the Eagle Eye video wall to the canonical proxied camera image endpoint.