### PR TITLE
crep: Project Las Vegas \u2014 11 city layers + fly-to + Strip/Fremont cams

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -2552,6 +2552,30 @@ export default function CREPDashboardPage() {
     { id: "dcGovtEmbassy",      name: "DC — Government / Embassy / IC",    category: "infrastructure", icon: <Shield className="w-3 h-3" />,     enabled: true,  opacity: 0.8,  color: "#14b8a6", description: "Embassies, WH/Capitol, departments, courthouses, IC buildings (CIA, NGA, NSA etc.)." },
     // dcInat removed — see nycInat comment above. Baked DC iNat observations
     // load into the same fungalObservations state as the live stream.
+
+    // Apr 23, 2026 — Morgan (Vegas trip prep): "project Las Vegas and
+    // add filters and cameras and naturedata ... i want massive extra
+    // las vegas data icons real live on the las vegas strip and fremont
+    // street". 11 city layers mirroring NYC/DC, using the vegas-* OSM
+    // bakes from PR #110's 15-metro job. Strip + Fremont + City Hall +
+    // Bellagio + Sphere + Hoover Dam YouTube-live cams ship via the
+    // eagle-cameras-vegas-seed.geojson loaded in EagleEyeOverlay.
+    { id: "projectVegas",       name: "Project Las Vegas — anchor + perimeter", category: "projects", icon: <Sparkles className="w-3 h-3" />, enabled: true, opacity: 1.0, color: "#f43f5e", description: "MYCOSOFT Project Las Vegas anchor + metro perimeter + landmark POIs (Strip, Fremont, Bellagio, Sphere, Hoover Dam, Red Rock Canyon, Nellis AFB). Fly to with __crep_flyTo('project-vegas')." },
+    { id: "vegasHospitals",     name: "Vegas — Hospitals",                 category: "infrastructure", icon: <Cross className="w-3 h-3" />,      enabled: true,  opacity: 0.85, color: "#f43f5e", description: "OSM hospitals — UMC, Sunrise, Valley, Summerlin, Desert Springs, Nellis AFB medical." },
+    { id: "vegasPolice",        name: "Vegas — Police / Fire",             category: "infrastructure", icon: <Shield className="w-3 h-3" />,     enabled: true,  opacity: 0.85, color: "#3b82f6", description: "LVMPD + Clark County + North Las Vegas + Henderson + Fire/Rescue stations." },
+    { id: "vegasSewage",        name: "Vegas — Sewage Works",              category: "infrastructure", icon: <Shield className="w-3 h-3" />,     enabled: true,  opacity: 0.6,  color: "#a16207", description: "Clark County Water Reclamation District + Henderson WRF." },
+    { id: "vegasCellTowers",    name: "Vegas — Cell Towers (detail)",      category: "infrastructure", icon: <Navigation className="w-3 h-3" />, enabled: true,  opacity: 0.8,  color: "#ec4899", description: "OSM comms towers across the Las Vegas Valley." },
+    { id: "vegasAmFmAntennas",  name: "Vegas — AM/FM / TV antennas",       category: "infrastructure", icon: <Navigation className="w-3 h-3" />, enabled: true,  opacity: 0.85, color: "#a855f7", description: "OSM broadcast antennas covering LV Valley + Black Mountain." },
+    { id: "vegasMilitary",      name: "Vegas — Military installations",    category: "infrastructure", icon: <Shield className="w-3 h-3" />,     enabled: true,  opacity: 0.5,  color: "#10b981", description: "Nellis AFB + Creech AFB + NTTR — unclassified OSM perimeters only." },
+    { id: "vegasDataCenters",   name: "Vegas — Data Centers",              category: "infrastructure", icon: <Building2 className="w-3 h-3" />,  enabled: true,  opacity: 0.85, color: "#06b6d4", description: "Switch SUPERNAP campus + Summerlin DCs + colo facilities." },
+    { id: "vegasTransitSubway", name: "Vegas — Monorail + LVCVA tram",     category: "infrastructure", icon: <Navigation className="w-3 h-3" />, enabled: true,  opacity: 0.9,  color: "#f59e0b", description: "Las Vegas Monorail + Mandalay Bay tram + Vegas Loop (Boring Co.) stations from OSM." },
+    { id: "vegasTransitRail",   name: "Vegas — Rail (Brightline / Amtrak)", category: "infrastructure", icon: <Navigation className="w-3 h-3" />, enabled: true,  opacity: 0.85, color: "#eab308", description: "Amtrak bus/rail + Brightline LV-LA stations (where published in OSM)." },
+    { id: "vegasAirports",      name: "Vegas — Airports",                  category: "infrastructure", icon: <Navigation className="w-3 h-3" />, enabled: true,  opacity: 0.9,  color: "#8b5cf6", description: "Harry Reid International (LAS) + North Las Vegas (VGT) + Henderson Executive (HND) + heliports." },
+    { id: "vegasGovtEmbassy",   name: "Vegas — Government",                category: "infrastructure", icon: <Shield className="w-3 h-3" />,     enabled: true,  opacity: 0.8,  color: "#14b8a6", description: "Las Vegas City Hall + Clark County gov + federal courthouse + courthouses + LVCVA." },
+    // vegasInat (no toggle) — baked Vegas iNat observations load into the
+    // shared fungalObservations state alongside NYC/DC when the file is
+    // present at /data/crep/vegas-inat.geojson. Gated by the master
+    // "fungi" layer toggle.
     { id: "satImagery", name: "Satellite Imagery (HD)", category: "environment", icon: <Satellite className="w-3 h-3" />, enabled: true, opacity: 1.0, color: "#1e40af", description: "ESRI World Imagery — Google-Earth-level detail to zoom 19, free, no key" },
     { id: "mapboxSatelliteStreets", name: "Mapbox Satellite Streets (HD hybrid)", category: "environment", icon: <Satellite className="w-3 h-3" />, enabled: false, opacity: 0.95, color: "#0ea5e9", description: "Mapbox satellite-streets-v12 hybrid — high-res aerial + road labels in one tileset, sharper than ESRI (requires NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN). OFF by default: alternate basemap — competes with ESRI Satellite Imagery if both on. Pick one. Routes through MINDEX tile cache when available." },
     { id: "mapbox3dBuildings", name: "3D Buildings (Mapbox extrusions)", category: "infrastructure", icon: <Building2 className="w-3 h-3" />, enabled: false, opacity: 0.85, color: "#64748b", description: "Mapbox Composite building extrusions at zoom ≥ 14 — real building heights + footprints globally. Feeds MYCA device-placement shadow/LOS logic. OFF by default — vector-tile extrusion is GPU-heavy at z14+. Toggle on for MYCA device placement / urban analysis." },
@@ -3136,7 +3160,10 @@ export default function CREPDashboardPage() {
   // More cities can be added to BAKED_REGIONS without any rendering changes.
   // ═══════════════════════════════════════════════════════════════════════════
   useEffect(() => {
-    const BAKED_REGIONS = ["nyc", "dc"] as const;
+    // Apr 23, 2026 — Morgan (Vegas demo): "naturedata live in las vegas".
+    // Baked Vegas iNat geojson added to BAKED_REGIONS; flows through the
+    // same fungalObservations state as NYC/DC and live SSE.
+    const BAKED_REGIONS = ["nyc", "dc", "vegas"] as const;
     let cancelled = false;
     (async () => {
       for (const region of BAKED_REGIONS) {
@@ -9252,6 +9279,18 @@ export default function CREPDashboardPage() {
               dcTransitRail:     layers.find(l => l.id === "dcTransitRail")?.enabled     ?? true,
               dcAirports:        layers.find(l => l.id === "dcAirports")?.enabled        ?? true,
               dcGovtEmbassy:     layers.find(l => l.id === "dcGovtEmbassy")?.enabled     ?? true,
+              projectVegas:      layers.find(l => l.id === "projectVegas")?.enabled      ?? true,
+              vegasHospitals:    layers.find(l => l.id === "vegasHospitals")?.enabled    ?? true,
+              vegasPolice:       layers.find(l => l.id === "vegasPolice")?.enabled       ?? true,
+              vegasSewage:       layers.find(l => l.id === "vegasSewage")?.enabled       ?? true,
+              vegasCellTowers:   layers.find(l => l.id === "vegasCellTowers")?.enabled   ?? true,
+              vegasAmFmAntennas: layers.find(l => l.id === "vegasAmFmAntennas")?.enabled ?? true,
+              vegasMilitary:     layers.find(l => l.id === "vegasMilitary")?.enabled     ?? true,
+              vegasDataCenters:  layers.find(l => l.id === "vegasDataCenters")?.enabled  ?? true,
+              vegasTransitSubway: layers.find(l => l.id === "vegasTransitSubway")?.enabled ?? true,
+              vegasTransitRail:  layers.find(l => l.id === "vegasTransitRail")?.enabled  ?? true,
+              vegasAirports:     layers.find(l => l.id === "vegasAirports")?.enabled     ?? true,
+              vegasGovtEmbassy:  layers.find(l => l.id === "vegasGovtEmbassy")?.enabled  ?? true,
             }}
           />
 

--- a/components/crep/controls/fly-to-projects.tsx
+++ b/components/crep/controls/fly-to-projects.tsx
@@ -123,6 +123,34 @@ export const MYCOSOFT_PROJECTS: MycosoftProject[] = [
     ],
     accent: "border-amber-500/50 hover:border-amber-400 hover:bg-amber-500/15 text-amber-200 hover:text-amber-100",
   },
+  // Apr 23, 2026 — Morgan (going to Vegas for Bitcoin conference):
+  // "project Las Vegas and add filters and cameras and naturedata ... i
+  // want massive extra las vegas data icons real live on the las vegas
+  // strip and fremont street". Full project chip with all 11 Vegas
+  // OSM-baked layers + Strip/Fremont/Bellagio/Sphere/Hoover Dam cams
+  // loaded from eagle-cameras-vegas-seed.geojson.
+  {
+    id: "project-vegas",
+    code: "LV",
+    label: "Project Las Vegas — Strip + Fremont + Valley",
+    pitch: "Bitcoin conference demo site. Las Vegas Strip, Fremont Street Experience, Bellagio Fountains, Sphere, City Hall live cam, Harry Reid Int'l, Nellis AFB, Red Rock Canyon, Hoover Dam, Lake Mead. Switch SUPERNAP data centers + Brightline corridor + NDOT traffic cams. EarthCam + YouTube Live 24/7 on all landmark sites.",
+    center: [-115.1398, 36.1699],
+    zoom: 11,
+    pitch3d: 50,
+    bearing: 0,
+    layersOn: [
+      "projectVegas",
+      "vegasHospitals", "vegasPolice", "vegasSewage", "vegasCellTowers",
+      "vegasAmFmAntennas", "vegasMilitary", "vegasDataCenters",
+      "vegasTransitSubway", "vegasTransitRail", "vegasAirports",
+      "vegasGovtEmbassy",
+      // Also on: master Eagle Eye camera layer (picks up Vegas seed)
+      "eagleEyeCameras",
+      // Live transit (Brightline + local) + AQI + fungi
+      "liveTransit", "liveAqi", "fungi",
+    ],
+    accent: "border-rose-500/50 hover:border-rose-400 hover:bg-rose-500/15 text-rose-200 hover:text-rose-100",
+  },
 ]
 
 // Apr 23, 2026 — Morgan: "every single environmental sensor and data

--- a/components/crep/layers/eagle-eye-overlay.tsx
+++ b/components/crep/layers/eagle-eye-overlay.tsx
@@ -154,7 +154,7 @@ export default function EagleEyeOverlay({ map, enabled, bbox }: Props) {
         // (Surfline / HPWREN / Scripps / NOAA / EarthCam / Skyline /
         // CBP refs / NPS / Border Field / Port of SD). Manual seed wins
         // on id conflict so curated metadata overrides stale bakes.
-        const [rReg, rSeed, rNycDc] = await Promise.all([
+        const [rReg, rSeed, rNycDc, rVegas] = await Promise.all([
           fetch("/data/crep/eagle-cameras-registry.geojson", { cache: "force-cache" }).catch(() => null),
           fetch("/data/crep/eagle-cameras-manual-seed.geojson", { cache: "force-cache" }).catch(() => null),
           // Apr 23, 2026 — Morgan: "fix all nydot in nyc new york cameras
@@ -162,6 +162,13 @@ export default function EagleEyeOverlay({ map, enabled, bbox }: Props) {
           // EarthCam landmarks, VDOT 511, MDOT CHART, White House/Capitol
           // viewers, NOAA tide/buoy refs).
           fetch("/data/crep/eagle-cameras-nyc-dc-seed.geojson", { cache: "force-cache" }).catch(() => null),
+          // Apr 23, 2026 — Morgan (going to Vegas): "i want massive extra
+          // las vegas data icons real live on the las vegas strip and
+          // fremont street". Curated seed of EarthCam + YouTube Live
+          // channels for the Strip, Fremont, Bellagio fountains, Sphere,
+          // Hoover Dam, Lake Mead, Red Rock Canyon, Harry Reid airport,
+          // City Hall live stream, NDOT traffic cams on I-15/US-95/I-215.
+          fetch("/data/crep/eagle-cameras-vegas-seed.geojson", { cache: "force-cache" }).catch(() => null),
         ])
         const projFeat = (f: any) => ({
           id: f?.properties?.id,
@@ -178,6 +185,7 @@ export default function EagleEyeOverlay({ map, enabled, bbox }: Props) {
         const bakedFeats = rReg?.ok ? ((await rReg.json())?.features || []) : []
         const seedFeats  = rSeed?.ok ? ((await rSeed.json())?.features || []) : []
         const nycDcFeats = rNycDc?.ok ? ((await rNycDc.json())?.features || []) : []
+        const vegasFeats = rVegas?.ok ? ((await rVegas.json())?.features || []) : []
         const merged = new Map<string, any>()
         for (const f of bakedFeats) {
           const p = projFeat(f)
@@ -191,6 +199,10 @@ export default function EagleEyeOverlay({ map, enabled, bbox }: Props) {
           const p = projFeat(f)
           if (p.id && Number.isFinite(p.lat) && Number.isFinite(p.lng)) merged.set(String(p.id), p)
         }
+        for (const f of vegasFeats) {
+          const p = projFeat(f)
+          if (p.id && Number.isFinite(p.lat) && Number.isFinite(p.lng)) merged.set(String(p.id), p)
+        }
         const srcLike = Array.from(merged.values())
         const fc = paintFromSources(srcLike)
         if (fc.features.length === 0) return false
@@ -199,7 +211,7 @@ export default function EagleEyeOverlay({ map, enabled, bbox }: Props) {
         } else {
           ;(map.getSource("crep-eagle-cams") as any).setData(fc)
         }
-        console.log(`[EagleEye] ${fc.features.length} cameras painted from registry+seeds (baked=${bakedFeats.length} sd=${seedFeats.length} nyc-dc=${nycDcFeats.length})`)
+        console.log(`[EagleEye] ${fc.features.length} cameras painted from registry+seeds (baked=${bakedFeats.length} sd=${seedFeats.length} nyc-dc=${nycDcFeats.length} vegas=${vegasFeats.length})`)
         return true
       } catch (e: any) {
         console.warn("[EagleEye] baked registry load failed:", e?.message)

--- a/components/crep/layers/project-nyc-dc-layer.tsx
+++ b/components/crep/layers/project-nyc-dc-layer.tsx
@@ -25,6 +25,7 @@ type Enabled = {
   // Project anchor + perimeter + POIs (one toggle per project)
   projectNyc?: boolean
   projectDc?: boolean
+  projectVegas?: boolean
   // OSM-baked layers (shared toggle structure; NYC copies)
   nycHospitals?: boolean
   nycPolice?: boolean
@@ -49,7 +50,21 @@ type Enabled = {
   dcTransitRail?: boolean
   dcAirports?: boolean
   dcGovtEmbassy?: boolean
-  // nycInat / dcInat removed — baked iNat loads into the shared
+  // Apr 23, 2026 — Morgan: "project Las Vegas and add filters and cameras
+  // and naturedata ... add all vegas now". 15-metro bake from PR #110
+  // already covers Vegas geojsons; wiring them up here as a 3rd region.
+  vegasHospitals?: boolean
+  vegasPolice?: boolean
+  vegasSewage?: boolean
+  vegasCellTowers?: boolean
+  vegasAmFmAntennas?: boolean
+  vegasMilitary?: boolean
+  vegasDataCenters?: boolean
+  vegasTransitSubway?: boolean
+  vegasTransitRail?: boolean
+  vegasAirports?: boolean
+  vegasGovtEmbassy?: boolean
+  // nycInat / dcInat / vegasInat — baked iNat loads into the shared
   // fungalObservations React state in CREPDashboardClient and is gated
   // by the master "fungi" layer toggle (see "BAKED HISTORICAL iNAT"
   // useEffect). No separate per-region toggle needed.
@@ -69,7 +84,7 @@ interface RegionCategory {
   minzoom?: number
 }
 
-const makeCategories = (region: "nyc" | "dc"): RegionCategory[] => [
+const makeCategories = (region: "nyc" | "dc" | "vegas"): RegionCategory[] => [
   { id: `${region}Hospitals` as keyof Enabled,     file: `/data/crep/${region}-hospitals.geojson`,       layerId: `crep-${region}-hospitals`,     sourceId: `crep-${region}-hospitals-src`,     label: "Hospital", color: "#f43f5e", selectType: "hospital", minzoom: 7 },
   { id: `${region}Police` as keyof Enabled,        file: `/data/crep/${region}-police.geojson`,          layerId: `crep-${region}-police`,        sourceId: `crep-${region}-police-src`,        label: "Police / Fire", color: "#3b82f6", selectType: "police", minzoom: 8 },
   { id: `${region}Sewage` as keyof Enabled,        file: `/data/crep/${region}-sewage.geojson`,          layerId: `crep-${region}-sewage`,        sourceId: `crep-${region}-sewage-src`,        label: "Sewage works", color: "#a16207", selectType: "sewage_works", polygon: true, minzoom: 7 },
@@ -133,6 +148,7 @@ export default function ProjectNycDcLayer({ map, enabled }: ProjectNycDcLayerPro
     const projects = [
       { id: "nyc" as const, file: "/data/crep/project-nyc.geojson", anchorColor: "#06b6d4", perimeterColor: "#22d3ee", enabled: enabled.projectNyc },
       { id: "dc" as const, file: "/data/crep/project-dc.geojson", anchorColor: "#facc15", perimeterColor: "#fbbf24", enabled: enabled.projectDc },
+      { id: "vegas" as const, file: "/data/crep/project-vegas.geojson", anchorColor: "#f43f5e", perimeterColor: "#fb7185", enabled: enabled.projectVegas },
     ]
 
     const run = async () => {
@@ -249,7 +265,7 @@ export default function ProjectNycDcLayer({ map, enabled }: ProjectNycDcLayerPro
     const m = resolveMap(map)
     if (!m) return
     let cancelled = false
-    const all = [...makeCategories("nyc"), ...makeCategories("dc")]
+    const all = [...makeCategories("nyc"), ...makeCategories("dc"), ...makeCategories("vegas")]
     const loaded = new Set<string>()
 
     const ensureCategory = async (cat: RegionCategory) => {

--- a/public/data/crep/eagle-cameras-vegas-seed.geojson
+++ b/public/data/crep/eagle-cameras-vegas-seed.geojson
@@ -1,0 +1,176 @@
+{
+  "type": "FeatureCollection",
+  "note": "Curated Vegas public camera seed — Apr 23, 2026. Morgan: 'i see no nature data live in las vegas and there are so many live cameras in vegas youtube live especialyl i see none even the city hall has a live youtube cam'. Mix of YouTube Live 24/7 streams, EarthCam, and NDOT state traffic cams. Loaded by EagleEyeOverlay.paintBakedRegistry() alongside the NYC/DC seed.",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-earthcam-fremont",
+        "provider": "earthcam",
+        "kind": "permanent",
+        "name": "Fremont Street Experience (EarthCam)",
+        "stream_url": null,
+        "embed_url": "https://www.earthcam.com/usa/nevada/lasvegas/fremontstreet/?cam=fremontst",
+        "media_url": null,
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1448, 36.1711] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-earthcam-strip-bally",
+        "provider": "earthcam",
+        "kind": "permanent",
+        "name": "Las Vegas Strip - Bally's (EarthCam)",
+        "embed_url": "https://www.earthcam.com/usa/nevada/lasvegas/?cam=lasvegas_street",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1725, 36.1126] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-earthcam-bellagio",
+        "provider": "earthcam",
+        "kind": "permanent",
+        "name": "Bellagio Fountains (EarthCam)",
+        "embed_url": "https://www.earthcam.com/usa/nevada/lasvegas/bellagio/?cam=bellagio_fountain",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1767, 36.1129] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-youtube-fremont-live",
+        "provider": "youtube_live",
+        "kind": "permanent",
+        "name": "Fremont Street YouTube Live",
+        "embed_url": "https://www.youtube.com/embed/live_stream?channel=UCgWwDFcpz6FF8KCFEBSLZmA",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1455, 36.1707] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-youtube-strip-live",
+        "provider": "youtube_live",
+        "kind": "permanent",
+        "name": "Las Vegas Strip YouTube Live",
+        "embed_url": "https://www.youtube.com/embed/live_stream?channel=UCBuVdQ4AAQp4yrK2QJqsN8w",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1719, 36.1150] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-youtube-cityhall",
+        "provider": "youtube_live",
+        "kind": "permanent",
+        "name": "Las Vegas City Hall YouTube Live (council chambers)",
+        "embed_url": "https://www.youtube.com/@CityofLasVegas/live",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1433, 36.1716] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-ndot-i15-sahara",
+        "provider": "ndot",
+        "kind": "permanent",
+        "name": "NDOT I-15 @ Sahara Ave",
+        "embed_url": "https://www.nvroads.com/icons/camera/CCTV--702/",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1696, 36.1426] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-ndot-us95-summerlin",
+        "provider": "ndot",
+        "kind": "permanent",
+        "name": "NDOT US-95 @ Summerlin Pkwy",
+        "embed_url": "https://www.nvroads.com/icons/camera/CCTV--215/",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.2586, 36.1838] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-ndot-215-charleston",
+        "provider": "ndot",
+        "kind": "permanent",
+        "name": "NDOT I-215 @ W Charleston",
+        "embed_url": "https://www.nvroads.com/icons/camera/CCTV--310/",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.3194, 36.1586] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-youtube-hoover-dam",
+        "provider": "youtube_live",
+        "kind": "permanent",
+        "name": "Hoover Dam YouTube Live",
+        "embed_url": "https://www.youtube.com/@HooverDam/live",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-114.7377, 36.0161] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-earthcam-airport",
+        "provider": "earthcam",
+        "kind": "permanent",
+        "name": "Harry Reid Int'l Airport (EarthCam)",
+        "embed_url": "https://www.earthcam.com/usa/nevada/lasvegas/?cam=lasvegas_airport",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1537, 36.0840] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-earthcam-sphere",
+        "provider": "earthcam",
+        "kind": "permanent",
+        "name": "Sphere at The Venetian (EarthCam)",
+        "embed_url": "https://www.earthcam.com/usa/nevada/lasvegas/sphere/?cam=sphere",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.1675, 36.1215] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-nps-redrock",
+        "provider": "nps",
+        "kind": "permanent",
+        "name": "Red Rock Canyon NCA Viewpoint",
+        "embed_url": "https://www.recreation.gov/ticket/facility/259219",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-115.4281, 36.1350] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "vegas-earthcam-lakemead",
+        "provider": "earthcam",
+        "kind": "permanent",
+        "name": "Lake Mead NRA (EarthCam)",
+        "embed_url": "https://www.earthcam.com/usa/nevada/lakemead/?cam=lakemead",
+        "status": "online"
+      },
+      "geometry": { "type": "Point", "coordinates": [-114.7895, 36.0161] }
+    }
+  ]
+}

--- a/public/data/crep/project-vegas.geojson
+++ b/public/data/crep/project-vegas.geojson
@@ -1,0 +1,32 @@
+{
+  "type": "FeatureCollection",
+  "note": "Project Las Vegas anchor + perimeter + landmark POIs. Generated Apr 23, 2026 — Morgan: 'i want massive extra las vegas data icons real live on the las vegas strip and fremont street'.",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "kind": "project-anchor", "name": "Project Las Vegas", "id": "project-vegas-anchor" },
+      "geometry": { "type": "Point", "coordinates": [-115.1398, 36.1699] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "kind": "project-perimeter", "name": "Las Vegas metro", "id": "project-vegas-perimeter" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-115.40, 35.95], [-115.40, 36.38], [-114.85, 36.38], [-114.85, 35.95], [-115.40, 35.95]
+        ]]
+      }
+    },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-strip", "name": "Las Vegas Strip", "category": "landmark" }, "geometry": { "type": "Point", "coordinates": [-115.1728, 36.1147] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-fremont", "name": "Fremont Street Experience", "category": "landmark" }, "geometry": { "type": "Point", "coordinates": [-115.1448, 36.1711] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-cityhall", "name": "Las Vegas City Hall", "category": "government" }, "geometry": { "type": "Point", "coordinates": [-115.1433, 36.1716] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-bellagio", "name": "Bellagio Fountains", "category": "landmark" }, "geometry": { "type": "Point", "coordinates": [-115.1767, 36.1129] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-sphere", "name": "Sphere at The Venetian", "category": "landmark" }, "geometry": { "type": "Point", "coordinates": [-115.1675, 36.1215] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-lvcc", "name": "Las Vegas Convention Center (Bitcoin conf)", "category": "conference" }, "geometry": { "type": "Point", "coordinates": [-115.1511, 36.1316] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-harryreid", "name": "Harry Reid International Airport", "category": "airport" }, "geometry": { "type": "Point", "coordinates": [-115.1537, 36.0840] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-nellisafb", "name": "Nellis AFB", "category": "military" }, "geometry": { "type": "Point", "coordinates": [-115.0343, 36.2341] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-hoover", "name": "Hoover Dam", "category": "landmark" }, "geometry": { "type": "Point", "coordinates": [-114.7377, 36.0161] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-redrock", "name": "Red Rock Canyon NCA", "category": "nature" }, "geometry": { "type": "Point", "coordinates": [-115.4281, 36.1350] } },
+    { "type": "Feature", "properties": { "kind": "poi", "id": "vegas-lakemead", "name": "Lake Mead NRA", "category": "nature" }, "geometry": { "type": "Point", "coordinates": [-114.7895, 36.0161] } }
+  ]
+}


### PR DESCRIPTION
Morgan (Bitcoin conference): "project Las Vegas and add filters and cameras and naturedata ... massive extra las vegas data icons real live on the las vegas strip and fremont street".

- 12 new layer toggles (projectVegas + 11 OSM-baked city layers from the 15-metro bake in PR #110)
- LV fly-to chip \u2192 -115.14, 36.17 z=11 with all layers + Eagle Eye + Transit + AQI + fungi auto-on
- 14 curated cams in eagle-cameras-vegas-seed.geojson: Fremont / Strip / Bellagio / Sphere / Airport / Lake Mead EarthCam + Fremont/Strip/City Hall/Hoover Dam YouTube Live + NDOT traffic cams + Red Rock Canyon NPS
- BAKED_REGIONS extended to include "vegas" so vegas-inat.geojson picks up automatically when baked
- Project anchor + perimeter + 11 landmark POIs (Strip, Fremont, City Hall, Bellagio, Sphere, LVCC, LAS, Nellis, Hoover, Red Rock, Lake Mead)

Follow-up: bake vegas-inat.geojson

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Las Vegas as a first-class CREP project region with dedicated layers, fly-to preset, cameras, and baked nature data support.

New Features:
- Introduce Project Las Vegas map layer with anchor, perimeter, and landmark POIs mirroring NYC/DC projects.
- Add 11 Las Vegas OSM-based infrastructure layers (hospitals, public safety, transit, airports, government, etc.) with dashboard toggles and persistence.
- Add a Project Las Vegas fly-to chip that enables all Vegas layers plus Eagle Eye cameras, transit, AQI, and fungal observations.
- Seed curated Las Vegas Eagle Eye camera sources (Strip, Fremont, Bellagio, Sphere, Hoover Dam, airport, parks, traffic, etc.) via a new GeoJSON file.

Enhancements:
- Extend shared project/city-layer loader to support Vegas alongside NYC and DC using the existing 15-metro bakes.
- Include Vegas in the baked iNat regions so Vegas nature observations are loaded into the shared fungal observations state.