### PR TITLE
crep(live-transit): resilient poll \u2014 wait for source + surface errors

### DIFF
--- a/components/crep/layers/live-transit-layer.tsx
+++ b/components/crep/layers/live-transit-layer.tsx
@@ -155,28 +155,69 @@ export function LiveTransitLayer({ map, visible, bbox, pollMs = 15_000, onSelect
     if (!map || !visible) return
     let cancelled = false
     let intervalId: any = null
-
+    // Apr 23, 2026 — Morgan (browser audit after PR #119 deployed):
+    // source "crep-live-transit" exists, /api/transit/all returns 3047 MTA
+    // vehicles for NYC bbox, but window.__crep_last_transit_count stayed
+    // undefined. That means the poll's try-block never reached the write.
+    //
+    // Likely race: `poll()` fires on mount BEFORE the add-layers effect
+    // (same component, different useEffect) actually creates the source.
+    // Previously we silently `return` when source is missing — permanent
+    // data loss if the source spawns *after* poll's first tick and before
+    // the 15s interval wraps. Worse: the silent `catch{}` hid every
+    // fetch / JSON / setData error too.
+    //
+    // New contract:
+    //   • `poll()` retries every 500 ms until the source exists (up to 30s)
+    //   • Any thrown error logs [CREP/LiveTransit] and counts toward a
+    //     breaker so we don't spam devtools if the endpoint is dead.
+    //   • Success writes window.__crep_last_transit_count + logs the first
+    //     successful paint count.
     const bboxStr = bbox ? bbox.join(",") : ""
+    const errCountRef = { v: 0 }
+    let firstLogged = false
+
+    const waitForSource = async (timeoutMs = 30_000): Promise<maplibregl.GeoJSONSource | null> => {
+      const start = Date.now()
+      while (Date.now() - start < timeoutMs) {
+        if (cancelled) return null
+        const s = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined
+        if (s) return s
+        await new Promise((r) => setTimeout(r, 500))
+      }
+      return null
+    }
 
     const poll = async () => {
       if (cancelled) return
       try {
         const url = `/api/transit/all${bboxStr ? `?bbox=${encodeURIComponent(bboxStr)}` : ""}`
         const r = await fetch(url, { signal: AbortSignal.timeout(15_000), cache: "no-store" })
-        if (!r.ok || cancelled) return
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
         const j = await r.json()
         if (cancelled) return
-        const src = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined
-        if (!src) return
+        const src = await waitForSource()
+        if (!src) throw new Error("source 'crep-live-transit' never appeared")
         src.setData({
           type: "FeatureCollection",
           features: Array.isArray(j?.features) ? j.features : [],
         })
+        errCountRef.v = 0
+        const n = j?.vehicles_total ?? j?.features?.length ?? 0
         if (typeof window !== "undefined") {
-          ;(window as any).__crep_last_transit_count = j?.vehicles_total ?? j?.features?.length ?? 0
+          ;(window as any).__crep_last_transit_count = n
         }
-      } catch {
-        // Silent — transient failure, try next tick.
+        if (!firstLogged) {
+          firstLogged = true
+          // eslint-disable-next-line no-console
+          console.log(`[CREP/LiveTransit] first paint: ${n} vehicles (bbox=${bboxStr || "global"})`)
+        }
+      } catch (e) {
+        errCountRef.v++
+        if (errCountRef.v <= 3) {
+          // eslint-disable-next-line no-console
+          console.warn(`[CREP/LiveTransit] poll ${errCountRef.v}:`, (e as Error)?.message)
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
Browser audit on prod after PR #119 deployed showed \`/api/transit/all?bbox=<NYC>\` returning **3047 MTA vehicles** but the MapLibre source staying at 0 features. Manual \`src.setData(...)\` from DevTools worked immediately — so addSource was fine but the poll wasn't landing data.

Two bugs the previous silent \`catch{}\` hid:

1. **Source race** — \`poll()\` fires on mount but \`addLayers()\` runs in a separate effect. If \`poll()\` beats \`addLayers()\`, \`map.getSource(\"crep-live-transit\")\` returns undefined, \`return\` early-bailed, the first 15 s tick was lost. Subsequent ticks *should* have worked, but any other error kept hiding behind \`catch{}\`.
2. **Silent catch** — every fetch / JSON / setData error disappeared with no signal.

## Fixes
- \`waitForSource(30 s)\` retries every 500 ms until the source exists, so \`poll()\` never bails on a race.
- Errors log \`[CREP/LiveTransit] poll N: <message>\` for the first 3 failures (then silent to avoid devtools spam). Any fix-or-regress will show up cleanly.
- First successful paint logs \`[CREP/LiveTransit] first paint: N vehicles (bbox=...)\` as a positive signal.

## Test plan
- [ ] NYC z=11: console shows \`[CREP/LiveTransit] first paint: ~3000 vehicles (bbox=-74.3,40.5,-73.7,40.9)\`.
- [ ] Source populates within 15 s; subway + bus dots visible on map.
- [ ] \`window.__crep_last_transit_count\` equals the server's \`vehicles_total\`.
- [ ] Pan to DC → new bbox triggers a refetch and dots shift to WMATA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve robustness and observability of the live transit polling layer to ensure data reliably reaches the map source and surfaces failures.

Bug Fixes:
- Prevent loss of the initial polling tick by waiting up to 30 seconds for the live transit map source to exist before setting data.
- Avoid silent failures in the live transit polling loop by surfacing HTTP, parsing, and source-availability errors with bounded console logging.

Enhancements:
- Track and log the first successful live transit paint with vehicle counts and bbox, and expose the last vehicle count via a window-global for easier verification.