### PR TITLE
crep(perf): PMTiles URLs \u2192 Cloudflare R2 CDN when NEXT_PUBLIC_TILES_CDN set

### DIFF
--- a/lib/crep/static-infra-loader.ts
+++ b/lib/crep/static-infra-loader.ts
@@ -112,6 +112,51 @@ export const INFRA_LAYERS: Record<string, InfraLayerConfig> = {
 }
 
 /**
+ * Apr 23, 2026 — Morgan: "scale up fast now with aws compute/gpu/extra vms".
+ * When Cursor's AWS MVT tile pipeline is live (see
+ * docs/CURSOR_AWS_MVT_TILE_PIPELINE.md), each layer's .pmtiles archive is
+ * baked nightly on 249 (or AWS g6.xlarge spot) and parked on Cloudflare R2
+ * at https://tiles.mycosoft.com. The CDN has zero egress cost and sits on
+ * every Cloudflare edge POP — pulling tiles from there is ~10 ms instead
+ * of ~500 ms through our origin `/api/crep/tiles/*` route.
+ *
+ * Set `NEXT_PUBLIC_TILES_CDN=https://tiles.mycosoft.com` (or a preview CDN)
+ * and we rewrite the PMTiles URLs to the CDN. If the env is unset, we fall
+ * back to the existing app-served path, which in turn falls back to GeoJSON
+ * when the pmtiles archive isn't published yet. No behavioural change until
+ * the CDN is live.
+ *
+ * Naming convention on the CDN (matches scripts/bake_mvt_tiles.sh output):
+ *   substations.pmtiles
+ *   transmission-major.pmtiles    (≥345 kV backbone)
+ *   transmission-full.pmtiles     (all voltages)
+ *   data-centers.pmtiles
+ *   power-plants.pmtiles
+ *   cell-towers.pmtiles           (global)
+ *   cell-towers-us-tw.pmtiles     (instant bundle)
+ */
+function resolvePmtilesUrl(appPath: string): string {
+  const cdn = (typeof process !== "undefined" && process.env?.NEXT_PUBLIC_TILES_CDN)?.trim()
+  if (!cdn) return appPath
+  // Pull the filename off the app path and serve it from the CDN root.
+  // Handles both /data/crep/tiles/foo.pmtiles and /api/crep/tiles/foo.pmtiles.
+  const fname = appPath.split("/").pop() || appPath
+  // Map old verbose filenames to the canonical CDN names the bake script
+  // produces. Unmapped → use the filename as-is (zero-config new layers).
+  const canonical: Record<string, string> = {
+    "substations-us.pmtiles": "substations.pmtiles",
+    "transmission-lines-us-major.pmtiles": "transmission-major.pmtiles",
+    "transmission-lines-us-full.pmtiles": "transmission-full.pmtiles",
+    "data-centers-global.pmtiles": "data-centers.pmtiles",
+    "power-plants-global.pmtiles": "power-plants.pmtiles",
+    "cell-towers-global.pmtiles": "cell-towers.pmtiles",
+    "cell-towers-us-tw-instant.pmtiles": "cell-towers-us-tw.pmtiles",
+  }
+  const mapped = canonical[fname] || fname
+  return `${cdn.replace(/\/$/, "")}/${mapped}`
+}
+
+/**
  * Probe whether a .pmtiles file is reachable (HEAD request).
  * 15-second in-memory memoization so we don't re-probe on every source add.
  */
@@ -156,13 +201,21 @@ export async function addInfraSourceWithFallback(
     return { mode: "skipped", sourceId: cfg.sourceId }
   }
 
-  // Prefer PMTiles when the archive is published
-  if (!opts?.forceGeoJSON && (await isPMTilesAvailable(cfg.pmtilesUrl))) {
+  // Prefer PMTiles when the archive is published. If the
+  // NEXT_PUBLIC_TILES_CDN env is set (Cloudflare R2 edge), fetch directly
+  // from the CDN — zero origin cost and ~10 ms edge latency vs ~500 ms
+  // through /api/crep/tiles/*. The client pmtiles library handles HTTP
+  // range requests natively.
+  const pmtilesUrl = resolvePmtilesUrl(cfg.pmtilesUrl)
+  if (!opts?.forceGeoJSON && (await isPMTilesAvailable(pmtilesUrl))) {
+    const absoluteUrl = /^https?:\/\//.test(pmtilesUrl)
+      ? pmtilesUrl
+      : new URL(pmtilesUrl, window.location.origin).toString()
     map.addSource(cfg.sourceId, {
       type: "vector",
-      url: `pmtiles://${new URL(cfg.pmtilesUrl, window.location.origin).toString()}`,
+      url: `pmtiles://${absoluteUrl}`,
     })
-    console.log(`[CREP/Infra] ${cfg.label}: PMTiles source added`)
+    console.log(`[CREP/Infra] ${cfg.label}: PMTiles source added (${/^https?:\/\//.test(pmtilesUrl) ? "CDN" : "origin"})`)
     return { mode: "pmtiles", sourceId: cfg.sourceId }
   }
 


### PR DESCRIPTION
## Summary
**PR #128** of the perf chain. Ready to merge the moment Cursor confirms R2 bucket + nightly bake are live (plan at \`docs/CURSOR_AWS_MVT_TILE_PIPELINE.md\`, Cursor tracking in \`.cursor/plans/aws_mvt_tile_pipeline_3d55b19d.plan.md\`).

Static-infra-loader already does PMTiles-first + GeoJSON fallback. This PR just adds a CDN rewrite: when \`NEXT_PUBLIC_TILES_CDN\` is set, the client requests \`.pmtiles\` directly from Cloudflare R2 at the edge (~10 ms) instead of tunneling through our origin \`/api/crep/tiles/*\` (~500 ms + bandwidth cost).

## Cost + latency
|  | Origin path | R2 + CDN |
|---|---|---|
| First byte | ~500 ms | ~10 ms (edge cache) |
| Egress | $$$ per GB | $0/GB (Cloudflare R2) |
| Origin CPU | per request | 0 |
| Cacheability | per-request | global edge pops |

## Change
- \`resolvePmtilesUrl(appPath)\` — reads \`NEXT_PUBLIC_TILES_CDN\` at call time. When set, takes the filename off the app path and rewrites to the CDN root using canonical names matching \`scripts/bake_mvt_tiles.sh\` output (\`substations-us.pmtiles\` → \`substations.pmtiles\`, etc.).
- \`addInfraSourceWithFallback()\` uses the resolved URL — absolute CDN URL goes through \`pmtiles://\` without re-rooting; relative origin path keeps existing \`new URL(..., window.location.origin)\` behaviour.
- Logs \`PMTiles source added (CDN)\` vs \`(origin)\` so Morgan can visually confirm edge cache is hit.

## Zero behaviour change until CDN is wired
The rewrite only fires when the env is set. Cursor's \`ensure_sandbox_lan_api_urls.py\` merges \`NEXT_PUBLIC_TILES_CDN=https://tiles.mycosoft.com\` once the R2 bucket + custom domain are up.

## Test plan (after deploy + CDN live)
- [ ] DevTools Network tab at page load: \`.pmtiles\` requests land on \`tiles.mycosoft.com\`, not \`mycosoft.com/api/crep/tiles/...\`.
- [ ] Each request has \`cf-cache-status: HIT\` after first warm.
- [ ] Console log: \`[CREP/Infra] US substations (HIFLD): PMTiles source added (CDN)\`.
- [ ] Falls back gracefully to origin path if CDN is unreachable (disable env var, verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route PMTiles layer requests through a configurable CDN when available to reduce latency and origin load while preserving existing behavior by default.

New Features:
- Add resolution of PMTiles URLs against a NEXT_PUBLIC_TILES_CDN environment variable to support serving tiles from a Cloudflare R2-backed CDN.
- Allow PMTiles vector sources to be loaded from either CDN or origin URLs based on availability and configuration, with explicit logging of the chosen path.

Enhancements:
- Preserve existing GeoJSON fallback behavior while conditionally preferring CDN-hosted PMTiles archives without changing behavior when the CDN is not configured.