### PR TITLE
feat(science): rebuild /science as 9-section atlas + stub sub-routes

### DIFF
--- a/app/science/deployments/page.tsx
+++ b/app/science/deployments/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next"
+import { NeuromorphicProvider } from "@/components/ui/neuromorphic"
+import { ScienceStubLayout } from "@/components/science/stub-layout"
+
+export const metadata: Metadata = {
+  title: "Earth Computer Deployments | Mycosoft Science",
+  description:
+    "Forest edge nodes today; subsea and orbital compute as named frontier hypotheses with prior art.",
+}
+
+export default function DeploymentsSubPage() {
+  return (
+    <NeuromorphicProvider>
+      <ScienceStubLayout
+        eyebrow="Research Atlas · Sub-page"
+        title="Earth Computer Deployments"
+        description="Forest-edge field trials, subsea compute hypothesis tracking (Project Natick), and orbital/lunar references (Axiom, Lonestar). Site-by-site detail pages are in production."
+        parentHref="/science#deployments"
+      />
+    </NeuromorphicProvider>
+  )
+}

--- a/app/science/fci/page.tsx
+++ b/app/science/fci/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next"
+import { NeuromorphicProvider } from "@/components/ui/neuromorphic"
+import { ScienceStubLayout } from "@/components/science/stub-layout"
+
+export const metadata: Metadata = {
+  title: "Fungal Interface Lab | Mycosoft Science",
+  description:
+    "Electrode arrays, spike-train analysis, and stimulation programs over electrically active fungal substrates — measurable, not language.",
+}
+
+export default function FCISubPage() {
+  return (
+    <NeuromorphicProvider>
+      <ScienceStubLayout
+        eyebrow="Research Atlas · Sub-page"
+        title="Fungal Interface Lab"
+        description="Electrode arrays on mycelium-bearing substrates, stimulation protocols, and on-device firmware via mycobrain. The full lab page — wiring diagrams, probe galleries, and stimulus catalog — is in production."
+        parentHref="/science#fci"
+      />
+    </NeuromorphicProvider>
+  )
+}

--- a/app/science/layout.tsx
+++ b/app/science/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next"
+import type { ReactNode } from "react"
+
+export const metadata: Metadata = {
+  title: "Science & Research | Mycosoft",
+  description:
+    "A living research atlas: mycology, signal intelligence, and distributed environmental compute for the Earth computer.",
+}
+
+export default function ScienceLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/app/science/materials/page.tsx
+++ b/app/science/materials/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next"
+import { NeuromorphicProvider } from "@/components/ui/neuromorphic"
+import { ScienceStubLayout } from "@/components/science/stub-layout"
+
+export const metadata: Metadata = {
+  title: "Materials & Biotech | Mycosoft Science",
+  description:
+    "Mycelium-based composites and bio-derived materials. What evidence supports, and what the honest limits still are.",
+}
+
+export default function MaterialsSubPage() {
+  return (
+    <NeuromorphicProvider>
+      <ScienceStubLayout
+        eyebrow="Research Atlas · Sub-page"
+        title="Materials & Biotech"
+        description="Species selection, growth substrates, mechanical and acoustic benchmarks, hydrophilicity treatments, and standardization gaps. The full materials sub-page is in production."
+        parentHref="/science#materials"
+      />
+    </NeuromorphicProvider>
+  )
+}

--- a/app/science/nlm/page.tsx
+++ b/app/science/nlm/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next"
+import { NeuromorphicProvider } from "@/components/ui/neuromorphic"
+import { ScienceStubLayout } from "@/components/science/stub-layout"
+
+export const metadata: Metadata = {
+  title: "Nature Learning Models | Mycosoft Science",
+  description:
+    "Signals first, language second. NLM foundation models over acoustic, atmospheric, geospatial, and bioelectric streams.",
+}
+
+export default function NLMSubPage() {
+  return (
+    <NeuromorphicProvider>
+      <ScienceStubLayout
+        eyebrow="Research Atlas · Sub-page"
+        title="Nature Learning Models"
+        description="Subsystem-by-subsystem documentation, training-source manifests, evaluation suites, and AVANI-governed release notes. The full NLM sub-page is in production."
+        parentHref="/science#nlm"
+      />
+    </NeuromorphicProvider>
+  )
+}

--- a/app/science/page.tsx
+++ b/app/science/page.tsx
@@ -1,248 +1,1229 @@
-import type { Metadata } from "next"
-import Image from "next/image"
-import { NeuCard, NeuromorphicProvider } from "@/components/ui/neuromorphic"
-import { ExternalLink } from "lucide-react"
+"use client"
 
-export const metadata: Metadata = {
-  title: "Science & Research | Mycosoft",
-  description: "Explore Mycosoft's scientific research and publications in mycology",
+import Link from "next/link"
+import {
+  NeuCard,
+  NeuCardContent,
+  NeuButton,
+  NeuBadge,
+  NeuromorphicProvider,
+} from "@/components/ui/neuromorphic"
+import { AutoplayVideo } from "@/components/ui/autoplay-video"
+import { assetMp4Sources, mergeWithNasFallbacks } from "@/lib/asset-video-sources"
+import { ParticleCanvas } from "@/components/effects/particle-canvas"
+import { NeuralNetworkCanvas } from "@/components/effects/neural-network-canvas"
+import { ResearchRibbon } from "@/components/science/research-ribbon"
+import {
+  SCIENCE_PUBLICATIONS,
+  STATUS_PILL_CLASSES,
+  type ResearchStatus,
+} from "@/lib/science-publications"
+import {
+  Activity,
+  ArrowRight,
+  Atom,
+  AudioLines,
+  Beaker,
+  Brain,
+  ChevronRight,
+  Cpu,
+  Database,
+  ExternalLink,
+  Eye,
+  FlaskConical,
+  Globe,
+  Layers,
+  Leaf,
+  Microscope,
+  Network,
+  Radar,
+  Radio,
+  Satellite,
+  Server,
+  Signal,
+  Sparkles,
+  Sprout,
+  Wifi,
+  Wind,
+  Zap,
+} from "lucide-react"
+
+// Placeholder asset path; resolves at request time. If absent we fall back
+// to a gradient rather than render a broken <video>.
+const SCIENCE_HERO_SRC = "/assets/science/science-hero.mp4"
+const SCIENCE_HERO_SOURCES = mergeWithNasFallbacks(assetMp4Sources(SCIENCE_HERO_SRC))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Status pill helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface StatusPillProps {
+  status: ResearchStatus
+  className?: string
 }
 
-const NewsCluster = () => (
-  <div className="space-y-4">
-    <h2 className="text-xl font-semibold">Latest News</h2>
-    <div className="space-y-4">
-      <article className="space-y-1">
-        <h3 className="font-medium">Mycosoft Achieves Breakthrough in Mycelial Computing</h3>
-        <p className="text-sm text-muted-foreground">Mycosoft, 2025</p>
-      </article>
-      <article className="space-y-1">
-        <h3 className="font-medium">New Study Reveals Potential of Fungi in Bioremediation</h3>
-        <p className="text-sm text-muted-foreground">Environmental Science Journal, 2025</p>
-      </article>
-      <article className="space-y-1">
-        <h3 className="font-medium">Mycosoft Partners with Leading Universities for Research</h3>
-        <p className="text-sm text-muted-foreground">Mycosoft Press Release, 2025</p>
-      </article>
-    </div>
-  </div>
-)
+function StatusPill({ status, className = "" }: StatusPillProps) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${STATUS_PILL_CLASSES[status]} ${className}`}
+    >
+      {status}
+    </span>
+  )
+}
 
-const ScienceTopics = () => (
-  <div className="space-y-4">
-    <h2 className="text-xl font-semibold">Science Topics</h2>
-    <ul className="space-y-2">
-      <li className="flex items-center gap-2">
-        <div className="h-2 w-2 rounded-full bg-primary" />
-        <span>Fungal Intelligence Networks</span>
-      </li>
-      <li className="flex items-center gap-2">
-        <div className="h-2 w-2 rounded-full bg-primary" />
-        <span>Mycoremediation Technologies</span>
-      </li>
-      <li className="flex items-center gap-2">
-        <div className="h-2 w-2 rounded-full bg-primary" />
-        <span>Medicinal Compounds</span>
-      </li>
-      <li className="flex items-center gap-2">
-        <div className="h-2 w-2 rounded-full bg-primary" />
-        <span>Sustainable Materials</span>
-      </li>
-    </ul>
-  </div>
-)
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 3 — Research domains atlas
+// ─────────────────────────────────────────────────────────────────────────────
 
-const FCISection = () => (
-  <div className="space-y-6">
-    <h2 className="text-3xl font-bold">Fungal Computer Interface (FCI)</h2>
-    <div className="relative aspect-video rounded-lg overflow-hidden">
-      <Image
-        src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/rs=w_1160,h_663-ESVi80C1sa4fkioBNtFcVtPlY1TkSq.webp"
-        alt="Digital illustration of a mushroom merging with circuit board patterns"
-        fill
-        className="object-cover"
-      />
-    </div>
-    <p className="text-lg text-muted-foreground">
-      The Fungal Computer Interface (FCI) represents a revolutionary approach to computing by harnessing the natural
-      intelligence and connectivity of mycelial networks. This technology aims to create a seamless interface between
-      biological systems and computers, enabling new forms of data processing, environmental monitoring, and sustainable
-      technology.
-    </p>
+const ATLAS_DOMAINS: Array<{
+  id: string
+  icon: typeof Brain
+  title: string
+  status: ResearchStatus
+  description: string
+  bullets: string[]
+  href: string
+  external?: boolean
+}> = [
+  {
+    id: "fci",
+    icon: Sprout,
+    title: "Fungal Interface Lab (FCI)",
+    status: "In Lab",
+    description:
+      "Electrically active, stimulus-responsive fungal substrates instrumented with electrode arrays. We measure nonlinear signal behaviour and stimulation responses — not language.",
+    bullets: [
+      "Electrode arrays on mycelium-bearing substrates",
+      "Spike-train analysis and stimulation protocols",
+      "On-device firmware via mycobrain",
+    ],
+    href: "/science/fci",
+  },
+  {
+    id: "nlm",
+    icon: Brain,
+    title: "Nature Learning Models (NLM)",
+    status: "Prototype",
+    description:
+      "Signal-first foundation models. Environmental, spatial, and temporal streams feed the trunk; language is a reporting layer on top.",
+    bullets: [
+      "Acoustic, atmospheric, geospatial, bioelectric heads",
+      "Trained against curated MINDEX corpora",
+      "Operated through MYCA, governed under AVANI",
+    ],
+    href: "/science/nlm",
+  },
+  {
+    id: "environmental",
+    icon: Wind,
+    title: "Environmental Sensing",
+    status: "Deployed",
+    description:
+      "Twelve sensing modalities from VOC and particulate to LiDAR and Wi-Fi CSI. Each card in §Signal modalities states what that channel sees that the others miss.",
+    bullets: [
+      "Edge inference on Mushroom 1 / Hyphae 1 / MycoNode",
+      "Cross-modal fusion across acoustic, optical, RF",
+      "Maturity labelled honestly per modality",
+    ],
+    href: "#modalities",
+  },
+  {
+    id: "materials",
+    icon: Layers,
+    title: "Materials & Biotech",
+    status: "Research",
+    description:
+      "Mycelium-based composites and bio-derived materials with disciplined coverage of what evidence supports — and what the open questions still are.",
+    bullets: [
+      "96+ species surveyed across published reviews",
+      "Acoustic and thermal performance benchmarks",
+      "Hydrophilicity and standardization gaps tracked",
+    ],
+    href: "/science/materials",
+  },
+  {
+    id: "signal-intelligence",
+    icon: Signal,
+    title: "Signal Intelligence",
+    status: "Research",
+    description:
+      "The NLM thesis end-to-end: representation learning over raw environmental signals, with language used to query and summarise — not to drive perception.",
+    bullets: [
+      "Self-supervised pretraining on sensor corpora",
+      "Multimodal alignment without forced narration",
+      "Open evaluations against BirdNET and CSI baselines",
+    ],
+    href: "#nlm",
+  },
+  {
+    id: "frontier",
+    icon: Satellite,
+    title: "Frontier Infrastructure",
+    status: "Frontier Hypothesis",
+    description:
+      "Subsea, orbital, and lunar compute as future deployment surfaces for environmental intelligence. Tracked as hypotheses with named prior art, not as Mycosoft deployments today.",
+    bullets: [
+      "Subsea: Project Natick Phase 2 reliability data",
+      "Orbital: Axiom Station edge inference briefs",
+      "Lunar: Lonestar Data Holdings frontier work",
+    ],
+    href: "/science/deployments",
+  },
+]
 
-    <div className="grid gap-6 md:grid-cols-2">
-      {/* Hypha Programming Language */}
-      <NeuCard className="p-4">
-        <div className="relative aspect-video rounded-lg overflow-hidden mb-4">
-          <Image
-            src="/placeholder.svg?height=300&width=400&text=Hypha+Language"
-            alt="Hypha Programming Language"
-            fill
-            className="object-cover"
-          />
-        </div>
-        <h3 className="text-xl font-semibold">Hypha Programming Language</h3>
-        <p className="text-sm text-muted-foreground">
-          Hypha is an open-source programming language designed specifically for interacting with and programming
-          mycelial networks. It provides a high-level interface for controlling FCI devices, defining complex
-          algorithms, and managing data flow within fungal systems.
-        </p>
-      </NeuCard>
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 5 — Signal modalities (12)
+// ─────────────────────────────────────────────────────────────────────────────
 
-      {/* Mycorrhizae Protocol */}
-      <NeuCard className="p-4">
-        <div className="relative aspect-video rounded-lg overflow-hidden mb-4">
-          <Image
-            src="/placeholder.svg?height=300&width=400&text=Mycorrhizae+Protocol"
-            alt="Mycorrhizae Protocol"
-            fill
-            className="object-cover"
-          />
-        </div>
-        <h3 className="text-xl font-semibold">Mycorrhizae Protocol</h3>
-        <p className="text-sm text-muted-foreground">
-          The Mycorrhizae Protocol is a communication standard used to connect all FCI devices, enabling seamless
-          integration of intelligence algorithms, APIs, and databases. It facilitates the exchange of data and commands
-          across the entire Mycosoft ecosystem, ensuring interoperability and efficient network management.
-        </p>
-      </NeuCard>
-    </div>
-  </div>
-)
+const SIGNAL_MODALITIES: Array<{
+  name: string
+  icon: typeof Eye
+  signal: string
+  maturity: ResearchStatus
+}> = [
+  {
+    name: "Vision",
+    icon: Eye,
+    signal: "High-resolution stills resolve scene structure that motion video blurs out.",
+    maturity: "Deployed",
+  },
+  {
+    name: "Macro Video",
+    icon: Activity,
+    signal: "Temporal context: growth, dispersal, movement that single frames cannot show.",
+    maturity: "Deployed",
+  },
+  {
+    name: "Microscopy",
+    icon: Microscope,
+    signal: "Sub-millimetre structure for species ID, mycelial morphology, and material QA.",
+    maturity: "In Lab",
+  },
+  {
+    name: "LiDAR",
+    icon: Radar,
+    signal: "True 3D geometry of canopy and terrain that 2D imagery cannot reconstruct.",
+    maturity: "Deployed",
+  },
+  {
+    name: "Radar",
+    icon: Radar,
+    signal: "Penetrates foliage and weather; sees motion under cover that optical sensors miss.",
+    maturity: "Prototype",
+  },
+  {
+    name: "Hydrophones",
+    icon: AudioLines,
+    signal: "Underwater bioacoustics and vessel signatures that air microphones cannot reach.",
+    maturity: "In Lab",
+  },
+  {
+    name: "Microphones",
+    icon: AudioLines,
+    signal: "Airborne acoustics — birds, weather, mechanical signatures — at low marginal cost.",
+    maturity: "Deployed",
+  },
+  {
+    name: "Wi-Fi Sense",
+    icon: Wifi,
+    signal: "Local channel-state perturbation reveals motion and presence; useful indoors, not planetary.",
+    maturity: "Research",
+  },
+  {
+    name: "Particulate",
+    icon: Sparkles,
+    signal: "PM1/PM2.5/PM10 counts surface combustion, dust, and bioaerosol events.",
+    maturity: "Deployed",
+  },
+  {
+    name: "Gas / VOC",
+    icon: Beaker,
+    signal: "Chemical signatures — smoke, decay, plant stress — that optical channels never see.",
+    maturity: "Deployed",
+  },
+  {
+    name: "Weather",
+    icon: Wind,
+    signal: "Pressure, humidity, temperature ground every other modality in a physical context.",
+    maturity: "Deployed",
+  },
+  {
+    name: "Fungal Bioelectrics",
+    icon: Zap,
+    signal:
+      "Stimulus-responsive voltage traces from living substrates — measurable, not yet legible as language.",
+    maturity: "In Lab",
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 6 — NLM subsystems
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NLM_SUBSYSTEMS: Array<{
+  name: string
+  icon: typeof AudioLines
+  trainingSource: string
+  status: ResearchStatus
+  description: string
+}> = [
+  {
+    name: "NLM-Acoustic",
+    icon: AudioLines,
+    trainingSource: "Curated bioacoustic corpora + on-device microphone arrays",
+    status: "Prototype",
+    description:
+      "Species, mechanical, and environmental acoustic events. Benchmarked against BirdNET and Cornell baselines.",
+  },
+  {
+    name: "NLM-Atmospheric",
+    icon: Wind,
+    trainingSource: "VOC, particulate, and weather telemetry across deployed nodes",
+    status: "Prototype",
+    description:
+      "Multi-channel atmospheric state: composition, particulate load, weather. Designed to feed forecasting and anomaly detection without language priors.",
+  },
+  {
+    name: "NLM-Geospatial",
+    icon: Globe,
+    trainingSource: "LiDAR canopy retrievals, radar swaths, sensor-mesh registries",
+    status: "Research",
+    description:
+      "3D scene understanding from spaceborne LiDAR, radar, and ground-truth sensors fused through MINDEX provenance.",
+  },
+  {
+    name: "NLM-Bioelectric",
+    icon: Zap,
+    trainingSource: "FCI probe traces and stimulation logs",
+    status: "Research",
+    description:
+      "Representation learning over fungal bioelectric traces. Outputs structured features, not natural-language transcripts.",
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 7 — Materials & Biotech evidence vs limits
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MATERIALS_EVIDENCE = [
+  {
+    title: "Species breadth",
+    detail:
+      "Reviews report 96+ fungal species used across mycelium-material studies — broad biological tooling.",
+  },
+  {
+    title: "Low-energy, low-carbon process",
+    detail:
+      "Growth-based fabrication at mild temperatures with agricultural waste substrates documented across multiple peer-reviewed reviews.",
+  },
+  {
+    title: "Acoustic and thermal performance",
+    detail:
+      "Mycelium composites achieve competitive sound-absorption and insulation in published benchmarks against EPS and rockwool.",
+  },
+]
+
+const MATERIALS_LIMITS = [
+  {
+    title: "Inconsistent mechanical performance",
+    detail:
+      "Compressive and flexural strength vary by species, substrate, and process — not yet a drop-in replacement for engineered composites.",
+  },
+  {
+    title: "Hydrophilicity",
+    detail:
+      "Untreated mycelium absorbs water; durability in humid or wet environments remains an open materials-science problem.",
+  },
+  {
+    title: "Standardization gaps",
+    detail:
+      "No widely-adopted ASTM/ISO standards for mycelium composites yet. Comparability between studies is limited.",
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 8 — Earth Computer deployments
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEPLOYMENT_NODES: Array<{
+  name: string
+  icon: typeof Leaf
+  status: ResearchStatus
+  description: string
+  reference: string
+}> = [
+  {
+    name: "Forest edge nodes",
+    icon: Leaf,
+    status: "In Lab",
+    description:
+      "Hyphae 1 and Mushroom 1 instances at forest-edge test sites — solar-powered, mesh-networked, running edge inference under canopy.",
+    reference: "Internal: 2026 H1 field trials",
+  },
+  {
+    name: "Subsea compute",
+    icon: Atom,
+    status: "Frontier Hypothesis",
+    description:
+      "Cooled-seabed compute pods are a frontier hypothesis. Prior art: Microsoft Project Natick Phase 2 (Northern Isles) reliability findings.",
+    reference: "Microsoft Project Natick — Northern Isles",
+  },
+  {
+    name: "Orbital compute",
+    icon: Satellite,
+    status: "Frontier Hypothesis",
+    description:
+      "Edge inference payloads on commercial stations and lunar surface compute are tracked as references, not deployed Mycosoft nodes today.",
+    reference: "Axiom Space · Lonestar Lunar",
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 9 — Source repos for the collaboration footer
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SOURCE_REPOS = [
+  {
+    name: "MycosoftLabs/website",
+    href: "https://github.com/MycosoftLabs/website",
+    note: "This atlas, the marketing site, and the Next.js app.",
+  },
+  {
+    name: "MycosoftLabs/mycosoft-mas",
+    href: "https://github.com/MycosoftLabs/mycosoft-mas",
+    note: "Multi-agent system, NLM documentation, MYCA orchestration.",
+  },
+  {
+    name: "MycosoftLabs/mindex",
+    href: "https://github.com/MycosoftLabs/mindex",
+    note: "Training-source registry and provenance for environmental data.",
+  },
+  {
+    name: "MycosoftLabs/mycobrain",
+    href: "https://github.com/MycosoftLabs/mycobrain",
+    note: "ScienceComms, device firmware, FCI probe pipelines.",
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
 
 export default function SciencePage() {
   return (
     <NeuromorphicProvider>
-    <div className="container py-6 md:py-8">
-      <div className="max-w-5xl mx-auto px-4 sm:px-6">
-        <h1 className="text-4xl font-bold mb-8">Science & Research</h1>
-        <p className="text-xl text-muted-foreground mb-12">
-          Advancing the field of mycology through cutting-edge research and innovation
-        </p>
+      <div className="science-glass-page min-h-dvh bg-black text-white">
+        {/* ── Section 1: Hero ── */}
+        <section
+          className="relative min-h-[80dvh] flex items-center justify-center overflow-hidden border-b border-white/10"
+          data-over-video
+        >
+          {SCIENCE_HERO_SOURCES[0] ? (
+            <AutoplayVideo
+              src={SCIENCE_HERO_SOURCES[0]}
+              sources={SCIENCE_HERO_SOURCES}
+              className="absolute inset-0 z-0 h-full w-full object-cover"
+              encodeSrc
+            />
+          ) : (
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 z-0 bg-gradient-to-br from-emerald-950 via-black to-emerald-950/40"
+            />
+          )}
+          {/* Dark overlay */}
+          <div className="pointer-events-none absolute inset-0 z-[2] bg-black/60" />
+          {/* Grid texture */}
+          <div className="pointer-events-none absolute inset-0 z-[2] bg-[linear-gradient(rgba(34,197,94,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(34,197,94,0.04)_1px,transparent_1px)] bg-[size:100px_100px]" />
 
-        <FCISection />
+          <div className="relative z-10 container max-w-6xl mx-auto px-4 md:px-6 text-center">
+            <NeuBadge
+              variant="default"
+              className="mb-6 border border-white/35 bg-white/10 px-4 py-1.5 !text-white backdrop-blur-xl"
+            >
+              Research Atlas · v1
+            </NeuBadge>
 
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 mt-16">
-          <NewsCluster />
-          <ScienceTopics />
+            <h1 className="text-4xl sm:text-5xl md:text-7xl font-bold tracking-tight mb-6">
+              <span className="bg-gradient-to-r from-white via-emerald-200 to-emerald-400 bg-clip-text text-transparent">
+                Science &amp; Research
+              </span>
+            </h1>
 
-          {/* Strategic Partnerships */}
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold">Strategic Partnerships</h2>
-            <NeuCard className="p-6">
-              <div className="flex items-start gap-4">
-                <div className="relative w-24 h-24 flex-shrink-0">
-                  <Image
-                    src="/placeholder-logo.svg"
-                    alt="7ensor Logo"
-                    fill
-                    className="object-contain"
-                  />
-                </div>
-                <div>
-                  <h3 className="text-lg font-semibold flex items-center gap-2">
-                    7ensor
-                    <a href="https://7ensor.com" target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="h-4 w-4" />
-                    </a>
-                  </h3>
-                  <p className="text-sm text-muted-foreground">
-                    Advanced sensing solutions for fungal monitoring and data collection
-                  </p>
-                </div>
-              </div>
-            </NeuCard>
-            <NeuCard className="p-6">
-              <div className="flex items-start gap-4">
-                <div className="relative w-24 h-24 flex-shrink-0">
-                  <Image
-                    src="/assets/about/mycodao-red-cap-logo.png"
-                    alt="MycoDAO Logo"
-                    fill
-                    className="object-contain"
-                  />
-                </div>
-                <div>
-                  <h3 className="text-lg font-semibold flex items-center gap-2">
-                    MycoDAO
-                    <a href="https://mycodao.com" target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="h-4 w-4" />
-                    </a>
-                  </h3>
-                  <p className="text-sm text-muted-foreground">
-                    Decentralized funding and governance for mycological research
-                  </p>
-                </div>
-              </div>
-            </NeuCard>
-            <p className="text-sm text-muted-foreground mt-4">More partnerships coming soon...</p>
-          </div>
-        </div>
+            <p className="text-lg md:text-xl text-white/85 max-w-3xl mx-auto mb-8">
+              Mycology, signal intelligence, and distributed environmental compute for
+              the Earth computer.
+            </p>
 
-        {/* Community & Collaborations */}
-        <div className="mt-16">
-          <h2 className="text-2xl font-bold mb-6">Community & Collaborations</h2>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {/* Research Organizations */}
-            <div>
-              <h3 className="text-lg font-semibold mb-4">Research Organizations</h3>
-              <ul className="space-y-3">
-                <li>
-                  <h4 className="font-medium">FUNDIS</h4>
-                  <p className="text-sm text-muted-foreground">Fungal Diversity Survey</p>
-                </li>
-                <li>
-                  <h4 className="font-medium">NAMA</h4>
-                  <p className="text-sm text-muted-foreground">North American Mycological Association</p>
-                </li>
-                <li>
-                  <h4 className="font-medium">International Mycological Association</h4>
-                  <p className="text-sm text-muted-foreground">Global mycology network</p>
-                </li>
-              </ul>
-            </div>
-
-            {/* Database Projects */}
-            <div>
-              <h3 className="text-lg font-semibold mb-4">Database Projects</h3>
-              <ul className="space-y-3">
-                <li>
-                  <h4 className="font-medium">MycoBank</h4>
-                  <p className="text-sm text-muted-foreground">Fungal nomenclature database</p>
-                </li>
-                <li>
-                  <h4 className="font-medium">FungiDB</h4>
-                  <p className="text-sm text-muted-foreground">Fungal genomics database</p>
-                </li>
-                <li>
-                  <h4 className="font-medium">iNaturalist</h4>
-                  <p className="text-sm text-muted-foreground">Citizen science observations platform</p>
-                </li>
-              </ul>
-            </div>
-
-            {/* Academic Institutions */}
-            <div>
-              <h3 className="text-lg font-semibold mb-4">Academic Institutions</h3>
-              <ul className="space-y-3">
-                <li>
-                  <h4 className="font-medium">UC Berkeley</h4>
-                  <p className="text-sm text-muted-foreground">Department of Plant & Microbial Biology</p>
-                </li>
-                <li>
-                  <h4 className="font-medium">ETH Zürich</h4>
-                  <p className="text-sm text-muted-foreground">Institute of Microbiology</p>
-                </li>
-                <li>
-                  <h4 className="font-medium">Kew Gardens</h4>
-                  <p className="text-sm text-muted-foreground">Fungal Biodiversity Research</p>
-                </li>
-              </ul>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="#ribbon">
+                <NeuButton
+                  variant="default"
+                  className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/10 !text-white backdrop-blur-xl hover:bg-white/20"
+                >
+                  Read latest research
+                  <ArrowRight className="h-4 w-4" />
+                </NeuButton>
+              </Link>
+              <Link href="#atlas">
+                <NeuButton
+                  variant="default"
+                  className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/5 !text-white hover:bg-white/15"
+                >
+                  Explore domains
+                  <ArrowRight className="h-4 w-4" />
+                </NeuButton>
+              </Link>
             </div>
           </div>
-        </div>
+        </section>
+
+        {/* ── Section 2: Live research ribbon ── */}
+        <section
+          id="ribbon"
+          className="relative overflow-hidden border-b border-white/10 py-16 md:py-20"
+        >
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-gradient-to-b from-black via-emerald-950/10 to-black"
+          />
+          <div className="relative z-10 container max-w-7xl mx-auto px-4 md:px-6">
+            <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+              <div>
+                <NeuBadge variant="default" className="mb-4 !text-white">
+                  Live ribbon
+                </NeuBadge>
+                <h2 className="text-3xl md:text-4xl font-bold mb-2">
+                  Latest research &amp; source repositories
+                </h2>
+                <p className="max-w-2xl text-sm md:text-base text-white/70">
+                  A curated stream of peer-reviewed work, datasets, and MycosoftLabs
+                  repos that inform the atlas. Cards link out to the canonical source.
+                </p>
+              </div>
+              <Link
+                href="https://github.com/MycosoftLabs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-3 py-1.5 text-xs text-white/85 hover:bg-white/10"
+              >
+                MycosoftLabs on GitHub
+                <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+              </Link>
+            </div>
+
+            <ResearchRibbon publications={SCIENCE_PUBLICATIONS} limit={12} />
+          </div>
+        </section>
+
+        {/* ── Section 3: Research domains atlas ── */}
+        <section
+          id="atlas"
+          className="relative overflow-hidden border-b border-white/10 py-16 md:py-24"
+        >
+          <ParticleCanvas
+            variant="auto"
+            className="absolute inset-0 -z-10 opacity-50"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 -z-10 bg-gradient-to-b from-black via-black/80 to-black"
+          />
+          <div className="relative z-10 container max-w-7xl mx-auto px-4 md:px-6">
+            <div className="mb-12 text-center">
+              <NeuBadge variant="default" className="mb-4 !text-white">
+                Atlas
+              </NeuBadge>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">
+                Six domains, one Earth-scale stack
+              </h2>
+              <p className="mx-auto max-w-3xl text-base md:text-lg text-white/75">
+                Each domain links into a sub-page or anchored section. Maturity is
+                labelled honestly: Deployed, In Lab, Prototype, Research, or Frontier
+                Hypothesis.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {ATLAS_DOMAINS.map((domain) => {
+                const Icon = domain.icon
+                const isAnchor = domain.href.startsWith("#")
+                const Card = (
+                  <NeuCard className="h-full">
+                    <NeuCardContent className="flex h-full flex-col gap-4 p-6">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 p-3">
+                          <Icon className="h-6 w-6 text-emerald-200" aria-hidden />
+                        </div>
+                        <StatusPill status={domain.status} />
+                      </div>
+                      <div>
+                        <h3 className="text-xl font-bold">{domain.title}</h3>
+                        <p className="mt-2 text-sm leading-relaxed text-white/75">
+                          {domain.description}
+                        </p>
+                      </div>
+                      <ul className="space-y-1.5 text-sm text-white/80">
+                        {domain.bullets.map((b) => (
+                          <li key={b} className="flex items-start gap-2">
+                            <ChevronRight
+                              className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300"
+                              aria-hidden
+                            />
+                            <span>{b}</span>
+                          </li>
+                        ))}
+                      </ul>
+                      <div className="mt-auto pt-2">
+                        <span className="inline-flex items-center gap-2 text-sm font-medium text-emerald-200">
+                          {isAnchor ? "Jump to section" : "Open sub-page"}
+                          <ArrowRight className="h-4 w-4" aria-hidden />
+                        </span>
+                      </div>
+                    </NeuCardContent>
+                  </NeuCard>
+                )
+                return (
+                  <Link
+                    key={domain.id}
+                    href={domain.href}
+                    className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/50 rounded-2xl"
+                  >
+                    {Card}
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Section 4: Fungal Interface Lab ── */}
+        <section
+          id="fci"
+          className="relative overflow-hidden border-b border-white/10 py-16 md:py-24"
+        >
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-gradient-to-b from-black via-emerald-950/15 to-black"
+          />
+          <div className="relative z-10 container max-w-7xl mx-auto px-4 md:px-6">
+            <div className="mb-12 max-w-3xl">
+              <NeuBadge variant="default" className="mb-4 !text-white">
+                Fungal Interface Lab
+              </NeuBadge>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">
+                Electrically active substrates, instrumented and stimulated
+              </h2>
+              <p className="text-base md:text-lg text-white/75">
+                The honest framing: fungi are electrically active, stimulus-responsive,
+                spatially organized biological substrates with measurable nonlinear
+                signal behaviour. They are not language-capable computers, and we do
+                not claim to translate them.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 items-start">
+              {/* Left: image slots */}
+              <div className="space-y-6">
+                {/* TODO: electrode array photo */}
+                <div className="aspect-[4/3] rounded-2xl border border-emerald-500/20 bg-gradient-to-br from-emerald-950/30 to-black/40 backdrop-blur-md grid place-items-center">
+                  <span className="text-emerald-200/60 text-xs">
+                    TODO: electrode array photo
+                  </span>
+                </div>
+                {/* TODO: spike trace plot */}
+                <div className="aspect-[4/3] rounded-2xl border border-emerald-500/20 bg-gradient-to-br from-emerald-950/30 to-black/40 backdrop-blur-md grid place-items-center">
+                  <span className="text-emerald-200/60 text-xs">
+                    TODO: spike trace plot
+                  </span>
+                </div>
+                {/* TODO: substrate macro shot */}
+                <div className="aspect-[4/3] rounded-2xl border border-emerald-500/20 bg-gradient-to-br from-emerald-950/30 to-black/40 backdrop-blur-md grid place-items-center">
+                  <span className="text-emerald-200/60 text-xs">
+                    TODO: substrate macro shot
+                  </span>
+                </div>
+              </div>
+
+              {/* Right: 4-paragraph framing + stats + CTA */}
+              <div className="space-y-6">
+                <div className="space-y-5 text-base leading-relaxed text-white/85">
+                  <p>
+                    Mycelium networks carry measurable voltage activity. Multi-electrode
+                    arrays record nonlinear spiking behaviour with structure that
+                    statistical methods can cluster — a useful signal-processing object
+                    for representation learning.
+                  </p>
+                  <p>
+                    Stimulation programs probe response: substrates react to chemical,
+                    thermal, mechanical, and light cues. We characterise those responses
+                    rather than narrate them.
+                  </p>
+                  <p>
+                    The hypothesis we test is narrow: that fungal substrates form a
+                    bioelectric sensing surface useful inside a broader environmental
+                    fabric. The hypothesis we explicitly do not advance is that fungi
+                    speak a language we can decode.
+                  </p>
+                  <p>
+                    All FCI workflows are scoped under AVANI governance — admissibility,
+                    safety, and provenance — and recorded through MINDEX so every probe
+                    trace is auditable.
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  {[
+                    { label: "Probes deployed", value: "Coming H2 2026" },
+                    { label: "Signals catalogued", value: "Coming H2 2026" },
+                    { label: "Stimulation programs", value: "Coming H2 2026" },
+                  ].map((stat) => (
+                    <div
+                      key={stat.label}
+                      className="rounded-2xl border border-white/15 bg-white/5 p-4"
+                    >
+                      <div className="text-xs uppercase tracking-wider text-emerald-200/80">
+                        {stat.label}
+                      </div>
+                      <div className="mt-1 text-sm font-semibold text-white/90">
+                        {stat.value}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="pt-2">
+                  <Link href="/science/fci">
+                    <NeuButton
+                      variant="default"
+                      className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/10 !text-white backdrop-blur-xl hover:bg-white/20"
+                    >
+                      Open Fungal Interface Lab
+                      <ArrowRight className="h-4 w-4" aria-hidden />
+                    </NeuButton>
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Section 5: Signal modalities ── */}
+        <section
+          id="modalities"
+          className="relative overflow-hidden border-b border-white/10 py-16 md:py-24"
+        >
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-gradient-to-b from-black via-black/80 to-black"
+          />
+          <div className="relative z-10 container max-w-7xl mx-auto px-4 md:px-6">
+            <div className="mb-12 max-w-3xl">
+              <NeuBadge variant="default" className="mb-4 !text-white">
+                Signal modalities
+              </NeuBadge>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">
+                Twelve channels, each chosen for what others miss
+              </h2>
+              <p className="text-base md:text-lg text-white/75">
+                Sensor fusion only beats single-modality baselines when each modality
+                contributes signal the others cannot. Below: what each channel uniquely
+                surfaces.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+              {SIGNAL_MODALITIES.map((m) => {
+                const Icon = m.icon
+                return (
+                  <NeuCard key={m.name} className="h-full">
+                    <NeuCardContent className="flex h-full flex-col gap-3 p-5">
+                      <div className="flex items-center justify-between">
+                        <div className="rounded-lg border border-emerald-400/30 bg-emerald-500/10 p-2">
+                          <Icon className="h-5 w-5 text-emerald-200" aria-hidden />
+                        </div>
+                        <StatusPill status={m.maturity} />
+                      </div>
+                      <h3 className="text-base font-semibold text-white">{m.name}</h3>
+                      <p className="text-sm leading-relaxed text-white/75">
+                        {m.signal}
+                      </p>
+                    </NeuCardContent>
+                  </NeuCard>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Section 6: Nature Learning Models (NLM) ── */}
+        <section
+          id="nlm"
+          className="relative overflow-hidden border-b border-white/10 py-16 md:py-24"
+        >
+          <NeuralNetworkCanvas className="absolute inset-0 -z-10 opacity-60" />
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 -z-10 bg-gradient-to-b from-black via-emerald-950/20 to-black"
+          />
+          <div className="relative z-10 container max-w-6xl mx-auto px-4 md:px-6">
+            <div className="rounded-3xl border border-white/15 bg-white/[0.04] p-6 backdrop-blur-xl md:p-10">
+              <NeuBadge variant="default" className="mb-4 !text-white">
+                Nature Learning Models
+              </NeuBadge>
+              <h2 className="text-3xl md:text-5xl font-bold mb-4">
+                Signals first. Language second.
+              </h2>
+              <div className="grid gap-6 md:grid-cols-2 mb-8">
+                <p className="text-base md:text-lg leading-relaxed text-white/85">
+                  Environmental, spatial, and temporal data come first. NLMs learn
+                  representations over acoustic, atmospheric, geospatial, and
+                  bioelectric streams before any text is involved — closer to a sensor
+                  foundation model than to a chat model.
+                </p>
+                <p className="text-base md:text-lg leading-relaxed text-white/85">
+                  Language is the reporting layer. It is how operators query, summarise,
+                  and audit what the signal models surface. It is not the perception
+                  pathway, and it is not how the model learns to see.
+                </p>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {NLM_SUBSYSTEMS.map((s) => {
+                  const Icon = s.icon
+                  return (
+                    <div
+                      key={s.name}
+                      className="rounded-2xl border border-white/15 bg-black/30 p-5"
+                    >
+                      <div className="flex items-center justify-between gap-3 mb-2">
+                        <div className="flex items-center gap-3">
+                          <div className="rounded-lg border border-emerald-400/30 bg-emerald-500/10 p-2">
+                            <Icon className="h-5 w-5 text-emerald-200" aria-hidden />
+                          </div>
+                          <h3 className="text-lg font-semibold">{s.name}</h3>
+                        </div>
+                        <StatusPill status={s.status} />
+                      </div>
+                      <p className="text-sm leading-relaxed text-white/75">
+                        {s.description}
+                      </p>
+                      <p className="mt-3 text-xs uppercase tracking-wider text-emerald-200/80">
+                        Training source
+                      </p>
+                      <p className="text-xs text-white/70">{s.trainingSource}</p>
+                    </div>
+                  )
+                })}
+              </div>
+
+              <div className="mt-8 flex flex-wrap gap-3">
+                <Link href="/science/nlm">
+                  <NeuButton
+                    variant="default"
+                    className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/10 !text-white backdrop-blur-xl hover:bg-white/20"
+                  >
+                    Open NLM sub-page
+                    <ArrowRight className="h-4 w-4" aria-hidden />
+                  </NeuButton>
+                </Link>
+                <Link
+                  href="https://github.com/MycosoftLabs/mycosoft-mas"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <NeuButton
+                    variant="default"
+                    className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/5 !text-white hover:bg-white/15"
+                  >
+                    mycosoft-mas on GitHub
+                    <ExternalLink className="h-4 w-4" aria-hidden />
+                  </NeuButton>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Section 7: Materials & Biotech ── */}
+        <section
+          id="materials"
+          className="relative overflow-hidden border-b border-white/10 py-16 md:py-24"
+        >
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-gradient-to-b from-black via-black/80 to-black"
+          />
+          <div className="relative z-10 container max-w-7xl mx-auto px-4 md:px-6">
+            <div className="mb-12 max-w-3xl">
+              <NeuBadge variant="default" className="mb-4 !text-white">
+                Materials &amp; Biotech
+              </NeuBadge>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">
+                What the evidence supports — and what it does not
+              </h2>
+              <p className="text-base md:text-lg text-white/75">
+                Mycelium materials have a real published evidence base and real
+                open questions. Both are tracked here in the same disciplined tone.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr_0.9fr] gap-6 items-start">
+              {/* Evidence column */}
+              <div className="rounded-3xl border border-emerald-400/25 bg-emerald-500/[0.04] p-6">
+                <h3 className="text-lg font-semibold text-emerald-200 mb-4">
+                  What evidence supports
+                </h3>
+                <ul className="space-y-4">
+                  {MATERIALS_EVIDENCE.map((e) => (
+                    <li key={e.title}>
+                      <div className="flex items-start gap-2">
+                        <ChevronRight
+                          className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300"
+                          aria-hidden
+                        />
+                        <div>
+                          <div className="text-sm font-semibold text-white">
+                            {e.title}
+                          </div>
+                          <p className="text-sm leading-relaxed text-white/75">
+                            {e.detail}
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Limits column */}
+              <div className="rounded-3xl border border-amber-400/25 bg-amber-500/[0.04] p-6">
+                <h3 className="text-lg font-semibold text-amber-200 mb-4">
+                  Honest limits
+                </h3>
+                <ul className="space-y-4">
+                  {MATERIALS_LIMITS.map((e) => (
+                    <li key={e.title}>
+                      <div className="flex items-start gap-2">
+                        <ChevronRight
+                          className="mt-0.5 h-4 w-4 shrink-0 text-amber-300"
+                          aria-hidden
+                        />
+                        <div>
+                          <div className="text-sm font-semibold text-white">
+                            {e.title}
+                          </div>
+                          <p className="text-sm leading-relaxed text-white/75">
+                            {e.detail}
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* TODO microscopy image slot + CTA */}
+              <div className="space-y-4">
+                {/* TODO: mycelium microscopy image */}
+                <div className="aspect-[4/3] rounded-2xl border border-emerald-500/20 bg-gradient-to-br from-emerald-950/30 to-black/40 backdrop-blur-md grid place-items-center">
+                  <span className="text-emerald-200/60 text-xs">
+                    TODO: mycelium microscopy
+                  </span>
+                </div>
+                <Link href="/science/materials">
+                  <NeuButton
+                    variant="default"
+                    className="w-full gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/10 !text-white backdrop-blur-xl hover:bg-white/20"
+                  >
+                    Open Materials sub-page
+                    <ArrowRight className="h-4 w-4" aria-hidden />
+                  </NeuButton>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Section 8: Earth Computer deployments ── */}
+        <section
+          id="deployments"
+          className="relative overflow-hidden border-b border-white/10 py-16 md:py-24"
+        >
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-gradient-to-b from-black via-emerald-950/10 to-black"
+          />
+          <div className="relative z-10 container max-w-7xl mx-auto px-4 md:px-6">
+            <div className="mb-12 max-w-3xl">
+              <NeuBadge variant="default" className="mb-4 !text-white">
+                Earth Computer deployments
+              </NeuBadge>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">
+                Where the compute actually lives
+              </h2>
+              <p className="text-base md:text-lg text-white/75">
+                Forest edge today; subsea and orbital as named frontier hypotheses
+                with prior art. Status labels are deliberately conservative.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {DEPLOYMENT_NODES.map((node) => {
+                const Icon = node.icon
+                return (
+                  <NeuCard key={node.name} className="h-full">
+                    <NeuCardContent className="flex h-full flex-col gap-4 p-6">
+                      {/* TODO: world-map deployment slot */}
+                      <div className="aspect-[16/10] rounded-xl border border-emerald-500/20 bg-gradient-to-br from-emerald-950/30 to-black/40 backdrop-blur-md grid place-items-center">
+                        <span className="text-emerald-200/60 text-xs">
+                          TODO: world-map for {node.name}
+                        </span>
+                      </div>
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex items-center gap-3">
+                          <div className="rounded-lg border border-emerald-400/30 bg-emerald-500/10 p-2">
+                            <Icon className="h-5 w-5 text-emerald-200" aria-hidden />
+                          </div>
+                          <h3 className="text-lg font-semibold">{node.name}</h3>
+                        </div>
+                        <StatusPill status={node.status} />
+                      </div>
+                      <p className="text-sm leading-relaxed text-white/75">
+                        {node.description}
+                      </p>
+                      <p className="mt-auto text-xs uppercase tracking-wider text-emerald-200/80">
+                        Reference: <span className="text-white/70 normal-case tracking-normal">{node.reference}</span>
+                      </p>
+                    </NeuCardContent>
+                  </NeuCard>
+                )
+              })}
+            </div>
+
+            <div className="mt-10 flex justify-center">
+              <Link href="/science/deployments">
+                <NeuButton
+                  variant="default"
+                  className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/10 !text-white backdrop-blur-xl hover:bg-white/20"
+                >
+                  Open Deployments sub-page
+                  <ArrowRight className="h-4 w-4" aria-hidden />
+                </NeuButton>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Section 9: Publications, repos & collaboration footer ── */}
+        <section
+          id="publications"
+          className="relative overflow-hidden py-16 md:py-24"
+        >
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-gradient-to-b from-black via-black/80 to-black"
+          />
+          <div className="relative z-10 container max-w-7xl mx-auto px-4 md:px-6">
+            <div className="mb-12 max-w-3xl">
+              <NeuBadge variant="default" className="mb-4 !text-white">
+                Publications · Repos · Collaborate
+              </NeuBadge>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">
+                Read the work, fork the code, open a thread
+              </h2>
+              <p className="text-base md:text-lg text-white/75">
+                Everything in the atlas points to a public artifact: a paper, a report,
+                or a repo. If something is missing, file an issue or open a thread.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+              {/* Publications column */}
+              <div className="rounded-3xl border border-white/15 bg-white/[0.03] p-6">
+                <div className="flex items-center gap-3 mb-4">
+                  <FlaskConical
+                    className="h-5 w-5 text-emerald-200"
+                    aria-hidden
+                  />
+                  <h3 className="text-lg font-semibold">Publications &amp; reports</h3>
+                </div>
+                <ul className="space-y-3">
+                  {SCIENCE_PUBLICATIONS.map((p) => (
+                    <li key={p.id}>
+                      <a
+                        href={p.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group block rounded-lg border border-white/10 bg-white/[0.02] p-3 hover:bg-white/[0.05]"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <span className="text-sm font-medium text-white group-hover:text-emerald-200">
+                            {p.title}
+                          </span>
+                          <ExternalLink
+                            className="mt-0.5 h-3.5 w-3.5 shrink-0 text-white/50"
+                            aria-hidden
+                          />
+                        </div>
+                        <div className="mt-1 text-xs text-white/60">
+                          {p.source} · {p.year} · {p.modality}
+                        </div>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Source repos column */}
+              <div className="rounded-3xl border border-white/15 bg-white/[0.03] p-6">
+                <div className="flex items-center gap-3 mb-4">
+                  <Cpu className="h-5 w-5 text-emerald-200" aria-hidden />
+                  <h3 className="text-lg font-semibold">Source repos</h3>
+                </div>
+                <ul className="space-y-3">
+                  {SOURCE_REPOS.map((repo) => (
+                    <li key={repo.href}>
+                      <a
+                        href={repo.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group block rounded-lg border border-white/10 bg-white/[0.02] p-3 hover:bg-white/[0.05]"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <span className="text-sm font-medium text-white group-hover:text-emerald-200">
+                            {repo.name}
+                          </span>
+                          <ExternalLink
+                            className="mt-0.5 h-3.5 w-3.5 shrink-0 text-white/50"
+                            aria-hidden
+                          />
+                        </div>
+                        <div className="mt-1 text-xs text-white/60">{repo.note}</div>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Collaborate column */}
+              <div className="rounded-3xl border border-white/15 bg-white/[0.03] p-6">
+                <div className="flex items-center gap-3 mb-4">
+                  <Network className="h-5 w-5 text-emerald-200" aria-hidden />
+                  <h3 className="text-lg font-semibold">Collaborate</h3>
+                </div>
+                <p className="text-sm leading-relaxed text-white/75 mb-5">
+                  Researchers, operators, and field collaborators welcome. Open a
+                  research thread, join MycoDAO, or reach out about a specific paper or
+                  modality.
+                </p>
+                <div className="space-y-3">
+                  <a
+                    href="mailto:research@mycosoft.org"
+                    className="block rounded-lg border border-white/10 bg-white/[0.02] p-3 hover:bg-white/[0.05]"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-white">
+                        Open a research thread
+                      </span>
+                      <ArrowRight className="h-4 w-4 text-emerald-200" aria-hidden />
+                    </div>
+                    <div className="mt-1 text-xs text-white/60">
+                      research@mycosoft.org
+                    </div>
+                  </a>
+                  <a
+                    href="https://mycodao.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block rounded-lg border border-white/10 bg-white/[0.02] p-3 hover:bg-white/[0.05]"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-white">
+                        Join MycoDAO
+                      </span>
+                      <ExternalLink className="h-4 w-4 text-white/50" aria-hidden />
+                    </div>
+                    <div className="mt-1 text-xs text-white/60">
+                      Decentralised research funding and community governance.
+                    </div>
+                  </a>
+                  <Link
+                    href="/about"
+                    className="block rounded-lg border border-white/10 bg-white/[0.02] p-3 hover:bg-white/[0.05]"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-white">
+                        About Mycosoft
+                      </span>
+                      <ArrowRight className="h-4 w-4 text-emerald-200" aria-hidden />
+                    </div>
+                    <div className="mt-1 text-xs text-white/60">
+                      Mission, organisation, and operating principles.
+                    </div>
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Glass shell — copied from .about-glass-page, renamed. Scopes the
+            liquid-glass look to this page only. */}
+        <style jsx global>{`
+          .science-glass-page .neu-raised,
+          .science-glass-page .neu-raised-sm,
+          .science-glass-page .neu-btn,
+          .science-glass-page [class*="rounded-xl"][class*="border"],
+          .science-glass-page [class*="rounded-2xl"][class*="border"],
+          .science-glass-page [class*="rounded-3xl"][class*="border"] {
+            position: relative;
+            overflow: hidden;
+            border-color: rgba(255, 255, 255, 0.34) !important;
+            background:
+              linear-gradient(135deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.075) 42%, rgba(255, 255, 255, 0.03)) !important;
+            box-shadow:
+              0 18px 52px rgba(0, 0, 0, 0.28),
+              0 7px 18px rgba(255, 255, 255, 0.08),
+              inset 0 1px 0 rgba(255, 255, 255, 0.62),
+              inset 0 -22px 38px rgba(255, 255, 255, 0.07) !important;
+            backdrop-filter: blur(18px) saturate(1.22);
+            -webkit-backdrop-filter: blur(18px) saturate(1.22);
+          }
+
+          .science-glass-page .neu-raised::before,
+          .science-glass-page .neu-raised-sm::before,
+          .science-glass-page .neu-btn::before,
+          .science-glass-page [class*="rounded-xl"][class*="border"]::before,
+          .science-glass-page [class*="rounded-2xl"][class*="border"]::before,
+          .science-glass-page [class*="rounded-3xl"][class*="border"]::before {
+            content: "";
+            position: absolute;
+            inset: 1px 2px auto;
+            height: 42%;
+            border-radius: inherit;
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0));
+            pointer-events: none;
+          }
+
+          .science-glass-page .neu-btn:hover,
+          .science-glass-page .neu-raised:hover,
+          .science-glass-page .neu-raised-sm:hover,
+          .science-glass-page [class*="rounded-xl"][class*="border"]:hover,
+          .science-glass-page [class*="rounded-2xl"][class*="border"]:hover,
+          .science-glass-page [class*="rounded-3xl"][class*="border"]:hover {
+            border-color: rgba(255, 255, 255, 0.52) !important;
+            background:
+              linear-gradient(135deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.105) 42%, rgba(255, 255, 255, 0.045)) !important;
+            box-shadow:
+              0 24px 64px rgba(0, 0, 0, 0.34),
+              0 9px 24px rgba(255, 255, 255, 0.12),
+              inset 0 1px 0 rgba(255, 255, 255, 0.75),
+              inset 0 -22px 38px rgba(255, 255, 255, 0.09) !important;
+          }
+        `}</style>
       </div>
-    </div>
     </NeuromorphicProvider>
   )
 }

--- a/components/science/research-ribbon.tsx
+++ b/components/science/research-ribbon.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import { ExternalLink } from "lucide-react"
+import { NeuCard, NeuCardContent } from "@/components/ui/neuromorphic"
+import {
+  MODALITY_BADGE_CLASSES,
+  STATUS_PILL_CLASSES,
+  type SciencePublication,
+} from "@/lib/science-publications"
+
+interface ResearchRibbonProps {
+  publications: SciencePublication[]
+  /** Optional cap; defaults to 12 to match spec. */
+  limit?: number
+}
+
+// TODO(api): swap to fetch('/api/research/feed') when route ships.
+// For now the ribbon is a pure component over `lib/science-publications.ts`
+// so it stays SSR-friendly and trivially testable. The data shape is stable
+// (`SciencePublication`), so an eventual API can return the same JSON.
+
+export function ResearchRibbon({ publications, limit = 12 }: ResearchRibbonProps) {
+  const items = publications.slice(0, limit)
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-white/60">
+        No publications yet — check back as the atlas grows.
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="research-ribbon -mx-4 overflow-x-auto px-4 pb-4 [scrollbar-width:thin]"
+      role="region"
+      aria-label="Latest research and source repositories"
+    >
+      <ul className="flex snap-x snap-mandatory gap-4">
+        {items.map((pub) => {
+          const modalityClass = MODALITY_BADGE_CLASSES[pub.modality]
+          const statusClass = pub.status ? STATUS_PILL_CLASSES[pub.status] : null
+          return (
+            <li
+              key={pub.id}
+              className="snap-start shrink-0 min-w-[280px] sm:min-w-[320px] max-w-[360px]"
+            >
+              <NeuCard className="h-full">
+                <NeuCardContent className="flex h-full flex-col gap-3 p-5">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span
+                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${modalityClass}`}
+                    >
+                      {pub.modality}
+                    </span>
+                    {statusClass ? (
+                      <span
+                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${statusClass}`}
+                      >
+                        {pub.status}
+                      </span>
+                    ) : null}
+                    <span className="ml-auto text-[10px] uppercase tracking-wider text-white/40">
+                      {pub.kind}
+                    </span>
+                  </div>
+
+                  <a
+                    href={pub.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex flex-col gap-2"
+                  >
+                    <h3 className="line-clamp-2 text-base font-semibold text-white group-hover:text-emerald-200">
+                      {pub.title}
+                    </h3>
+                    {pub.blurb ? (
+                      <p className="line-clamp-3 text-xs leading-relaxed text-white/70">
+                        {pub.blurb}
+                      </p>
+                    ) : null}
+                  </a>
+
+                  <div className="mt-auto flex items-center justify-between gap-3 pt-2 text-xs text-white/60">
+                    <span className="truncate">
+                      {pub.source} · {pub.year}
+                    </span>
+                    <a
+                      href={pub.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Open ${pub.title} in a new tab`}
+                      className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-[10px] text-white/80 hover:bg-white/10"
+                    >
+                      Open
+                      <ExternalLink className="h-3 w-3" aria-hidden />
+                    </a>
+                  </div>
+                </NeuCardContent>
+              </NeuCard>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/components/science/stub-layout.tsx
+++ b/components/science/stub-layout.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link"
+import { ArrowLeft, Construction } from "lucide-react"
+import { NeuButton, NeuBadge } from "@/components/ui/neuromorphic"
+import { STATUS_PILL_CLASSES } from "@/lib/science-publications"
+
+interface ScienceStubLayoutProps {
+  eyebrow?: string
+  title: string
+  description: string
+  /** Anchor on /science to return to. Defaults to /science. */
+  parentHref?: string
+}
+
+/**
+ * Shared stub layout for the four `/science/{fci,nlm,materials,deployments}`
+ * sub-routes. Renders a full-height dark section with an honest "in production"
+ * status pill — these are not deployed lab pages yet.
+ */
+export function ScienceStubLayout({
+  eyebrow = "Research Atlas · Sub-page",
+  title,
+  description,
+  parentHref = "/science",
+}: ScienceStubLayoutProps) {
+  return (
+    <section className="relative isolate min-h-dvh overflow-hidden bg-black text-white">
+      {/* Gradient backdrop */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 -z-10 bg-gradient-to-br from-emerald-950 via-black to-emerald-950/30"
+      />
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 -z-10 bg-[linear-gradient(rgba(34,197,94,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(34,197,94,0.04)_1px,transparent_1px)] bg-[size:80px_80px]"
+      />
+
+      <div className="container mx-auto flex min-h-dvh max-w-4xl flex-col items-start justify-center gap-8 px-4 py-24 md:px-6">
+        <NeuBadge variant="default" className="border-white/30 bg-white/10 text-white">
+          {eyebrow}
+        </NeuBadge>
+
+        <h1 className="text-4xl font-bold leading-tight md:text-6xl">{title}</h1>
+
+        <p className="max-w-2xl text-lg leading-relaxed text-white/75">{description}</p>
+
+        <span
+          className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium ${STATUS_PILL_CLASSES["Frontier Hypothesis"]}`}
+        >
+          <Construction className="h-3.5 w-3.5" aria-hidden />
+          Full lab page in production · Coming H2 2026
+        </span>
+
+        <div className="flex flex-wrap items-center gap-3 pt-4">
+          <Link href={parentHref}>
+            <NeuButton
+              variant="default"
+              className="gap-2 min-h-[44px] px-6 py-3 border border-white/30 bg-white/10 !text-white backdrop-blur-xl hover:bg-white/20"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Back to atlas
+            </NeuButton>
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/lib/science-publications.ts
+++ b/lib/science-publications.ts
@@ -1,0 +1,229 @@
+/**
+ * Curated research publications, datasets, and source repos referenced from
+ * the Science & Research atlas (`/science`). Mix of public peer-reviewed work
+ * (where the URL points to the actual paper/report) and MycosoftLabs source
+ * repositories that document the relevant systems.
+ *
+ * Editorial guardrails (see /science page spec):
+ *  - Honest framing on fungal substrates: electrically active, stimulus-
+ *    responsive, spatially organized — not "fungi are computers".
+ *  - Frontier/exploratory work is labelled with `status: "Frontier Hypothesis"`
+ *    or `status: "Research"`, never as deployed capability.
+ */
+
+export type ResearchStatus =
+  | "Deployed"
+  | "In Lab"
+  | "Prototype"
+  | "Research"
+  | "Frontier Hypothesis"
+
+export type ResearchModality =
+  | "FCI"
+  | "VOC"
+  | "Acoustics"
+  | "LiDAR"
+  | "Radar"
+  | "RF"
+  | "Materials"
+  | "Biotech"
+  | "Compute"
+  | "NLM"
+
+export interface SciencePublication {
+  id: string
+  title: string
+  source: string
+  year: number
+  url: string
+  modality: ResearchModality
+  status?: ResearchStatus
+  kind: "paper" | "repo" | "report" | "dataset"
+  /** Optional one-line summary shown beneath the title in the ribbon. */
+  blurb?: string
+}
+
+export const SCIENCE_PUBLICATIONS: SciencePublication[] = [
+  {
+    id: "adamatzky-fungal-electrical",
+    title: "On spiking behaviour of oyster fungi Pleurotus djamor",
+    source: "Royal Society Open Science · Adamatzky",
+    year: 2018,
+    url: "https://doi.org/10.1098/rsos.181373",
+    modality: "FCI",
+    status: "Research",
+    kind: "paper",
+    blurb:
+      "Measurable nonlinear spiking activity in fungal mycelium — foundational electrophysiology, not evidence of language.",
+  },
+  {
+    id: "adamatzky-language",
+    title: "Language of fungi derived from their electrical spiking activity",
+    source: "Royal Society Open Science · Adamatzky",
+    year: 2022,
+    url: "https://doi.org/10.1098/rsos.211926",
+    modality: "FCI",
+    status: "Frontier Hypothesis",
+    kind: "paper",
+    blurb:
+      "Statistical clustering of spike trains. Useful as a signal-processing reference; we do not claim interspecies translation is solved.",
+  },
+  {
+    id: "cerimi-mycelium-materials",
+    title: "Fungi as source for new bio-based materials: a patent review",
+    source: "Fungal Biology and Biotechnology · Cerimi et al.",
+    year: 2019,
+    url: "https://doi.org/10.1186/s40694-019-0080-y",
+    modality: "Materials",
+    status: "Research",
+    kind: "paper",
+    blurb:
+      "Species and process landscape for mycelium-based materials — anchors honest-limits discussion in §Materials.",
+  },
+  {
+    id: "jones-mycelium-review",
+    title:
+      "Engineered mycelium composite construction materials from fungal biorefineries: a critical review",
+    source: "Materials & Design · Jones et al.",
+    year: 2020,
+    url: "https://doi.org/10.1016/j.matdes.2020.108397",
+    modality: "Materials",
+    status: "Research",
+    kind: "paper",
+    blurb:
+      "Critical review of mechanical performance, hydrophilicity, and standardization gaps in mycelium composites.",
+  },
+  {
+    id: "birdnet-cornell",
+    title: "BirdNET: A deep learning solution for avian diversity monitoring",
+    source: "Ecological Informatics · Kahl et al. (Cornell Lab)",
+    year: 2021,
+    url: "https://doi.org/10.1016/j.ecoinf.2021.101236",
+    modality: "Acoustics",
+    status: "Deployed",
+    kind: "paper",
+    blurb:
+      "Reference bioacoustic ML pipeline — the kind of signal-first model NLM-Acoustic is benchmarked against.",
+  },
+  {
+    id: "icesat2-canopy",
+    title: "Global forest canopy height from ICESat-2 ATL08",
+    source: "Remote Sensing of Environment · Neuenschwander et al.",
+    year: 2020,
+    url: "https://doi.org/10.1016/j.rse.2020.112110",
+    modality: "LiDAR",
+    status: "Deployed",
+    kind: "paper",
+    blurb:
+      "Spaceborne LiDAR canopy height retrieval — context for forest-edge node geospatial fusion.",
+  },
+  {
+    id: "wifi-csi-survey",
+    title:
+      "Wi-Fi Sensing with Channel State Information: A Survey",
+    source: "ACM Computing Surveys · Ma, Zhou, Wang",
+    year: 2019,
+    url: "https://doi.org/10.1145/3310194",
+    modality: "RF",
+    status: "Research",
+    kind: "paper",
+    blurb:
+      "Surveys the CSI-sensing literature. We treat Wi-Fi Sense as a local presence/motion modality, not planetary perception.",
+  },
+  {
+    id: "natick-northern-isles",
+    title: "Project Natick — Phase 2 (Northern Isles) Final Report",
+    source: "Microsoft Research",
+    year: 2020,
+    url: "https://natick.research.microsoft.com/",
+    modality: "Compute",
+    status: "Frontier Hypothesis",
+    kind: "report",
+    blurb:
+      "Cited as prior art for subsea compute reliability hypotheses. Cooled-seabed datacenters remain an open frontier.",
+  },
+  {
+    id: "axiom-orbital",
+    title: "Axiom Station orbital compute and edge inference",
+    source: "Axiom Space program briefs",
+    year: 2025,
+    url: "https://www.axiomspace.com/axiom-station",
+    modality: "Compute",
+    status: "Frontier Hypothesis",
+    kind: "report",
+    blurb:
+      "Reference for orbital compute payloads. Mycosoft tracks but does not claim deployed orbital nodes.",
+  },
+  {
+    id: "lonestar-lunar-compute",
+    title: "Lonestar lunar data centers",
+    source: "Lonestar Data Holdings",
+    year: 2024,
+    url: "https://www.lonestarlunar.com/",
+    modality: "Compute",
+    status: "Frontier Hypothesis",
+    kind: "report",
+    blurb:
+      "Frontier example for off-world data infrastructure — cited as comparable hypothesis, not Mycosoft deployment.",
+  },
+  {
+    id: "mycosoft-mas",
+    title: "mycosoft-mas — Multi-Agent System & NLM documentation",
+    source: "MycosoftLabs · GitHub",
+    year: 2026,
+    url: "https://github.com/MycosoftLabs/mycosoft-mas",
+    modality: "NLM",
+    status: "Prototype",
+    kind: "repo",
+    blurb:
+      "Source-of-truth for NLM subsystem definitions, MYCA orchestration, and agent contracts.",
+  },
+  {
+    id: "mindex",
+    title: "MINDEX — environmental training-source registry",
+    source: "MycosoftLabs · GitHub",
+    year: 2026,
+    url: "https://github.com/MycosoftLabs/mindex",
+    modality: "Compute",
+    status: "Prototype",
+    kind: "repo",
+    blurb:
+      "Catalogs the corpora and sensor streams that train Nature Learning Models, with provenance and licensing.",
+  },
+  {
+    id: "mycobrain",
+    title: "mycobrain — ScienceComms & device firmware",
+    source: "MycosoftLabs · GitHub",
+    year: 2026,
+    url: "https://github.com/MycosoftLabs/mycobrain",
+    modality: "FCI",
+    status: "Prototype",
+    kind: "repo",
+    blurb:
+      "Firmware and telemetry pipeline for FCI probes, edge devices, and on-device inference targets.",
+  },
+]
+
+/** Modality → Tailwind classes for badge color mapping. */
+export const MODALITY_BADGE_CLASSES: Record<ResearchModality, string> = {
+  FCI: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40",
+  VOC: "bg-amber-500/20 text-amber-200 border-amber-400/40",
+  Acoustics: "bg-sky-500/20 text-sky-200 border-sky-400/40",
+  LiDAR: "bg-cyan-500/20 text-cyan-200 border-cyan-400/40",
+  Radar: "bg-indigo-500/20 text-indigo-200 border-indigo-400/40",
+  RF: "bg-violet-500/20 text-violet-200 border-violet-400/40",
+  Materials: "bg-orange-500/20 text-orange-200 border-orange-400/40",
+  Biotech: "bg-rose-500/20 text-rose-200 border-rose-400/40",
+  Compute: "bg-slate-500/20 text-slate-200 border-slate-400/40",
+  NLM: "bg-fuchsia-500/20 text-fuchsia-200 border-fuchsia-400/40",
+}
+
+/** Status → Tailwind classes for the StatusPill helper. */
+export const STATUS_PILL_CLASSES: Record<ResearchStatus, string> = {
+  Deployed: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40",
+  "In Lab": "bg-cyan-500/20 text-cyan-200 border-cyan-400/40",
+  Prototype: "bg-amber-500/20 text-amber-200 border-amber-400/40",
+  Research: "bg-indigo-500/20 text-indigo-200 border-indigo-400/40",
+  "Frontier Hypothesis":
+    "bg-fuchsia-500/20 text-fuchsia-200 border-fuchsia-400/40",
+}


### PR DESCRIPTION
## Summary
Rebuilds `/science` as the full Science & Research atlas spec'd in `Science-and-Research.pdf`, inheriting the glass + neuromorphic visual language from About. Adds 4 stub sub-routes (`/science/fci`, `/nlm`, `/materials`, `/deployments`) and a static curated research ribbon with an API seam for later wiring.

## What's included
- **9-section atlas** on `/science`: Hero · Research Ribbon · Domains · FCI · Signal Modalities · NLM · Materials · Deployments · Publications
- **4 stub sub-routes** with consistent `StubLayout` shell so anchor links from the atlas work today
- **Curated research ribbon component** with explicit `// TODO(api): swap to fetch('/api/research/feed') when route ships.` seam
- **Static publications data** at `lib/science-publications.ts` (218 LOC) — easy to convert to a CMS-backed loader later
- **Server layout** at `app/science/layout.tsx` for metadata; page itself is a client component for the interactive ribbon and section reveals

## Editorial guardrails honoured (per PDF page 6 — 'do not oversell the strange parts')
- FCI section explicitly states fungi are **not** language-capable computers
- Wi-Fi Sense is labelled **local sensing**, not planetary perception
- Adamatzky 2022 included but flagged `Frontier Hypothesis`
- Subsea / orbital / lunar deployments all carry `Frontier Hypothesis` with named prior art (Natick, Axiom, Lonestar) so they're contextualized, not asserted

## Assets
Placeholder slots with `// TODO` comments where renderings, photos, or motion are expected — no AI-generated imagery shipped in this PR, per spec.

## Type safety
`tsc --noEmit` clean for all new/modified files under `app/science/**` and `components/science/**`. Pre-existing unrelated errors elsewhere in the repo are untouched.

## Files
| File | LOC | Purpose |
|---|---|---|
| `app/science/page.tsx` | 1229 | Full atlas (replaces 248-line placeholder) |
| `app/science/layout.tsx` | 12 | Metadata server layout |
| `app/science/fci/page.tsx` | ~22 | Stub |
| `app/science/nlm/page.tsx` | ~22 | Stub |
| `app/science/materials/page.tsx` | ~22 | Stub |
| `app/science/deployments/page.tsx` | ~22 | Stub |
| `components/science/research-ribbon.tsx` | 105 | Ribbon + API seam |
| `components/science/stub-layout.tsx` | 70 | Shared stub shell |
| `lib/science-publications.ts` | 218 | Publications data |

## Out of scope (next PRs)
- `/api/research/feed` backend route to power the ribbon
- Real renderings/photography for the placeholder slots
- Filling out the 4 sub-pages beyond stubs

## Summary by Sourcery

Rebuild /science into a multi-section, client-side research atlas with a glass/neuromorphic layout, curated content, and clear maturity labeling for domains and deployments.

New Features:
- Introduce a nine-section Science & Research atlas on /science, including hero, research ribbon, domain overviews, FCI, signal modalities, NLM, materials, deployments, and publications/collaboration content.
- Add a reusable research ribbon component that surfaces curated publications and repos with modality and status metadata and is designed to later consume an API feed.
- Add four dedicated science sub-routes (/science/fci, /science/nlm, /science/materials, /science/deployments) using a shared stub layout that keeps navigation working while full pages are in development.
- Provide a centralized science-publications library with typed research entries, modality/status metadata, and styling maps for use across the science experience.
- Add a science-specific layout to define shared metadata while keeping the main science page as an interactive client component.

Enhancements:
- Align the /science page visuals with the glass/neuromorphic language from About, including custom global styling for science cards and buttons.