### PR TITLE
CRITICAL: stop CREP auto-refreshing mid-session (dual-SW conflict)

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -263,7 +263,10 @@ import EagleEyeOverlay from "@/components/crep/layers/eagle-eye-overlay";
 import VideoWallWidget from "@/components/crep/eagle-eye/VideoWallWidget";
 import TimelineScrubber from "@/components/crep/eagle-eye/TimelineScrubber";
 import IntelFeedEagleEyeSection from "@/components/crep/eagle-eye/IntelFeedEagleEyeSection";
-import { RegisterCrepDataServiceWorker } from "@/components/crep/register-crep-data-sw";
+// Apr 23, 2026 — RegisterCrepDataServiceWorker removed, superseded by /crep-sw.js
+// (cache-first SW inline-registered in CREPDashboardPage). The old component
+// still exists at components/crep/register-crep-data-sw.tsx for any other
+// callers but is no longer imported here.
 import SunEarthImpactLayer from "@/components/crep/layers/sun-earth-impact-layer";
 // Realistic cloud rendering — Three.js volumetric + satellite-texture pipeline
 // driven by /api/eagle/weather/multi (Open-Meteo + NWS + Windy + OWM + Earth-2).
@@ -5587,7 +5590,13 @@ export default function CREPDashboardPage() {
 
   return (
     <div className="relative w-full h-dvh bg-[#0a1628] overflow-hidden flex flex-col">
-      <RegisterCrepDataServiceWorker />
+      {/* Apr 23, 2026 — <RegisterCrepDataServiceWorker /> removed. Its
+          /sw-crep-data.js fought with /crep-sw.js (both scope "/") and
+          caused auto-refreshes mid-session. The old SW is now a
+          self-unregistering stub (public/sw-crep-data.js) that drops
+          its cache and removes itself the next time a user hits the
+          page — after which only /crep-sw.js runs, which is the
+          unified cache for /data/crep + /crep/icons + /_next/static. */}
       {/* Top Classification Banner */}
       <div className="flex-shrink-0 flex justify-center py-1 bg-black/80 backdrop-blur-sm border-b border-amber-500/30 z-50">
         <Badge variant="outline" className="border-amber-500/50 text-amber-400 text-[9px] tracking-[0.15em] font-mono">

--- a/public/crep-sw.js
+++ b/public/crep-sw.js
@@ -52,10 +52,19 @@ function isCacheable(url) {
 }
 
 self.addEventListener("install", (event) => {
-  self.skipWaiting()
+  // Apr 23, 2026 — removed `skipWaiting()` (was tripping the auto-reload
+  // Morgan reported on prod). Without it, a NEW SW waits in the
+  // `installed` state until every tab controlled by the OLD SW closes.
+  // Tab refresh / navigation naturally picks up the new SW; nothing
+  // yanks control out from under an active session mid-click.
+  // If we ever need a forced update, it's one `navigator.serviceWorker
+  // .getRegistration().update()` call from the app, not automatic.
 })
 
 self.addEventListener("activate", (event) => {
+  // Apr 23, 2026 — removed `clients.claim()` for the same reason. The
+  // new SW only takes over clients that have navigated AFTER it
+  // activated. No forced hostile takeover of in-flight requests.
   event.waitUntil(
     caches
       .keys()
@@ -65,8 +74,7 @@ self.addEventListener("activate", (event) => {
             .filter((n) => n.startsWith("mycosoft-") && n !== CACHE_NAME)
             .map((n) => caches.delete(n)),
         ),
-      )
-      .then(() => self.clients.claim()),
+      ),
   )
 })
 

--- a/public/sw-crep-data.js
+++ b/public/sw-crep-data.js
@@ -1,25 +1,33 @@
-/* CREP static GeoJSON cache — Apr 17, 2026. Scope: /data/crep/* same-origin GET. */
-self.addEventListener("install", (e) => {
-  self.skipWaiting();
-});
+/**
+ * DEPRECATED — self-unregistering stub. Apr 23, 2026.
+ *
+ * Morgan: "why is local refreshing on its own still we cannot ever have
+ * that happen when a user is doing something using crep it makes the
+ * work go away".
+ *
+ * The narrow /data/crep/* cache this SW used to provide is now handled
+ * by /crep-sw.js (CREP SW v2, full scope: /data/crep/* + /crep/icons/*
+ * + /_next/static/*). Running both in parallel at scope "/" meant every
+ * deploy registered a new /crep-sw.js that called `skipWaiting()` +
+ * `clients.claim()` and stole control from the running /sw-crep-data.js,
+ * which occasionally tripped a Next.js chunk resolution failure and
+ * triggered the error-boundary's `window.location.reload()`.
+ *
+ * This file now exists only to cleanly retire the old registration for
+ * any browser that still has it installed. On install it drops its own
+ * cache and unregisters itself; after that the browser will only see
+ * /crep-sw.js and stop flipping controllers.
+ */
+self.addEventListener("install", () => {
+  self.skipWaiting()
+})
 self.addEventListener("activate", (e) => {
-  e.waitUntil(self.clients.claim());
-});
-const CACHE = "crep-geojson-v1";
-self.addEventListener("fetch", (e) => {
-  const u = new URL(e.request.url);
-  if (u.origin !== self.location.origin) return;
-  if (!u.pathname.startsWith("/data/crep/")) return;
-  if (e.request.method !== "GET") return;
-  e.respondWith(
-    caches.open(CACHE).then((cache) =>
-      cache.match(e.request).then((cached) => {
-        if (cached) return cached;
-        return fetch(e.request).then((res) => {
-          if (res.ok) cache.put(e.request, res.clone());
-          return res;
-        });
-      }),
-    ),
-  );
-});
+  e.waitUntil(
+    (async () => {
+      try { await caches.delete("crep-geojson-v1") } catch { /* ignore */ }
+      try { await self.registration.unregister() } catch { /* ignore */ }
+    })(),
+  )
+})
+// No fetch handler — all requests pass straight through to the network
+// (or the newer /crep-sw.js once it's in control).


### PR DESCRIPTION
## The bug
Morgan: \"why is local refreshing on its own still we cannot ever have that happen when a user is doing something using crep it makes the work go away\".

Two service workers registered at the same scope \`/\`:
- \`/sw-crep-data.js\` — Apr 17, narrow \`/data/crep/*\` cache
- \`/crep-sw.js\` — Apr 23 (PR #125), full scope

The new SW called \`skipWaiting()\` + \`clients.claim()\` on every deploy and stole control from the running old SW mid-session. In-flight Next.js dynamic chunk requests occasionally failed (the new SW didn't have a chunk the old SW was serving); the error boundary's fallback is \`window.location.reload()\`; user's work disappears.

## Fix
1. \`public/sw-crep-data.js\` → self-unregistering stub. On activate it drops its cache and calls \`self.registration.unregister()\`. Every client that still has it installed cleanly retires it on next page visit.
2. \`public/crep-sw.js\` → removed \`skipWaiting()\` + \`clients.claim()\`. A new SW now waits in \`installed\` state until existing tabs close or navigate. No mid-session controller flip.
3. \`app/dashboard/crep/CREPDashboardClient.tsx\` → dropped the old \`<RegisterCrepDataServiceWorker />\` render + import. The new inline SW registration remains the single source of truth.

## Why it was invisible before PR #125
The old \`sw-crep-data.js\` used the same aggressive pattern but was the ONLY SW at scope /, so no one stole control from it. PR #125 introduced the second SW, and the mutual stealing every deploy is what produced Morgan's auto-refresh.

## Test plan
- [ ] Deploy, hard-refresh once: the old SW unregisters itself in the background.
- [ ] Deploy a second time: no refresh, no toast, no visible change. Unsaved CREP state (drawn waypoints, open widgets, zoom) survives the deploy.
- [ ] DevTools → Application → Service Workers: only \`crep-sw.js\` registered at \`/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent CREP sessions from being interrupted by service worker controller flips during deploys by retiring the legacy data SW and letting the main CREP SW update only between sessions.

Bug Fixes:
- Stop mid-session auto-refresh and state loss caused by competing CREP service workers at the root scope during deployments.

Enhancements:
- Convert the legacy CREP data service worker into a self-unregistering stub that cleans up its cache and registration for existing clients.
- Rely solely on the unified crep-sw.js for CREP caching, avoiding aggressive skipWaiting/clients.claim takeover behavior.
- Remove the legacy CREP data service worker registration from the dashboard client so only the unified SW is used going forward.