### PR TITLE
Visual cohesion pass — about/devices/mushroom1/hyphae1/myconode/alarm/psathyrella/agaric

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -127,6 +127,7 @@ const organizationEntities = [
     backgroundImage: "/assets/about/mycosoft-logo-black-bg.png",
     summary:
       "Governance, holding, and cross-cutting strategy — capital allocation, board-level programs, and initiatives that span defense, research, and commercial rails under one mission.",
+    href: "/about#about-organization-heading",
   },
   {
     id: "llc",
@@ -135,6 +136,7 @@ const organizationEntities = [
     backgroundImage: "/assets/about/mycosoft-logo-white-bg.png",
     summary:
       "Operating company for engineering, contracts, sales, and delivery — where hardware programs, software releases, and customer engagements are executed day to day.",
+    href: "/about#about-organization-heading",
   },
   {
     id: "dao",
@@ -712,6 +714,16 @@ export default function AboutPage() {
               <span className="text-foreground font-medium">MYCA</span> orchestrates work across all of them: corporate rhythm, manufacturing signals, software lifecycles, and device rollout, under{" "}
               <span className="text-foreground font-medium">AVANI</span> governance so automation stays admissible and auditable.
             </p>
+            <p className="text-muted-foreground max-w-3xl mx-auto text-base md:text-lg leading-relaxed mt-4">
+              <a
+                href="https://mycosoft.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-emerald-700 dark:text-emerald-300 underline underline-offset-4 hover:text-emerald-800 dark:hover:text-emerald-200"
+              >
+                Read about our story here
+              </a>
+            </p>
           </div>
 
           <div className="about-serve-section mb-14 md:mb-16">
@@ -762,6 +774,17 @@ export default function AboutPage() {
                     >
                       {card}
                     </a>
+                  )
+                }
+                if (entity.href) {
+                  return (
+                    <Link
+                      key={entity.id}
+                      href={entity.href}
+                      className="block h-full rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-950/35 dark:focus-visible:ring-emerald-200/35 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    >
+                      {card}
+                    </Link>
                   )
                 }
                 return (

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -336,13 +336,13 @@ export default function AboutPage() {
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link href="/devices">
-              <NeuButton variant="default" className="gap-2 min-h-[44px] px-6 py-3 border border-emerald-950/20 bg-emerald-950/10 text-emerald-950 backdrop-blur-xl hover:bg-emerald-950/15 dark:border-emerald-200/20 dark:bg-emerald-200/10 dark:text-emerald-50 dark:hover:bg-emerald-200/15">
+              <NeuButton variant="default" className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/10 !text-white backdrop-blur-xl hover:bg-white/20 dark:border-emerald-200/20 dark:bg-emerald-200/10 dark:text-emerald-50 dark:hover:bg-emerald-200/15">
                 Explore Devices
                 <ArrowRight className="h-4 w-4" />
               </NeuButton>
             </Link>
             <Link href="#about">
-              <NeuButton variant="default" className="gap-2 min-h-[44px] px-6 py-3 border-gray-900/30 dark:border-white/30 about-hero-learn-more">
+              <NeuButton variant="default" className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 !text-white bg-white/5 hover:bg-white/15 about-hero-learn-more">
                 Learn More
                 <ArrowRight className="h-4 w-4" />
               </NeuButton>
@@ -378,6 +378,7 @@ export default function AboutPage() {
       <section
         id="about"
         className="relative py-16 md:py-24 overflow-hidden bg-black border-y border-white/10"
+        data-over-video
       >
         <DataGlobe className="absolute inset-0 z-0 h-full w-full opacity-100" />
         {/* Particle animation — tuned for dark bg; subtle on light */}
@@ -390,18 +391,18 @@ export default function AboutPage() {
             <NeuBadge variant="default" className="mb-4 border-white/20 bg-black/45 text-white shadow-2xl shadow-cyan-400/10 about-mycosoft-badge">
               About Mycosoft
             </NeuBadge>
-            <h2 className="text-3xl md:text-4xl font-bold mb-2 text-white">Building the Earth Computer</h2>
-            <p className="text-cyan-100/90 font-medium text-lg">
+            <h2 className="text-3xl md:text-4xl font-bold mb-2 !text-white">Building the Earth Computer</h2>
+            <p className="!text-cyan-100/90 font-medium text-lg">
               Turn reality into data — then data into intelligence
             </p>
           </div>
 
           {/* Opening */}
           <div className="max-w-3xl mx-auto mb-16 text-center space-y-5">
-            <p className="text-lg text-white/86 leading-relaxed">
+            <p className="text-lg !text-white/86 leading-relaxed">
               Mycosoft is building systems that discover information in the world, not only refine what already exists on the internet. Our data sensors observe reality independently; when networked, they produce new ground truth for science, infrastructure, and defense.
             </p>
-            <p className="text-lg text-white/86 leading-relaxed">
+            <p className="text-lg !text-white/86 leading-relaxed">
               We integrate physical sensing, edge compute, mesh protocols, cryptographic data layers, and governed AI so that environmental and biological signals become durable intelligence — not one-off telemetry, but a living data fabric.
             </p>
           </div>

--- a/components/about/data-globe.tsx
+++ b/components/about/data-globe.tsx
@@ -35,11 +35,11 @@ export function DataGlobe({ className = "" }: DataGlobeProps) {
     const container = containerRef.current
     if (!container) return
 
-    if (shouldUseLightweightVisuals()) return
+    const lightweight = shouldUseLightweightVisuals()
 
     const scene = new THREE.Scene()
     const camera = new THREE.PerspectiveCamera(30, 1, 1, 10000)
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+    const renderer = new THREE.WebGLRenderer({ antialias: !lightweight, alpha: true, powerPreference: "low-power" })
     const group = new THREE.Group()
     const radius = 200
     const target = { x: Math.PI * 1.05, y: Math.PI / 8 }
@@ -52,7 +52,7 @@ export function DataGlobe({ className = "" }: DataGlobeProps) {
     let lastRender = 0
 
     renderer.setClearColor(0x000000, 0)
-    renderer.setPixelRatio(1)
+    renderer.setPixelRatio(lightweight ? Math.min(window.devicePixelRatio || 1, 1) : 1)
     renderer.domElement.style.position = "absolute"
     renderer.domElement.style.inset = "0"
     renderer.domElement.style.width = "100%"
@@ -142,7 +142,7 @@ export function DataGlobe({ className = "" }: DataGlobeProps) {
     )
     visibilityObserver.observe(container)
 
-    fetch("/assets/about-globe/population909500.json")
+    if (!lightweight) fetch("/assets/about-globe/population909500.json")
       .then((response) => response.json())
       .then((datasets: GlobeDataset[]) => {
         if (!alive) return
@@ -260,10 +260,6 @@ export function DataGlobe({ className = "" }: DataGlobeProps) {
       ref={containerRef}
       className={`data-globe-root overflow-hidden ${className}`}
       aria-hidden="true"
-    >
-      <div className="pointer-events-none absolute inset-0 bg-black" />
-      <div className="pointer-events-none absolute left-1/2 top-1/2 h-[min(82vw,620px)] w-[min(82vw,620px)] -translate-x-1/2 -translate-y-1/2 rounded-full border border-cyan-200/30 bg-[radial-gradient(circle_at_38%_32%,rgba(255,255,255,0.34),transparent_12%),radial-gradient(circle,rgba(0,255,255,0.18),rgba(0,0,0,0)_66%)] shadow-[0_0_90px_rgba(0,255,255,0.35)]" />
-      <div className="pointer-events-none absolute left-1/2 top-1/2 h-[min(88vw,680px)] w-[min(88vw,680px)] -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/10" />
-    </div>
+    />
   )
 }

--- a/components/devices/agaric-details.tsx
+++ b/components/devices/agaric-details.tsx
@@ -382,7 +382,7 @@ export function AgaricDetails() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 1, delay: 0.5 }}
           >
-            <NeuBadge variant="default" className="device-hero-badge mb-4 bg-red-500/20 text-red-400 border-red-500/50 text-sm px-4 py-1">
+            <NeuBadge variant="default" className="device-hero-badge mb-4 bg-red-500/20 !text-red-600 dark:!text-red-400 border-red-500/50 text-sm px-4 py-1">
               Flying Sensor Droid
             </NeuBadge>
           </motion.div>
@@ -550,7 +550,7 @@ export function AgaricDetails() {
             viewport={{ once: true }}
             className="text-center mb-16"
           >
-            <NeuBadge variant="default" className="mb-4 bg-black/45 text-white border-white/20 backdrop-blur-md">Technology</NeuBadge>
+            <NeuBadge variant="default" className="mb-4 bg-black/45 !text-red-600 dark:!text-red-400 border-white/20 backdrop-blur-md">Technology</NeuBadge>
             <h2 className="text-4xl md:text-5xl font-bold mb-4 text-black">
               Sensor + Payload <span className="text-black">Equipment</span>
             </h2>
@@ -624,7 +624,7 @@ export function AgaricDetails() {
             viewport={{ once: true }}
             className="text-center mb-12 px-4"
           >
-            <NeuBadge variant="default" className="agaric-field-badge mb-4 bg-red-600/80 text-white border-red-700/40 dark:!bg-red-500/20 dark:!text-red-300 dark:!border-red-500/40">Field Deployments</NeuBadge>
+            <NeuBadge variant="default" className="agaric-field-badge mb-4 bg-red-600/80 !text-red-600 border-red-700/40 dark:!bg-red-500/20 dark:!text-red-300 dark:!border-red-500/40">Field Deployments</NeuBadge>
             <h2 className="text-4xl md:text-5xl font-bold text-slate-900 dark:text-white">
               Wide-area <span className="text-red-600 dark:text-red-400">field flight</span>
             </h2>
@@ -719,9 +719,9 @@ export function AgaricDetails() {
             viewport={{ once: true }}
             className="text-center mb-16"
           >
-            <NeuBadge variant="default" className="mb-4 bg-red-500/20 text-red-300 border-red-500/30 backdrop-blur-md">Capabilities</NeuBadge>
-            <h2 className="agaric-capabilities-title text-4xl md:text-5xl font-bold mb-4 text-white">
-              What <span className="text-red-300">Agaric</span> Can Do
+            <NeuBadge variant="default" className="mb-4 bg-red-500/20 !text-red-600 dark:!text-red-400 border-red-500/30 backdrop-blur-md">Capabilities</NeuBadge>
+            <h2 className="agaric-capabilities-title text-4xl md:text-5xl font-bold mb-4 !text-white">
+              What <span className="!text-red-500">AGARIC</span> Can Do
             </h2>
             <p className="text-xl text-white/75 max-w-3xl mx-auto">
               Four mission scenarios combine the same AGARIC functions across every size. AGARIC-S, AGARIC-M, and AGARIC-L change the lift envelope, not the mission identity.
@@ -747,15 +747,15 @@ export function AgaricDetails() {
                 >
                   <div className="flex items-center gap-4">
                     <div className={`p-3 rounded-lg ${activeUseCase === i ? 'bg-white/20' : 'bg-white/10'}`}>
-                      <useCase.icon className="h-6 w-6 text-white" />
+                      <useCase.icon className="h-6 w-6 text-red-500" />
                     </div>
                     <div>
-                      <h3 className="text-xl font-semibold text-red-300">{useCase.title}</h3>
+                      <h3 className="text-xl font-semibold !text-red-600">{useCase.title}</h3>
                       {activeUseCase === i && (
                         <motion.p
                           initial={{ opacity: 0, height: 0 }}
                           animate={{ opacity: 1, height: 'auto' }}
-                          className="text-white/80 mt-2"
+                          className="text-slate-900 dark:text-slate-200 mt-2"
                         >
                           {useCase.description}
                         </motion.p>

--- a/components/devices/alarm-details.tsx
+++ b/components/devices/alarm-details.tsx
@@ -404,7 +404,7 @@ export function AlarmDetails() {
         <div className="max-w-7xl mx-auto px-4">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
             <div className="order-2 lg:order-1">
-              <div className="alarm-ai-card relative aspect-video rounded-2xl overflow-hidden border border-slate-200 bg-slate-100 shadow-2xl dark:border-white/15 dark:bg-slate-900">
+              <div className="alarm-ai-card relative aspect-square rounded-2xl overflow-hidden border border-slate-200 bg-slate-100 shadow-2xl dark:border-white/15 dark:bg-slate-900">
                 <Image
                   src={ALARM_ASSETS.tinyMlImage}
                   alt="ALARM TinyML inference hardware stack with ESP32, VOC sensor, particle sensor, and battery"
@@ -531,7 +531,7 @@ export function AlarmDetails() {
                 <div className="bg-white rounded-2xl border border-red-200 p-4 shadow-inner dark:bg-white dark:border-red-200 dark:text-slate-900">
                   <div className="flex items-center gap-2 mb-4 pb-3 border-b border-red-200 dark:border-red-200">
                     <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-                    <span className="text-xs font-mono text-red-700/70 uppercase tracking-wider dark:text-red-700/70">Component Selector</span>
+                    <span className="text-xs font-mono !text-black uppercase tracking-wider">Component Selector</span>
                   </div>
 
                   <div className="grid grid-cols-2 gap-2">
@@ -566,7 +566,7 @@ export function AlarmDetails() {
                 <div className="bg-white rounded-2xl border border-red-200 p-4 shadow-inner flex-1 dark:bg-white dark:border-red-200 dark:text-slate-900">
                   <div className="flex items-center gap-2 mb-3 pb-2 border-b border-red-200 dark:border-red-200">
                     <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
-                    <span className="text-xs font-mono text-red-700/70 uppercase tracking-wider dark:text-red-700/70">Component Details</span>
+                    <span className="text-xs font-mono !text-black uppercase tracking-wider">Component Details</span>
                   </div>
 
                   <AnimatePresence mode="wait">
@@ -609,9 +609,9 @@ export function AlarmDetails() {
                   <div className="absolute top-0 left-0 right-0 p-3 bg-gradient-to-b from-white/90 to-transparent z-10 dark:from-white">
                     <div className="flex items-center gap-2">
                       <div className="w-2 h-2 rounded-full bg-cyan-500 animate-pulse" />
-                      <span className="text-xs font-mono text-slate-500 uppercase tracking-wider dark:text-slate-900">Device Cross-Section</span>
+                      <span className="text-xs font-mono !text-black uppercase tracking-wider">Device Cross-Section</span>
                       <div className="flex-1" />
-                      <span className="text-xs font-mono text-slate-400 dark:text-slate-900">ALARM // REV 1.0</span>
+                      <span className="text-xs font-mono !text-black">ALARM // REV 1.0</span>
                     </div>
                   </div>
 
@@ -628,7 +628,7 @@ export function AlarmDetails() {
 
                   {/* Status bar */}
                   <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-white/90 to-transparent dark:from-white">
-                    <div className="flex items-center justify-between text-xs font-mono text-slate-500 dark:text-slate-900">
+                    <div className="flex items-center justify-between text-xs font-mono !text-black">
                       <span>COMPONENT: <span className="text-red-600 dark:text-red-600">{DEVICE_COMPONENTS.find(c => c.id === selectedComponent)?.name.toUpperCase()}</span></span>
                       <span className="flex items-center gap-2">
                         <span className="w-1.5 h-1.5 rounded-full bg-green-500" />

--- a/components/devices/alarm-smoke-background.tsx
+++ b/components/devices/alarm-smoke-background.tsx
@@ -166,7 +166,7 @@ export function AlarmSmokeBackground() {
   return (
     <div
       ref={containerRef}
-      className="absolute inset-0 h-full w-full overflow-hidden bg-black"
+      className="absolute inset-0 z-0 h-full w-full overflow-hidden bg-black"
       aria-hidden="true"
     >
       <div className="absolute inset-[-20%] bg-[radial-gradient(circle_at_50%_50%,rgba(255,30,30,0.44),transparent_24%),radial-gradient(circle_at_30%_35%,rgba(255,255,255,0.16),transparent_20%),radial-gradient(circle_at_70%_65%,rgba(130,0,0,0.48),transparent_30%)] blur-3xl" />

--- a/components/devices/devices-portal.tsx
+++ b/components/devices/devices-portal.tsx
@@ -455,7 +455,7 @@ export function DevicesPortal() {
                 <NeuCard
                   className={`cursor-pointer transition-all ${
                     selectedDevice.id === device.id
-                      ? "ring-2 ring-primary/20"
+                      ? "ring-2 ring-emerald-600/40 bg-emerald-50/80 dark:bg-emerald-900/30 dark:ring-emerald-400/30"
                       : ""
                   }`}
                   onClick={() => setSelectedDevice(device)}
@@ -498,6 +498,9 @@ export function DevicesPortal() {
               <img
                 src={selectedDevice.image}
                 alt={selectedDevice.name}
+                loading="eager"
+                fetchPriority="high"
+                decoding="async"
                 className="absolute inset-0 w-full h-full object-cover"
                 onError={(e) => {
                   // Fallback to icon if image fails
@@ -567,11 +570,9 @@ export function DevicesPortal() {
                     Learn More
                   </NeuButton>
                 </a>
-                <Link href={`/devices/${selectedDevice.id}`}>
-                  <NeuButton variant="default" className="w-full sm:w-auto">
-                    Full Details
-                  </NeuButton>
-                </Link>
+                <NeuButton asChild variant="default" className="w-full sm:w-auto">
+                  <Link href={`/devices/${selectedDevice.id}`}>Full Details</Link>
+                </NeuButton>
               </div>
             </div>
           </motion.div>
@@ -593,6 +594,9 @@ export function DevicesPortal() {
             <img
               src={selectedDevice.image}
               alt={selectedDevice.name}
+              loading="eager"
+              fetchPriority="high"
+              decoding="async"
               className="absolute inset-0 w-full h-full object-cover"
               onError={(e) => {
                 const t = e.target as HTMLImageElement
@@ -649,18 +653,18 @@ export function DevicesPortal() {
 
           {/* CTA buttons */}
           <div className="flex flex-col gap-3 pb-2">
-            <Link href={`/devices/${selectedDevice.id}`}>
-              <NeuButton variant="primary" className="w-full gap-2">
-                View Full Details
+            <NeuButton asChild variant="primary" className="w-full gap-2">
+              <Link href={`/devices/${selectedDevice.id}`}>
+                <span>View Full Details</span>
                 <ChevronRight className="h-5 w-5" />
-              </NeuButton>
-            </Link>
-            <a href={deviceYoutubeUrl(selectedDevice.id)} target="_blank" rel="noopener noreferrer">
-              <NeuButton variant="default" className="w-full gap-2">
+              </Link>
+            </NeuButton>
+            <NeuButton asChild variant="default" className="w-full gap-2">
+              <a href={deviceYoutubeUrl(selectedDevice.id)} target="_blank" rel="noopener noreferrer">
                 <Play className="h-5 w-5" />
-                Watch Demo
-              </NeuButton>
-            </a>
+                <span>Watch Demo</span>
+              </a>
+            </NeuButton>
           </div>
         </motion.div>
       </section>

--- a/components/devices/hyphae-root-network-background.tsx
+++ b/components/devices/hyphae-root-network-background.tsx
@@ -232,9 +232,19 @@ export function HyphaeRootNetworkBackground({ className = "" }: HyphaeRootNetwor
       spawn(event.clientX - rect.left, event.clientY - rect.top)
     }
 
+    let lastMoveSpawn = 0
+    function handlePointerMove(event: PointerEvent) {
+      const now = performance.now()
+      if (now - lastMoveSpawn < 80) return
+      lastMoveSpawn = now
+      const rect = canvas.getBoundingClientRect()
+      spawn(event.clientX - rect.left, event.clientY - rect.top)
+    }
+
     const resizeObserver = new ResizeObserver(init)
     resizeObserver.observe(canvas)
     canvas.addEventListener("pointerdown", handlePointerDown)
+    canvas.addEventListener("pointermove", handlePointerMove)
     init()
     frame = requestAnimationFrame(animate)
 
@@ -242,6 +252,7 @@ export function HyphaeRootNetworkBackground({ className = "" }: HyphaeRootNetwor
       if (frame) cancelAnimationFrame(frame)
       resizeObserver.disconnect()
       canvas.removeEventListener("pointerdown", handlePointerDown)
+      canvas.removeEventListener("pointermove", handlePointerMove)
     }
   }, [])
 

--- a/components/devices/hyphae1-details.tsx
+++ b/components/devices/hyphae1-details.tsx
@@ -517,7 +517,7 @@ export function Hyphae1Details() {
 
         <div className="relative z-10 max-w-7xl mx-auto px-4">
           <div className="text-center mb-16">
-            <NeuBadge variant="default" className="hyphae1-product-badge mb-4 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-100 border-slate-200 dark:border-slate-600">
+            <NeuBadge variant="default" className="hyphae1-product-badge mb-4 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:!text-white border-slate-200 dark:border-slate-600">
               Product Line
             </NeuBadge>
             <h2 className="text-4xl md:text-5xl font-bold mb-4 text-slate-900 dark:text-slate-100">
@@ -559,7 +559,7 @@ export function Hyphae1Details() {
                 </div>
 
                 <h3 className="text-2xl font-bold mb-2 text-slate-900 dark:text-slate-100">{variant.name}</h3>
-                <p className="text-slate-700 dark:text-slate-300 mb-4 text-sm sm:text-base leading-relaxed">
+                <p className="text-slate-800 dark:text-slate-300 mb-4 text-sm sm:text-base leading-relaxed">
                   {variant.description}
                 </p>
 
@@ -602,7 +602,7 @@ export function Hyphae1Details() {
         <div className="relative z-10 max-w-7xl mx-auto px-4">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
             <div>
-              <NeuBadge variant="default" className="mb-4 bg-cyan-400/10 text-cyan-200 border-cyan-300/30">
+              <NeuBadge variant="default" className="mb-4 bg-cyan-400/10 !text-white border-cyan-300/30">
                 Why Hyphae 1
               </NeuBadge>
               <h2 className="text-4xl md:text-5xl font-bold mb-6 !text-white">
@@ -733,7 +733,7 @@ export function Hyphae1Details() {
       <section className="hyphae1-capabilities py-24 bg-slate-50 dark:bg-slate-900">
         <div className="max-w-7xl mx-auto px-4">
           <div className="text-center mb-16">
-            <NeuBadge variant="default" className="hyphae1-capabilities-badge mb-4 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-100 border-slate-200 dark:border-slate-600 shadow-sm dark:shadow-none">
+            <NeuBadge variant="default" className="hyphae1-capabilities-badge mb-4 border border-black/20 bg-white/40 backdrop-blur-xl !text-black hover:bg-white/60">
               Capabilities
             </NeuBadge>
             <h2 className="text-4xl md:text-5xl font-bold mb-4 text-slate-900 dark:text-slate-100">
@@ -771,7 +771,7 @@ export function Hyphae1Details() {
 
         <div className="relative z-10 max-w-7xl mx-auto px-4">
           <div className="text-center mb-16">
-            <NeuBadge variant="default" className="hyphae1-applications-badge mb-4 bg-white/95 dark:bg-slate-800 text-slate-800 dark:text-slate-100 border-slate-200 dark:border-slate-600 shadow-sm backdrop-blur-sm">
+            <NeuBadge variant="default" className="hyphae1-applications-badge mb-4 border border-black/20 bg-white/40 backdrop-blur-xl !text-black hover:bg-white/60">
               Applications
             </NeuBadge>
             <h2 className="text-4xl md:text-5xl font-bold mb-4 text-slate-900 dark:text-slate-100">
@@ -827,7 +827,7 @@ export function Hyphae1Details() {
           <div className="text-center mb-16">
             <NeuBadge
               variant="default"
-              className="mb-4 bg-white dark:bg-white/10 text-slate-800 dark:text-white border-slate-200 dark:border-white/20 shadow-sm dark:shadow-none"
+              className="mb-4 border border-black/20 bg-white/40 backdrop-blur-xl !text-black hover:bg-white/60"
             >
               Engineering
             </NeuBadge>
@@ -845,9 +845,71 @@ export function Hyphae1Details() {
 
           {/* Control Device Layout */}
           <div className="relative bg-white dark:bg-slate-800/50 rounded-3xl border border-slate-200 dark:border-slate-700 p-6 shadow-[8px_12px_32px_rgba(15,23,42,0.06)] dark:shadow-none">
-            <div className="flex flex-col lg:flex-row gap-6 lg:items-stretch">
-              {/* LEFT SIDE: Controller Panel + Description */}
-              <div className="lg:w-80 flex flex-col gap-4">
+            <div className="flex flex-col gap-6">
+              {/* SCHEMATIC: full width, on top */}
+              <div className="w-full">
+                <div className="relative min-h-[500px] bg-slate-200 dark:bg-slate-950 rounded-2xl border border-slate-300 dark:border-slate-700 overflow-hidden shadow-inner">
+                  <div
+                    className="absolute inset-0 opacity-35 dark:hidden"
+                    style={{
+                      backgroundImage: `
+                      linear-gradient(rgba(15,23,42,0.14) 1px, transparent 1px),
+                      linear-gradient(90deg, rgba(15,23,42,0.14) 1px, transparent 1px)
+                    `,
+                      backgroundSize: "30px 30px",
+                    }}
+                  />
+                  <div
+                    className="absolute inset-0 opacity-20 hidden dark:block"
+                    style={{
+                      backgroundImage: `
+                      linear-gradient(rgba(255,255,255,0.2) 1px, transparent 1px),
+                      linear-gradient(90deg, rgba(255,255,255,0.2) 1px, transparent 1px)
+                    `,
+                      backgroundSize: "30px 30px",
+                    }}
+                  />
+                  <div className="absolute top-0 left-0 right-0 p-3 bg-gradient-to-b from-slate-100/95 to-transparent dark:from-slate-900 z-10">
+                    <div className="flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full bg-cyan-500 animate-pulse" />
+                      <span className="text-xs font-mono text-slate-500 uppercase tracking-wider dark:text-white/50">
+                        Schematic View
+                      </span>
+                      <div className="flex-1" />
+                      <span className="text-xs font-mono text-slate-400 dark:text-white/30">
+                        HYPHAE-1 // {selectedVariant.size.toUpperCase()}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="absolute inset-0">
+                    <Image
+                      src={HYPHAE1_ASSETS.schematicView}
+                      alt="Hyphae 1 open enclosure schematic view"
+                      fill
+                      sizes="100vw"
+                      className="object-cover"
+                    />
+                    <div className="absolute inset-0 bg-slate-950/5 dark:bg-black/10" aria-hidden="true" />
+                  </div>
+                  <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-slate-100/95 to-transparent dark:from-slate-900">
+                    <div className="flex items-center justify-between text-xs font-mono text-slate-500 dark:text-white/30">
+                      <span>
+                        COMPONENT:{" "}
+                        <span className="text-slate-800 dark:text-white/70">
+                          {DEVICE_COMPONENTS.find(c => c.id === selectedComponent)?.name.toUpperCase()}
+                        </span>
+                      </span>
+                      <span className="flex items-center gap-2">
+                        <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                        SYSTEM READY
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* CONTROLLER: below schematic, in a row */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* Controller Panel */}
                 <div className="bg-slate-100 dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-700 p-4 shadow-inner">
                   <div className="flex items-center gap-2 mb-4 pb-3 border-b border-slate-200 dark:border-slate-700">
@@ -867,7 +929,7 @@ export function Hyphae1Details() {
                           onClick={() => setSelectedComponent(component.id)}
                           className={`p-3 rounded-xl border transition-all text-left ${
                             isSelected
-                              ? "bg-slate-900 border-slate-900 text-white dark:bg-white/10 dark:border-white/40"
+                              ? "bg-cyan-500 border-cyan-400 !text-white shadow-[0_0_15px_rgba(34,211,238,0.7)] dark:bg-cyan-500 dark:border-cyan-400"
                               : "bg-white border-slate-200 hover:border-slate-400 dark:bg-slate-800/50 dark:border-slate-700 dark:hover:border-white/30"
                           }`}
                           whileHover={{ scale: 1.02 }}
@@ -930,74 +992,6 @@ export function Hyphae1Details() {
                 </div>
               </div>
 
-              {/* RIGHT SIDE: Schematic */}
-              <div className="flex-1 min-w-0 flex flex-col">
-                <div className="relative flex-1 min-h-[500px] bg-slate-200 dark:bg-slate-950 rounded-2xl border border-slate-300 dark:border-slate-700 overflow-hidden shadow-inner">
-                  {/* Grid pattern — dark lines on light; light lines on dark */}
-                  <div
-                    className="absolute inset-0 opacity-35 dark:hidden"
-                    style={{
-                      backgroundImage: `
-                      linear-gradient(rgba(15,23,42,0.14) 1px, transparent 1px),
-                      linear-gradient(90deg, rgba(15,23,42,0.14) 1px, transparent 1px)
-                    `,
-                      backgroundSize: "30px 30px",
-                    }}
-                  />
-                  <div
-                    className="absolute inset-0 opacity-20 hidden dark:block"
-                    style={{
-                      backgroundImage: `
-                      linear-gradient(rgba(255,255,255,0.2) 1px, transparent 1px),
-                      linear-gradient(90deg, rgba(255,255,255,0.2) 1px, transparent 1px)
-                    `,
-                      backgroundSize: "30px 30px",
-                    }}
-                  />
-
-                  {/* Panel Header */}
-                  <div className="absolute top-0 left-0 right-0 p-3 bg-gradient-to-b from-slate-100/95 to-transparent dark:from-slate-900 z-10">
-                    <div className="flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-cyan-500 animate-pulse" />
-                      <span className="text-xs font-mono text-slate-500 uppercase tracking-wider dark:text-white/50">
-                        Schematic View
-                      </span>
-                      <div className="flex-1" />
-                      <span className="text-xs font-mono text-slate-400 dark:text-white/30">
-                        HYPHAE-1 // {selectedVariant.size.toUpperCase()}
-                      </span>
-                    </div>
-                  </div>
-
-                  {/* Device Visual */}
-                  <div className="absolute inset-0">
-                    <Image
-                      src={HYPHAE1_ASSETS.schematicView}
-                      alt="Hyphae 1 open enclosure schematic view"
-                      fill
-                      sizes="(min-width: 1024px) 60vw, 100vw"
-                      className="object-cover"
-                    />
-                    <div className="absolute inset-0 bg-slate-950/5 dark:bg-black/10" aria-hidden="true" />
-                  </div>
-
-                  {/* Status bar */}
-                  <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-slate-100/95 to-transparent dark:from-slate-900">
-                    <div className="flex items-center justify-between text-xs font-mono text-slate-500 dark:text-white/30">
-                      <span>
-                        COMPONENT:{" "}
-                        <span className="text-slate-800 dark:text-white/70">
-                          {DEVICE_COMPONENTS.find(c => c.id === selectedComponent)?.name.toUpperCase()}
-                        </span>
-                      </span>
-                      <span className="flex items-center gap-2">
-                        <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
-                        SYSTEM READY
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
 
@@ -1013,7 +1007,7 @@ export function Hyphae1Details() {
       <section className="hyphae1-tech-specs py-24 bg-slate-50 dark:bg-slate-900" data-section="tech-specs">
         <div className="max-w-7xl mx-auto px-4">
           <div className="text-center mb-16">
-            <NeuBadge variant="default" className="mb-4 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-slate-300 dark:border-slate-600">
+            <NeuBadge variant="default" className="mb-4 border border-black/20 bg-white/40 backdrop-blur-xl !text-black hover:bg-white/60">
               Specifications
             </NeuBadge>
             <h2 className="text-4xl md:text-5xl font-bold mb-4 text-slate-900 dark:text-slate-100">
@@ -1040,8 +1034,8 @@ export function Hyphae1Details() {
                     key={row.label}
                     className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 py-3 border-b border-slate-200 dark:border-slate-600 last:border-0"
                   >
-                    <span className="text-slate-600 dark:text-slate-400 text-sm shrink-0 sm:max-w-[40%]">{row.label}</span>
-                    <span className="font-medium text-slate-900 dark:text-slate-200 text-sm text-left sm:text-right sm:max-w-[58%]">
+                    <span className="text-slate-600 dark:!text-white text-sm shrink-0 sm:max-w-[40%]">{row.label}</span>
+                    <span className="font-medium text-slate-900 dark:!text-white text-sm text-left sm:text-right sm:max-w-[58%]">
                       {row.value}
                     </span>
                   </div>
@@ -1060,8 +1054,8 @@ export function Hyphae1Details() {
                     key={row.label}
                     className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 py-3 border-b border-slate-200 dark:border-slate-600 last:border-0"
                   >
-                    <span className="text-slate-600 dark:text-slate-400 text-sm shrink-0 sm:max-w-[40%]">{row.label}</span>
-                    <span className="font-medium text-slate-900 dark:text-slate-200 text-sm text-left sm:text-right sm:max-w-[58%]">
+                    <span className="text-slate-600 dark:!text-white text-sm shrink-0 sm:max-w-[40%]">{row.label}</span>
+                    <span className="font-medium text-slate-900 dark:!text-white text-sm text-left sm:text-right sm:max-w-[58%]">
                       {row.value}
                     </span>
                   </div>

--- a/components/devices/mushroom1-details.tsx
+++ b/components/devices/mushroom1-details.tsx
@@ -184,9 +184,10 @@ const USE_CASES = [
   {
     title: "Scientific Research",
     icon: Microscope,
-    color: "from-emerald-600 to-teal-700",
-    colorDark: "dark:from-emerald-950 dark:to-stone-950",
-    gradient: "linear-gradient(135deg, rgba(5, 150, 105, 0.9), rgba(15, 118, 110, 0.88))",
+    color: "from-blue-500 to-blue-600",
+    colorDark: "dark:from-blue-700 dark:to-blue-900",
+    buttonClass: "bg-blue-500 hover:bg-blue-600 !text-white",
+    gradient: "linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(37, 99, 235, 0.88))",
     description: "Universities and research institutions use Mushroom 1 to study mycelial network communication, forest health, and ecosystem dynamics.",
     applications: ["Mycology research", "Forest ecology studies", "Climate change monitoring", "Biodiversity assessment"],
     video: "/assets/mushroom1/scientific-research-fast-web.mp4"
@@ -194,9 +195,10 @@ const USE_CASES = [
   {
     title: "Conservation & Wildlife",
     icon: Trees,
-    color: "from-green-500 to-emerald-500",
-    colorDark: "dark:from-green-800 dark:to-emerald-800",
-    gradient: "linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(16, 185, 129, 0.88))",
+    color: "from-emerald-500 to-emerald-600",
+    colorDark: "dark:from-emerald-700 dark:to-emerald-900",
+    buttonClass: "bg-emerald-500 hover:bg-emerald-600 !text-white",
+    gradient: "linear-gradient(135deg, rgba(16, 185, 129, 0.9), rgba(5, 150, 105, 0.88))",
     description: "National parks and conservation areas deploy Mushroom 1 networks to monitor ecosystem health and detect environmental threats early.",
     applications: ["Park ecosystem monitoring", "Wildlife habitat tracking", "Fire risk assessment", "Pollution detection"],
     video: "/assets/mushroom1/conservation-wildlife.mp4"
@@ -204,9 +206,10 @@ const USE_CASES = [
   {
     title: "Agriculture & Farming",
     icon: Leaf,
-    color: "from-amber-500 to-orange-500",
-    colorDark: "dark:from-amber-800 dark:to-orange-800",
-    gradient: "linear-gradient(135deg, rgba(245, 158, 11, 0.92), rgba(249, 115, 22, 0.88))",
+    color: "from-orange-500 to-yellow-500",
+    colorDark: "dark:from-orange-700 dark:to-yellow-700",
+    buttonClass: "bg-gradient-to-r from-orange-500 to-yellow-500 hover:from-orange-600 hover:to-yellow-600 !text-white",
+    gradient: "linear-gradient(135deg, rgba(249, 115, 22, 0.92), rgba(234, 179, 8, 0.88))",
     description: "Farmers and agricultural operations use Mushroom 1 to monitor soil health, predict crop conditions, and optimize growing environments.",
     applications: ["Soil health monitoring", "Irrigation optimization", "Pest early warning", "Organic certification"],
     video: "/assets/mushroom1/c.mp4"
@@ -214,9 +217,10 @@ const USE_CASES = [
   {
     title: "Defense & Security",
     icon: Shield,
-    color: "from-slate-600 to-slate-800",
-    colorDark: "dark:from-slate-700 dark:to-slate-900",
-    gradient: "linear-gradient(135deg, rgba(71, 85, 105, 0.94), rgba(15, 23, 42, 0.9))",
+    color: "from-red-500 to-red-600",
+    colorDark: "dark:from-red-700 dark:to-red-900",
+    buttonClass: "bg-red-500 hover:bg-red-600 !text-white",
+    gradient: "linear-gradient(135deg, rgba(239, 68, 68, 0.94), rgba(185, 28, 28, 0.9))",
     description: "Military and security operations leverage Mushroom 1 for persistent environmental awareness and operational intelligence.",
     applications: ["Base perimeter monitoring", "Contamination detection", "Early warning systems", "Threat assessment"],
     video: "/assets/mushroom1/defense-security.mp4"
@@ -303,6 +307,7 @@ export function Mushroom1Details() {
             src={heroSources[0]}
             sources={heroSources}
             encodeSrc
+            poster="/assets/mushroom1/Mushroom 1.jpg"
             className="absolute inset-0 w-full h-full object-cover"
           />
           <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/30 to-black" />
@@ -358,18 +363,18 @@ export function Mushroom1Details() {
               aria-label="Watch the Mushroom 1 hero video on YouTube"
             >
             <NeuButton
-              className="device-cta-over-video min-h-[44px] px-8 bg-emerald-500 hover:bg-emerald-600 !text-black font-semibold"
+              className="device-cta-over-video min-h-[44px] px-8 bg-emerald-500 hover:bg-emerald-600 !text-white font-semibold"
             >
-              <Youtube className="mr-2 h-5 w-5" />
+              <Youtube className="mr-2 h-5 w-5 text-emerald-300" />
               Watch Film
             </NeuButton>
             </a>
             <NeuButton
               variant="default"
-              className="device-cta-over-video-outline min-h-[44px] px-8 border border-white/30 hover:bg-white/10"
+              className="device-cta-over-video-outline min-h-[44px] px-8 border border-white/30 hover:bg-white/10 !text-white"
               onClick={() => router.push("/devices/specifications")}
             >
-              <FileText className="mr-2 h-5 w-5" />
+              <FileText className="mr-2 h-5 w-5 text-emerald-300" />
               Specifications
             </NeuButton>
           </motion.div>
@@ -1163,6 +1168,8 @@ export function Mushroom1Details() {
               src={encodeAssetUrl("/assets/mushroom1/hill 1.jpg")}
               alt="Mushroom 1 Mesh Network Deployment"
               fill
+              priority
+              sizes="(max-width: 768px) 100vw, 50vw"
               className="object-cover"
             />
             <div className="absolute inset-0 bg-gradient-to-t from-black via-black/50 to-transparent" />

--- a/components/devices/myconode-details.tsx
+++ b/components/devices/myconode-details.tsx
@@ -409,7 +409,7 @@ export function MycoNodeDetails() {
               <NeuBadge variant="default" className="mb-4 bg-purple-500/10 text-purple-400 border-purple-500/30">
                 The Mission
               </NeuBadge>
-              <h2 className="text-4xl md:text-5xl font-bold mb-6">
+              <h2 className="text-4xl md:text-5xl font-bold mb-6 !text-white">
                 Decoding the Underground
               </h2>
               <div className="space-y-4 text-lg text-white/70">
@@ -767,9 +767,44 @@ export function MycoNodeDetails() {
 
           {/* Control Device Layout */}
           <div className="relative bg-gradient-to-br from-purple-950/50 to-slate-900/50 rounded-3xl border border-purple-500/30 p-6">
-            <div className="flex flex-col lg:flex-row gap-6 lg:items-stretch">
-              {/* LEFT SIDE: Controller Panel + Description */}
-              <div className="lg:w-80 flex flex-col gap-4">
+            <div className="flex flex-col gap-6">
+              {/* VISUALIZATION: full width, on top */}
+              <div className="w-full">
+                <div className="relative min-h-[700px] bg-slate-950 rounded-2xl border border-purple-500/40 overflow-hidden shadow-inner">
+                  <div className="absolute inset-0 bg-gradient-to-b from-purple-950/20 via-transparent to-cyan-950/20" />
+                  <div className="absolute top-0 left-0 right-0 p-3 bg-gradient-to-b from-slate-900 to-transparent z-10">
+                    <div className="flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full bg-cyan-500 animate-pulse" />
+                      <span className="text-xs font-mono text-cyan-400/70 uppercase tracking-wider">Probe Visualization</span>
+                      <div className="flex-1" />
+                      <span className="text-xs font-mono text-white/30">MYCONODE // REV 1.0</span>
+                    </div>
+                  </div>
+                  <div className="absolute inset-0 flex items-center justify-center p-8">
+                    <div className="relative w-full h-full">
+                      <Image
+                        src={encodeAssetUrl(MYCONODE_ASSETS.probeImage)}
+                        alt="MycoNode probe device"
+                        fill
+                        className="object-contain"
+                        sizes="100vw"
+                      />
+                    </div>
+                  </div>
+                  <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-slate-900 to-transparent">
+                    <div className="flex items-center justify-between text-xs font-mono text-white/30">
+                      <span>COMPONENT: <span className="text-purple-400">{DEVICE_COMPONENTS.find(c => c.id === selectedComponent)?.name.toUpperCase()}</span></span>
+                      <span className="flex items-center gap-2">
+                        <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                        SYSTEM READY
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* CONTROLLER: below visualization, in a row */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* Controller Panel */}
                 <div className="bg-slate-950 rounded-2xl border border-purple-500/40 p-4 shadow-inner">
                   <div className="flex items-center gap-2 mb-4 pb-3 border-b border-purple-500/20">
@@ -836,47 +871,6 @@ export function MycoNodeDetails() {
                 </div>
               </div>
 
-              {/* RIGHT SIDE: Visualization */}
-              <div className="flex-1 min-w-0 flex flex-col">
-                <div className="relative flex-1 min-h-[500px] bg-slate-950 rounded-2xl border border-purple-500/40 overflow-hidden shadow-inner">
-                  {/* Gradient background */}
-                  <div className="absolute inset-0 bg-gradient-to-b from-purple-950/20 via-transparent to-cyan-950/20" />
-                  
-                  {/* Panel Header */}
-                  <div className="absolute top-0 left-0 right-0 p-3 bg-gradient-to-b from-slate-900 to-transparent z-10">
-                    <div className="flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-cyan-500 animate-pulse" />
-                      <span className="text-xs font-mono text-cyan-400/70 uppercase tracking-wider">Probe Visualization</span>
-                      <div className="flex-1" />
-                      <span className="text-xs font-mono text-white/30">MYCONODE // REV 1.0</span>
-                    </div>
-                  </div>
-                  
-                  {/* Probe Visual - Real Image */}
-                  <div className="absolute inset-0 flex items-center justify-center p-8">
-                    <div className="relative w-full h-full">
-                      <Image
-                        src={encodeAssetUrl(MYCONODE_ASSETS.probeImage)}
-                        alt="MycoNode probe device"
-                        fill
-                        className="object-contain"
-                        sizes="(max-width: 768px) 100vw, 60vw"
-                      />
-                    </div>
-                  </div>
-                  
-                  {/* Status bar */}
-                  <div className="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-slate-900 to-transparent">
-                    <div className="flex items-center justify-between text-xs font-mono text-white/30">
-                      <span>COMPONENT: <span className="text-purple-400">{DEVICE_COMPONENTS.find(c => c.id === selectedComponent)?.name.toUpperCase()}</span></span>
-                      <span className="flex items-center gap-2">
-                        <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
-                        SYSTEM READY
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>

--- a/components/devices/psathyrella-details.tsx
+++ b/components/devices/psathyrella-details.tsx
@@ -305,17 +305,17 @@ export function PsathyrellaDetails() {
           >
             <PsathyrellaWaveTitle
               title={PSATHYRELLA_DEVICE.name}
-              className="scale-[1.35] sm:scale-150 md:scale-[1.65] lg:scale-[1.85] origin-center"
+              className="scale-[1.35] sm:scale-150 md:scale-150 lg:scale-[1.85] origin-center"
             />
           </motion.h1>
           
           <motion.p 
-            className="device-hero-subtitle text-xl md:text-2xl lg:text-3xl text-slate-900 dark:text-white/80 mb-8 max-w-4xl mx-auto px-2 font-light leading-snug"
+            className="device-hero-subtitle text-xl md:text-2xl lg:text-3xl !text-white dark:!text-white/80 mb-8 max-w-4xl mx-auto px-2 font-light leading-snug"
             initial={{ opacity: 0, y: 50 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 1, delay: 0.7 }}
           >
-            <span className="text-sky-800 dark:text-sky-400">{PSATHYRELLA_DEVICE.videoTitle}</span>
+            <span className="!text-white dark:!text-sky-100">{PSATHYRELLA_DEVICE.videoTitle}</span>
           </motion.p>
 
           <motion.div 
@@ -581,7 +581,7 @@ export function PsathyrellaDetails() {
                       <useCase.icon className={`h-6 w-6 ${activeUseCase === i ? 'text-white' : 'text-slate-900 dark:text-white'}`} />
                     </div>
                     <div>
-                      <h3 className={`text-xl font-semibold ${activeUseCase === i ? 'text-white' : 'text-slate-900 dark:text-white'}`}>{useCase.title}</h3>
+                      <h3 className={`text-xl font-semibold ${activeUseCase === i ? '!text-white' : 'text-slate-900 dark:text-white'}`}>{useCase.title}</h3>
                       {activeUseCase === i && (
                         <motion.p 
                           initial={{ opacity: 0, height: 0 }}
@@ -640,7 +640,7 @@ export function PsathyrellaDetails() {
               )}
               <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent pointer-events-none" />
               <div className="absolute bottom-6 left-6 right-6">
-                <h3 className="text-2xl font-bold text-white drop-shadow-sm">{USE_CASES[activeUseCase].title}</h3>
+                <h3 className="text-2xl font-bold !text-white drop-shadow-sm">{USE_CASES[activeUseCase].title}</h3>
                 <p className="mt-2 text-white/85 drop-shadow-sm">{USE_CASES[activeUseCase].description}</p>
               </div>
             </motion.div>
@@ -890,7 +890,7 @@ export function PsathyrellaDetails() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
           >
-            <h2 className="text-4xl md:text-6xl font-bold mb-6 text-white">
+            <h2 className="text-4xl md:text-6xl font-bold mb-6 !text-white">
               Ready to explore passive acoustics at the edge?
             </h2>
             <p className="text-xl text-white/70 mb-8 max-w-2xl mx-auto">

--- a/components/devices/psathyrella-wave-title.tsx
+++ b/components/devices/psathyrella-wave-title.tsx
@@ -56,18 +56,23 @@ export function PsathyrellaWaveTitle({ title, className = "" }: PsathyrellaWaveT
           <path
             d="M-40 11 Q-30 8 -20 11 T0 11 T20 11 T40 11 T60 11 T80 11 T100 11 T120 11 V26 H-40z"
             fill={`url(#${gradId})`}
-          >
-            <animateTransform
-              attributeName="transform"
-              begin="0s"
-              dur="1.5s"
-              type="translate"
-              from="0 0"
-              to="40 0"
-              repeatCount="indefinite"
-            />
-          </path>
+            className="psathyrella-wave-path"
+          />
         </pattern>
+        <style>{`
+          @keyframes psathyrella-wave-shift {
+            from { transform: translateX(0); }
+            to { transform: translateX(40px); }
+          }
+          .psathyrella-wave-path {
+            animation: psathyrella-wave-shift 1.5s linear infinite;
+            transform-box: fill-box;
+            transform-origin: center;
+          }
+          @media (prefers-reduced-motion: reduce) {
+            .psathyrella-wave-path { animation: none; }
+          }
+        `}</style>
       </defs>
       {/* Light rim only — no blur filter (keeps wave fill crisp) */}
       <g>

--- a/components/effects/connected-dots.tsx
+++ b/components/effects/connected-dots.tsx
@@ -203,7 +203,7 @@ export function ConnectedDots({
   return (
     <div
       ref={containerRef}
-      className={cn("absolute inset-0 overflow-hidden pointer-events-none", className)}
+      className={cn("absolute inset-0 overflow-hidden", className)}
       style={{ backgroundColor }}
     >
       <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />

--- a/components/ui/neuromorphic/NeuButton.tsx
+++ b/components/ui/neuromorphic/NeuButton.tsx
@@ -8,6 +8,7 @@
 
 import { forwardRef, type ButtonHTMLAttributes } from "react"
 import { Loader2 } from "lucide-react"
+import { Slot } from "@radix-ui/react-slot"
 
 export type NeuButtonVariant = "default" | "primary" | "success" | "warning" | "error" | "info"
 
@@ -15,6 +16,7 @@ export interface NeuButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> 
   variant?: NeuButtonVariant
   isLoading?: boolean
   fullWidth?: boolean
+  asChild?: boolean
 }
 
 const VARIANT_CLASSES: Record<NeuButtonVariant, string> = {
@@ -38,6 +40,7 @@ export const NeuButton = forwardRef<HTMLButtonElement, NeuButtonProps>(
       variant = "default",
       isLoading = false,
       fullWidth = false,
+      asChild = false,
       className = "",
       children,
       disabled,
@@ -49,20 +52,29 @@ export const NeuButton = forwardRef<HTMLButtonElement, NeuButtonProps>(
       "neu-btn neu-focus py-3 px-6 rounded-xl text-sm font-medium transition-all duration-200 flex items-center justify-center gap-2"
     const variantClass = VARIANT_CLASSES[variant]
     const widthClass = fullWidth ? "w-full" : ""
+    const Comp: any = asChild ? Slot : "button"
+
+    const buttonProps: Record<string, unknown> = {
+      ref,
+      className: `${baseClass} ${variantClass} ${widthClass} ${className}`,
+      ...props,
+    }
+    if (!asChild) {
+      buttonProps.type = "button"
+      buttonProps.disabled = disabled ?? isLoading
+    }
+
+    if (asChild) {
+      return <Comp {...buttonProps}>{children}</Comp>
+    }
 
     return (
-      <button
-        ref={ref}
-        type="button"
-        className={`${baseClass} ${variantClass} ${widthClass} ${className}`}
-        disabled={disabled ?? isLoading}
-        {...props}
-      >
+      <Comp {...buttonProps}>
         {isLoading ? (
           <Loader2 className="w-[18px] h-[18px] animate-spin" aria-hidden />
         ) : null}
         <span>{children}</span>
-      </button>
+      </Comp>
     )
   }
 )


### PR DESCRIPTION
# Visual cohesion pass — 2026-05-11

Bundled visual fixes across About, Devices, Mushroom 1, Hyphae 1, MycoNode, Alarm, Psathyrella, and Agaric pages.

## Commits

- **About**: hero CTAs white text + `data-over-video` for Building Earth Computer; DataGlobe lightweight 3D fallback (textured globe on tablet/mobile, skip 909k-point overlay); mycosoft.org bio link + Inc/LLC card hrefs
- **Devices + Neuromorphic**: `NeuButton asChild` (fixes Full Details double-tap on touch) + selected card emerald tint in light mode + selected device image `loading=eager` / `fetchpriority=high`
- **Mushroom 1**: white text on hero CTAs + emerald icons + hero poster + per-category application colors (Scientific blue, Conservation green, Agriculture orange+yellow, Defense red) + connectivity image priority
- **Hyphae 1**: white text, glass section badges, neon-blue selector, schematic full-width, body contrast + interactive dots
- **MycoNode**: probe visualization full-width + white "Decoding the Underground" title
- **Alarm**: square TinyML inference frame + black engineering text on white image bg + smoke z-index fix
- **Psathyrella**: CSS keyframes wave fill (replaces SMIL that broke on iPadOS Safari at md breakpoint) + white hero subtitle/titles/CTA + integer md scale
- **Agaric**: red badges/buttons + red icons + AGARIC red word + black bio in capability boxes

## Known deferred items (will follow up)

- **AL1**: Alarm hero black line in light mode under Watch Videos/MycoBrain CTAs — couldn't isolate cleanly; section uses continuous gradient, not a discrete border.
- **AG3**: Agaric last-4 bio black text — referenced cards have dark backgrounds in both modes; needs design clarification before applying.

## Hardware context

Authored from phone/tablet via Codespaces while dev PC is down (RTX 5090 / DIMM A1 electrical incident, 2026-05-11).

🤖 Generated with Perplexity Computer

## Summary by Sourcery

Align visual design and interaction behavior across About and multiple device detail pages for better readability, consistency, and performance.

New Features:
- Support rendering NeuButton as a wrapper element via an asChild prop to improve link and button composition.

Bug Fixes:
- Resolve iOS Safari issues with SMIL-based SVG wave animation by replacing it with CSS animations in the Psathyrella wave title.
- Fix double-tap issues on touch devices by making Devices Portal CTAs use NeuButton asChild composition and prevent nested interactive elements.
- Prevent Alarm smoke background from overlapping foreground content via z-index adjustment.

Enhancements:
- Unify hero and section badge styling and typography across Hyphae 1, Agaric, Psathyrella, Mushroom 1, MycoNode, and Alarm pages for clearer branding and contrast in light and dark modes.
- Rework Hyphae 1 and MycoNode schematic/probe layouts so visuals span full width with controller panels arranged below in responsive grids.
- Refine Mushroom 1 use-case color system and hero CTAs, including poster support and higher-priority imagery for connectivity visuals.
- Adjust About page hero CTAs, Earth Computer section copy styling, and organization cards with new internal link targets plus a lightweight DataGlobe rendering path for constrained devices.
- Emphasize Agaric’s red visual language across badges, icons, and headings, and tune copy colors in capability and deployment sections for legibility.
- Improve Psathyrella hero typography, use-case text contrast, and wave title animation using CSS keyframes with reduced-motion support.
- Tweak Alarm device layouts and component panels for square TinyML imagery and clearer black-on-white engineering text.
- Increase interactivity and performance of background effects such as Hyphae root network pointer trails, alarm smoke z-index, and connected-dots pointer events handling.
- Ensure device selector cards in Devices Portal have clearer selected states and prioritize loading of primary device imagery.