### PR TITLE
feat(edge): migrate process-telemetry to @supabase/server (pilot)

### DIFF
--- a/supabase/functions/process-telemetry/MIGRATION.md
+++ b/supabase/functions/process-telemetry/MIGRATION.md
@@ -1,0 +1,75 @@
+# `process-telemetry` — migration to `@supabase/server`
+
+Pilot migration for the new [`@supabase/server`](https://supabase.com/blog/supabase-server) package. Replaces hand-rolled JWT verification, CORS, and client setup with the `withSupabase` wrapper.
+
+## What changed
+
+| Before | After |
+|---|---|
+| `createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)` for every call | `ctx.supabase` (user-scoped, RLS-aware) for reads, `ctx.supabaseAdmin` (service role) only for writes |
+| Manual `OPTIONS` preflight handler | Handled by `withSupabase` via `cors` option |
+| No JWT verification — anyone with the function URL could write | `auth: ["user", "secret"]` — accepts a real user JWT or a Supabase secret key |
+| No device ownership check | When called as a user, we verify the device is visible under the user's RLS before inserting |
+| `SUPABASE_SERVICE_ROLE_KEY` env var | Reads new keys (`SUPABASE_PUBLISHABLE_KEYS`, `SUPABASE_SECRET_KEYS`, `SUPABASE_JWKS`) — populated automatically on Supabase platform |
+
+## Caller impact
+
+- **Dashboard / website (user JWT):** No code change required. The existing `Authorization: Bearer <jwt>` header already works.
+- **MycoBrain devices / backend cron:** Must send `Authorization: Bearer <secret_key>` instead of the legacy service-role key. Rotate device firmware to use the new secret key generated in Supabase Dashboard → Settings → API. Until rotation completes, the legacy service-role key continues to work as a secret key.
+- **Anonymous callers:** No longer accepted. Previously the function would happily write with the service role from any caller; now requests without a verified user JWT or secret key get a 401 from `withSupabase`.
+
+## Prerequisites
+
+1. Asymmetric JWT signing keys must be enabled on the project. Check **Dashboard → Settings → API → JWT Signing Keys**. If only legacy HS256 keys are present, generate the new asymmetric keys before deploying.
+2. New API keys (`SUPABASE_PUBLISHABLE_KEYS`, `SUPABASE_SECRET_KEYS`, `SUPABASE_JWKS`) are populated by the Supabase platform automatically. No manual secret config required.
+
+## Deploy
+
+```bash
+cd supabase/functions/process-telemetry
+supabase functions deploy process-telemetry --project-ref hnevnsxnhfibhbsipqvz
+```
+
+## Smoke tests
+
+```bash
+FN_URL="https://hnevnsxnhfibhbsipqvz.supabase.co/functions/v1/process-telemetry"
+
+# 1. Anonymous → expect 401
+curl -i -X POST "$FN_URL" -d '{}'
+
+# 2. With a user JWT → expect 200 if device is owned by user, 403 if not
+curl -i -X POST "$FN_URL" \
+  -H "Authorization: Bearer $USER_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"device_id": "<owned-device-uuid>", "telemetry_data": {"temp": 22.1}}'
+
+# 3. With a Supabase secret key (device path) → expect 200
+curl -i -X POST "$FN_URL" \
+  -H "Authorization: Bearer $SUPABASE_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"device_id": "<any-device-uuid>", "telemetry_data": {"temp": 22.1}}'
+
+# 4. CORS preflight → expect 200 with Access-Control-* headers
+curl -i -X OPTIONS "$FN_URL" \
+  -H "Origin: https://mycosoft.org" \
+  -H "Access-Control-Request-Method: POST"
+```
+
+## Rollback
+
+This change is contained to `supabase/functions/process-telemetry/index.ts`. If anything regresses, revert the file and redeploy:
+
+```bash
+git revert <commit-sha>
+supabase functions deploy process-telemetry --project-ref hnevnsxnhfibhbsipqvz
+```
+
+The legacy service-role key continues to work for at least one full deprecation window from Supabase, so rollback does not require key rotation.
+
+## Follow-ups (separate PRs)
+
+- Apply the same pattern to `generate-embeddings` (`auth: 'user'`).
+- New `stripe-webhooks` function — `auth: 'none'` because Stripe signs the body itself; verify the Stripe signature in the handler before touching `ctx.supabaseAdmin`.
+- New `sync-mindex` function — `auth: 'secret'` for cron / server-to-server.
+- Tighten CORS `origin` from `*` to known dashboard + device origins.

--- a/supabase/functions/process-telemetry/index.ts
+++ b/supabase/functions/process-telemetry/index.ts
@@ -1,92 +1,102 @@
 /**
  * Supabase Edge Function: Process Telemetry
- * 
- * Processes incoming telemetry data from MycoBrain devices
+ *
+ * Processes incoming telemetry data from MycoBrain devices.
+ *
+ * Auth model:
+ *  - `user`   → an end user (e.g. dashboard) submitting telemetry on behalf of a device they own
+ *  - `secret` → a MycoBrain device or backend agent using a Supabase secret key (server-to-server)
+ *
+ * `withSupabase` handles:
+ *  - JWT verification (asymmetric signing keys, JWKS)
+ *  - Claims parsing
+ *  - CORS (preflight + response headers)
+ *  - User-scoped client (`ctx.supabase`, RLS-aware)
+ *  - Admin client (`ctx.supabaseAdmin`, service role)
+ *
+ * Env (provided automatically on the Supabase platform):
+ *   SUPABASE_URL, SUPABASE_PUBLISHABLE_KEYS, SUPABASE_SECRET_KEYS, SUPABASE_JWKS
  */
 
 import "jsr:@supabase/functions-js/edge-runtime.d.ts"
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { withSupabase } from "npm:@supabase/server@latest"
 
-const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+Deno.serve(
+  withSupabase(
+    {
+      auth: ["user", "secret"],
+      // Tighten this to known origins once we audit dashboard + device callers.
+      cors: { origin: "*", methods: ["POST", "OPTIONS"] },
+    },
+    async (req, ctx) => {
+      if (req.method !== "POST") {
+        return Response.json({ error: "Method not allowed" }, { status: 405 })
+      }
 
-Deno.serve(async (req: Request) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 200,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-      },
-    })
-  }
-  
-  if (req.method !== 'POST') {
-    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
-  
-  try {
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-    const { device_id, telemetry_data } = await req.json()
-    
-    if (!device_id) {
-      return new Response(
-        JSON.stringify({ error: 'device_id is required' }),
-        { status: 400, headers: { 'Content-Type': 'application/json' } }
-      )
-    }
-    
-    // Insert telemetry data
-    const { data, error } = await supabase
-      .from('telemetry')
-      .insert({
-        device_id,
-        ...telemetry_data,
-        timestamp: new Date().toISOString(),
-      })
-      .select()
-      .single()
-    
-    if (error) {
-      throw error
-    }
-    
-    // Update device last_seen
-    await supabase
-      .from('devices')
-      .update({ last_seen: new Date().toISOString() })
-      .eq('id', device_id)
-    
-    return new Response(
-      JSON.stringify({
+      let payload: { device_id?: string; telemetry_data?: Record<string, unknown> }
+      try {
+        payload = await req.json()
+      } catch {
+        return Response.json({ error: "Invalid JSON body" }, { status: 400 })
+      }
+
+      const { device_id, telemetry_data } = payload
+      if (!device_id) {
+        return Response.json({ error: "device_id is required" }, { status: 400 })
+      }
+
+      // If a real user is calling, ensure they own this device. RLS on `devices`
+      // should enforce this too, but failing fast here gives a cleaner error.
+      if (ctx.authMode === "user") {
+        const { data: device, error: ownerErr } = await ctx.supabase
+          .from("devices")
+          .select("id")
+          .eq("id", device_id)
+          .maybeSingle()
+
+        if (ownerErr) {
+          console.error("device ownership check failed:", ownerErr)
+          return Response.json({ error: "Device lookup failed" }, { status: 500 })
+        }
+        if (!device) {
+          return Response.json({ error: "Device not found or not accessible" }, { status: 403 })
+        }
+      }
+
+      // Writes go through the admin client so telemetry inserts are not blocked
+      // by user RLS, while reads above remain user-scoped.
+      const now = new Date().toISOString()
+
+      const { data, error } = await ctx.supabaseAdmin
+        .from("telemetry")
+        .insert({
+          device_id,
+          ...(telemetry_data ?? {}),
+          timestamp: now,
+        })
+        .select("id")
+        .single()
+
+      if (error) {
+        console.error("telemetry insert failed:", error)
+        return Response.json({ error: error.message }, { status: 500 })
+      }
+
+      const { error: deviceUpdateErr } = await ctx.supabaseAdmin
+        .from("devices")
+        .update({ last_seen: now })
+        .eq("id", device_id)
+
+      if (deviceUpdateErr) {
+        // Non-fatal: telemetry is recorded, last_seen is best-effort.
+        console.warn("devices.last_seen update failed:", deviceUpdateErr)
+      }
+
+      return Response.json({
         success: true,
         telemetry_id: data.id,
-      }),
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
-        },
-      }
-    )
-  } catch (error) {
-    console.error('Error processing telemetry:', error)
-    return new Response(
-      JSON.stringify({
-        error: error instanceof Error ? error.message : 'Internal server error',
-      }),
-      {
-        status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
-        },
-      }
-    )
-  }
-})
+        auth_mode: ctx.authMode,
+      })
+    },
+  ),
+)


### PR DESCRIPTION
## Summary

Pilot migration for the new [`@supabase/server`](https://supabase.com/blog/supabase-server) package (public beta). Replaces hand-rolled JWT verification, CORS handling, and client setup in the `process-telemetry` Edge Function with the `withSupabase()` wrapper.

This is the first of a planned multi-PR rollout — see `supabase_server_integration_plan.md`. Follow-ups (`generate-embeddings`, `stripe-webhooks`, `sync-mindex`) will land as separate PRs once this one bakes in production for ~24h.

## What changed

- `supabase/functions/process-telemetry/index.ts` now uses `withSupabase({ auth: ['user', 'secret'] })`.
- **Reads** (device ownership check) go through `ctx.supabase` (RLS-aware).
- **Writes** (telemetry insert, `devices.last_seen` update) go through `ctx.supabaseAdmin`.
- CORS preflight handled by `withSupabase`.
- New auth behavior: **anonymous callers now get 401** (previously the function silently wrote with the service role for any caller — a security gap this PR closes).

## Caller impact

- **Dashboard / website (user JWT):** no change required.
- **MycoBrain devices / backend cron:** switch `Authorization` header from the legacy service-role key to a Supabase secret key. The legacy service-role key continues to work during the deprecation window, so this is non-breaking on day one.
- **Anonymous callers:** no longer accepted.

## Prerequisites

- Asymmetric JWT signing keys enabled on project `hnevnsxnhfibhbsipqvz` (Dashboard → Settings → API → JWT Signing Keys).
- `SUPABASE_PUBLISHABLE_KEYS`, `SUPABASE_SECRET_KEYS`, `SUPABASE_JWKS` are populated automatically on the platform — no manual secret config needed.

## Smoke tests

See `supabase/functions/process-telemetry/MIGRATION.md` for the four-test matrix (anonymous → 401, user JWT → 200/403, secret key → 200, OPTIONS preflight → 200).

## Rollback

Single-file change. Revert the commit and redeploy. Legacy keys remain valid throughout, so rollback does not require key rotation.

## Risk

**Low.** This function processes non-critical MycoBrain telemetry. Rollout plan: deploy to staging → 24h soak → promote.

## Summary by Sourcery

Migrate the process-telemetry Edge Function to use the @supabase/server withSupabase wrapper for auth, CORS, and client management, tightening authentication and device ownership checks while keeping writes via an admin client.

New Features:
- Add withSupabase-based handler supporting user and secret-key auth modes with automatic JWT verification, CORS handling, and provisioned Supabase clients.
- Introduce explicit device ownership validation when called with a user JWT, returning clear 4xx/5xx errors for invalid access or lookup failures.

Bug Fixes:
- Close a security gap where anonymous callers could write telemetry using the service-role key by now requiring either a user JWT or Supabase secret key and rejecting unauthenticated requests.
- Improve error handling around invalid JSON payloads, missing device_id, telemetry insert failures, and device updates with structured JSON responses.

Enhancements:
- Split reads through an RLS-aware user client and writes through an admin client to better align with access control while preserving telemetry ingestion reliability.
- Log telemetry insert and device update failures more explicitly, while treating last_seen updates as best-effort to avoid failing successful telemetry writes.
- Include auth_mode in successful responses to aid debugging and rollout monitoring of the new auth model.

Documentation:
- Add a MIGRATION.md document explaining the move to @supabase/server, caller impact, prerequisites, deployment steps, smoke tests, rollback, and planned follow-up migrations.