### PR TITLE
crep: fetchWithTimeout helper + fix 7 critical hang sites (Vegas demo)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -218,4 +218,20 @@ METROLINK_API_KEY=
 # Dallas DART — Azure API Management gateway, subscription key header (register at dart.developer.azure-api.net/).
 DART_API_KEY=
 # No-key connectors (MTA / Amtrak plaintext / SEPTA) need no env.
+# AirNow (AQI — /api/crep/airnow/bbox). Free key: https://docs.airnowapi.org/account/request/
+# AIRNOW_API_KEY=
+
+# -----------------------------------------------------------------------------
+# CREP tile render pipeline (Apr 23, 2026)
+# PR #125 proxy calls Legion-hosted tile servers (port 8230):
+#   Earth-2 rasters   TILE_RENDER_EARTH2_URL   (e.g. 192.168.0.249:8230 — GPU_EARTH2_IP)
+#   Density heatmaps  TILE_RENDER_DENSITY_URL  (e.g. 192.168.0.241:8230 — GPU_VOICE_IP)
+# Cloudflare R2 CDN + PMTiles:
+#   TILE_RENDER_CDN_FALLBACK + NEXT_PUBLIC_TILES_CDN
+# (Copy real URLs from MAS / Sandbox docs; do not commit secrets.)
+# TILE_RENDER_EARTH2_URL=http://192.168.0.249:8230
+# TILE_RENDER_DENSITY_URL=http://192.168.0.241:8230
+# TILE_RENDER_CDN_FALLBACK=https://tiles.mycosoft.com
+# NEXT_PUBLIC_TILES_CDN=https://tiles.mycosoft.com
+# See MAS: docs/AWS_MVT_IAM_AND_BUDGET_CHECKLIST_APR24_2026.md
 # -----------------------------------------------------------------------------

--- a/components/crep/eagle-eye/TimelineScrubber.tsx
+++ b/components/crep/eagle-eye/TimelineScrubber.tsx
@@ -103,7 +103,11 @@ export default function TimelineScrubber() {
       if (typeof document !== "undefined" && document.hidden) return
       setLoading(true)
       try {
-        const res = await fetch(`/api/eagle/events?hoursBack=${hoursBack}&limit=5000`)
+        // Apr 23, 2026 audit: no timeout meant a stalled Eagle backend
+        // left this panel "Loading events…" forever. 12 s deadline.
+        const res = await fetch(`/api/eagle/events?hoursBack=${hoursBack}&limit=5000`, {
+          signal: AbortSignal.timeout(12_000),
+        })
         if (!res.ok) return
         const j = await res.json()
         if (!cancelled) {

--- a/components/crep/eagle-eye/VideoWallWidget.tsx
+++ b/components/crep/eagle-eye/VideoWallWidget.tsx
@@ -47,9 +47,19 @@ interface ActiveFeed {
 }
 
 async function resolveStream(sourceId: string): Promise<ResolvedStream> {
-  const res = await fetch(`/api/eagle/stream/${encodeURIComponent(sourceId)}`)
-  if (!res.ok) return { id: sourceId, provider: "unknown", kind: "permanent", stream_type: "iframe", error: `HTTP ${res.status}` }
-  return res.json()
+  // Apr 23, 2026 audit: no timeout on the stream resolver meant a slow
+  // Eagle Eye backend left every video tile stuck at "Loading stream".
+  // 8 s deadline; on timeout we fall through to iframe embed which at
+  // least lets the user click through to the provider site.
+  try {
+    const res = await fetch(`/api/eagle/stream/${encodeURIComponent(sourceId)}`, {
+      signal: AbortSignal.timeout(8_000),
+    })
+    if (!res.ok) return { id: sourceId, provider: "unknown", kind: "permanent", stream_type: "iframe", error: `HTTP ${res.status}` }
+    return res.json()
+  } catch (err) {
+    return { id: sourceId, provider: "unknown", kind: "permanent", stream_type: "iframe", error: (err as Error)?.message || "stream resolver timeout" }
+  }
 }
 
 function HlsPlayer({ url }: { url: string }) {

--- a/components/crep/panels/entity-detail-panel.tsx
+++ b/components/crep/panels/entity-detail-panel.tsx
@@ -435,7 +435,13 @@ function AircraftDetail({ aircraft, onClose }: { aircraft: AircraftEntity; onClo
     let cancelled = false;
     setHistoryLoading(true);
     const idForLookup = aircraft.callsign || aircraft.flightNumber || aircraft.id;
-    fetch(`/api/oei/flight-history/${encodeURIComponent(String(idForLookup))}`)
+    // Apr 23, 2026 audit: fetch had no timeout so the Flight History
+    // section would stay at "Loading…" indefinitely when flightradar24
+    // or ADS-B backend is slow. 10 s deadline guarantees the spinner
+    // always resolves (either data or empty state).
+    fetch(`/api/oei/flight-history/${encodeURIComponent(String(idForLookup))}`, {
+      signal: AbortSignal.timeout(10_000),
+    })
       .then((r) => (r.ok ? r.json() : null))
       .then((h) => { if (!cancelled) { setHistory(h); setHistoryLoading(false); } })
       .catch(() => { if (!cancelled) setHistoryLoading(false); });

--- a/contexts/myca-context.tsx
+++ b/contexts/myca-context.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import { useAuth } from "@/contexts/auth-context"
+import { fetchWithTimeout } from "@/lib/fetch-with-timeout"
 
 export interface MYCAMessage {
   id: string
@@ -197,7 +198,11 @@ export function MYCAProvider({
     async (message: MYCAMessage) => {
       if (!memoryEnabled || !sessionId) return
       try {
-        await fetch("/api/mas/memory", {
+        // Apr 23, 2026 audit: was `fetch()` without timeout. If MAS
+        // restarts mid-session, every user message would block the
+        // memory-store call forever. 5 s hard deadline; memory is
+        // best-effort so dropping a slow-write is fine.
+        await fetchWithTimeout("/api/mas/memory", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -211,6 +216,7 @@ export function MYCAProvider({
               ...message.metadata,
             },
           }),
+          timeoutMs: 5_000,
         })
       } catch (error) {
         console.error("Failed to store MYCA memory:", error)
@@ -357,7 +363,10 @@ export function MYCAProvider({
     async (transcript: string) => {
       if (!pendingConfirmationId) return
       try {
-        const response = await fetch("/api/mas/voice/confirm", {
+        // Apr 23, 2026 audit: was `fetch()` without timeout. If MAS is
+        // slow, the voice-confirm modal would hang with no recovery.
+        // 10 s deadline → user can retry.
+        const response = await fetchWithTimeout("/api/mas/voice/confirm", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -365,6 +374,7 @@ export function MYCAProvider({
             actor: "user",
             transcript,
           }),
+          timeoutMs: 10_000,
         })
 
         const data = await response.json()
@@ -405,10 +415,14 @@ export function MYCAProvider({
     async (targetConversationId: string) => {
       if (!targetConversationId) return
       try {
-        const response = await fetch("/api/myca/conversations", {
+        // Apr 23, 2026 audit: conversation loader had no timeout. The
+        // "Load conversation" menu would hang silently when MAS is busy.
+        // 8 s deadline; returns early on timeout so user can retry.
+        const response = await fetchWithTimeout("/api/myca/conversations", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ conversationId: targetConversationId }),
+          timeoutMs: 8_000,
         })
         if (!response.ok) return
         const data = await response.json()
@@ -446,7 +460,10 @@ export function MYCAProvider({
   const syncToMAS = useCallback(async () => {
     if (!sessionId || messages.length === 0) return
     try {
-      await fetch("/api/myca/sync", {
+      // Apr 23, 2026 audit: MAS sync had no timeout. Best-effort write
+      // so a 10 s cap is fine — if MAS is down the messages persist in
+      // localStorage anyway.
+      await fetchWithTimeout("/api/myca/sync", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -455,6 +472,7 @@ export function MYCAProvider({
           conversation_id: conversationId,
           messages,
         }),
+        timeoutMs: 10_000,
       })
     } catch (error) {
       console.error("Failed to sync MYCA messages:", error)

--- a/lib/fetch-with-timeout.ts
+++ b/lib/fetch-with-timeout.ts
@@ -1,0 +1,89 @@
+/**
+ * fetchWithTimeout — shared wrapper around `fetch` with a mandatory deadline.
+ * Apr 23, 2026.
+ *
+ * Audit finding (Apr 23, Morgan): 21+ `fetch()` calls in CREP / MYCA code
+ * paths lacked `AbortSignal.timeout()`, so any slow/hung upstream (MAS
+ * restart, MINDEX overload, 511ny outage, etc.) froze user-facing widgets
+ * with "Loading…" forever. The top offenders were the MYCA confirmAction /
+ * memory sync / conversation loader, VideoWallWidget stream resolver,
+ * flight-history panel, and Eagle Eye TimelineScrubber.
+ *
+ * This helper enforces a 10 s default deadline and merges any caller-
+ * supplied AbortSignal so consumers can still cancel early on unmount.
+ * It preserves the exact Response contract of native fetch — callers use
+ * it as a drop-in replacement without any response-shape changes.
+ *
+ * Usage:
+ *   import { fetchWithTimeout } from "@/lib/fetch-with-timeout"
+ *
+ *   const res = await fetchWithTimeout("/api/foo", { timeoutMs: 5_000 })
+ *   if (!res.ok) throw new Error(`HTTP ${res.status}`)
+ *
+ * Passing `timeoutMs: 0` disables the deadline (rare — only use for
+ * long-lived SSE / streaming bodies where you're explicitly relying on
+ * the server to close the connection).
+ */
+
+export interface FetchWithTimeoutOptions extends RequestInit {
+  /** Hard deadline in milliseconds. 0 = disabled. Default 10 000. */
+  timeoutMs?: number
+}
+
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init?: FetchWithTimeoutOptions,
+): Promise<Response> {
+  const timeoutMs = init?.timeoutMs ?? 10_000
+  if (timeoutMs <= 0) {
+    const { timeoutMs: _drop, ...rest } = init || {}
+    return fetch(input, rest)
+  }
+  // Compose a signal that aborts on (a) the caller's signal, or
+  // (b) our timeout — whichever fires first.
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(new Error(`timeout after ${timeoutMs}ms`)), timeoutMs)
+  const userSignal = init?.signal
+  const onUserAbort = () => controller.abort((userSignal as any)?.reason)
+  userSignal?.addEventListener("abort", onUserAbort)
+  try {
+    const { timeoutMs: _drop, signal: _s, ...rest } = init || {}
+    return await fetch(input, { ...rest, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+    userSignal?.removeEventListener("abort", onUserAbort)
+  }
+}
+
+/**
+ * Same contract but returns `null` on any error (HTTP error, abort,
+ * network failure). Use this in components where a failed upstream
+ * should just skip the feature silently (e.g. a sidebar tile that
+ * degrades to empty rather than breaking the whole page).
+ *
+ * Logs each failure to the console with a `[fetchOrNull]` tag so the
+ * developer can still find what's broken without the audit needing to
+ * grep for silent `catch {}` patterns.
+ */
+export async function fetchOrNull(
+  input: RequestInfo | URL,
+  init?: FetchWithTimeoutOptions,
+): Promise<Response | null> {
+  try {
+    const res = await fetchWithTimeout(input, init)
+    if (!res.ok) {
+      if (typeof console !== "undefined") {
+        // eslint-disable-next-line no-console
+        console.warn(`[fetchOrNull] ${typeof input === "string" ? input : input.toString()} → HTTP ${res.status}`)
+      }
+      return null
+    }
+    return res
+  } catch (err) {
+    if (typeof console !== "undefined") {
+      // eslint-disable-next-line no-console
+      console.warn(`[fetchOrNull] ${typeof input === "string" ? input : input.toString()} →`, (err as Error)?.message)
+    }
+    return null
+  }
+}


### PR DESCRIPTION
Audit surfaced 21+ bare \`fetch()\` calls with no timeout. Top 7 demo-killers fixed here:

**New helper**: \`lib/fetch-with-timeout.ts\` (\`fetchWithTimeout\` + \`fetchOrNull\`) — drop-in replacement, default 10s deadline.

**Fixed**:
- MYCA storeMemory / confirmAction / loadConversation / syncToMAS — MAS restart no longer hangs the chat panel
- VideoWallWidget resolveStream — fallbacks to iframe embed on timeout instead of infinite spinner
- EntityDetailPanel flight history — always resolves
- Eagle TimelineScrubber — stops "Loading events..." hang

Next follow-up migrates the ~15 remaining unprotected fetches in CREPDashboardClient.tsx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared fetch-with-timeout helper and apply timeouts to several high-impact CREP and MYCA network calls to prevent user-visible hangs.

New Features:
- Add a fetchWithTimeout helper with configurable deadlines and a fetchOrNull variant for best-effort requests.

Bug Fixes:
- Prevent MYCA memory storage, voice confirmation, conversation loading, and MAS sync operations from hanging indefinitely when upstream services stall.
- Ensure Eagle Eye TimelineScrubber and VideoWallWidget no longer remain stuck in perpetual loading states when the Eagle backend is slow or unresponsive.
- Guarantee the EntityDetailPanel flight history section resolves instead of showing an endless loading spinner when upstream flight data providers are slow.