### PR TITLE
feat(docs): rebuild /docs as catalog-driven portal with 41 stubs

### DIFF
--- a/app/docs/ai/avani/page.tsx
+++ b/app/docs/ai/avani/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "AVANI",
+  description: "Voice and conversational interface across Mycosoft products.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="AVANI"
+      description="Voice and conversational interface across Mycosoft products."
+      section="AI Stack"
+      sectionHref="/docs/ai"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/avani.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/avani", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/ai/deterministic-vs-stochastic/page.tsx
+++ b/app/docs/ai/deterministic-vs-stochastic/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Deterministic vs Stochastic AI",
+  description: "When to use rule-based pipelines, LLMs, or hybrids; reliability tradeoffs in field deployments.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Deterministic vs Stochastic AI"
+      description="When to use rule-based pipelines, LLMs, or hybrids; reliability tradeoffs in field deployments."
+      section="AI Stack"
+      sectionHref="/docs/ai"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/deterministic-vs-stochastic.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/deterministic-vs-stochastic", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/ai/myca/page.tsx
+++ b/app/docs/ai/myca/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "MYCA",
+  description: "Mycosoft's primary multi-agent AI orchestrator — task automation law, agent roles, deployment patterns.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="MYCA"
+      description="Mycosoft's primary multi-agent AI orchestrator — task automation law, agent roles, deployment patterns."
+      section="AI Stack"
+      sectionHref="/docs/ai"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/myca-architecture.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/myca", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/ai/nlm/page.tsx
+++ b/app/docs/ai/nlm/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "NLM",
+  description: "Natural Language for Mycology — research model trained on mycological literature and biosignal data.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="NLM"
+      description="Natural Language for Mycology — research model trained on mycological literature and biosignal data."
+      section="AI Stack"
+      sectionHref="/docs/ai"
+      status="frontier"
+      sources={[
+        { label: "PDF", href: "/pdf/nlm.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/nlm", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/ai/page.tsx
+++ b/app/docs/ai/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "AI Stack",
+  description: "MYCA, AVANI, NLM, and the deterministic-vs-stochastic decision framework for field-deployed systems.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("ai")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/app/docs/api/page.tsx
+++ b/app/docs/api/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "APIs",
+  description: "Reference docs for the REST and GraphQL surfaces, webhooks, quotas, and authentication.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("api")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/app/docs/apps/alchemy-lab/page.tsx
+++ b/app/docs/apps/alchemy-lab/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Alchemy Lab",
+  description: "Compound design and reaction planning.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Alchemy Lab"
+      description="Compound design and reaction planning."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-alchemy-lab.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-alchemy-lab", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/compound-sim/page.tsx
+++ b/app/docs/apps/compound-sim/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Compound Sim",
+  description: "Molecular simulation surface.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Compound Sim"
+      description="Molecular simulation surface."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-compound-sim.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-compound-sim", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/digital-twin/page.tsx
+++ b/app/docs/apps/digital-twin/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Digital Twin",
+  description: "Live operational twin of a deployment site.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Digital Twin"
+      description="Live operational twin of a deployment site."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-digital-twin.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-digital-twin", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/earth-simulator/page.tsx
+++ b/app/docs/apps/earth-simulator/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Earth Simulator",
+  description: "Planetary-scale environmental modeling.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Earth Simulator"
+      description="Planetary-scale environmental modeling."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-earth-simulator.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-earth-simulator", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/genetic-circuit/page.tsx
+++ b/app/docs/apps/genetic-circuit/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Genetic Circuit",
+  description: "Synthetic-biology circuit design.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Genetic Circuit"
+      description="Synthetic-biology circuit design."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-genetic-circuit.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-genetic-circuit", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/growth-analytics/page.tsx
+++ b/app/docs/apps/growth-analytics/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Growth Analytics",
+  description: "Cultivation and growth metrics over time.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Growth Analytics"
+      description="Cultivation and growth metrics over time."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-growth-analytics.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-growth-analytics", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/lifecycle-sim/page.tsx
+++ b/app/docs/apps/lifecycle-sim/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Lifecycle Sim",
+  description: "Organism lifecycle modeling.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Lifecycle Sim"
+      description="Organism lifecycle modeling."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-lifecycle-sim.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-lifecycle-sim", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/mushroom-sim/page.tsx
+++ b/app/docs/apps/mushroom-sim/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Mushroom Sim",
+  description: "Fungal growth simulation playground.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Mushroom Sim"
+      description="Fungal growth simulation playground."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-mushroom-sim.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-mushroom-sim", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/page.tsx
+++ b/app/docs/apps/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "Apps",
+  description: "Studio tools and simulators built on the Mycosoft platform.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("apps")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/app/docs/apps/petri-dish-sim/page.tsx
+++ b/app/docs/apps/petri-dish-sim/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Petri Dish Sim",
+  description: "Lab-bench virtual experiment surface.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Petri Dish Sim"
+      description="Lab-bench virtual experiment surface."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-petri-dish-sim.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-petri-dish-sim", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/physics-sim/page.tsx
+++ b/app/docs/apps/physics-sim/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Physics Sim",
+  description: "Underlying physics engine for environment modeling.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Physics Sim"
+      description="Underlying physics engine for environment modeling."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-physics-sim.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-physics-sim", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/retrosynthesis/page.tsx
+++ b/app/docs/apps/retrosynthesis/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Retrosynthesis",
+  description: "Retrosynthetic route planning for target compounds.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Retrosynthesis"
+      description="Retrosynthetic route planning for target compounds."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-retrosynthesis.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-retrosynthesis", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/spore-tracker/page.tsx
+++ b/app/docs/apps/spore-tracker/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Spore Tracker",
+  description: "Track spore release and dispersion in the field.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Spore Tracker"
+      description="Track spore release and dispersion in the field."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-spore-tracker.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-spore-tracker", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/apps/symbiosis/page.tsx
+++ b/app/docs/apps/symbiosis/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Symbiosis",
+  description: "Multi-organism symbiosis modeling.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Symbiosis"
+      description="Multi-organism symbiosis modeling."
+      section="Apps"
+      sectionHref="/docs/apps"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/apps-symbiosis.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/apps-symbiosis", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/dashboards/fusarium/page.tsx
+++ b/app/docs/dashboards/fusarium/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Fusarium Dashboard",
+  description: "Research dashboard for biosignal analysis and lab work.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Fusarium Dashboard"
+      description="Research dashboard for biosignal analysis and lab work."
+      section="Dashboards"
+      sectionHref="/docs"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/dashboards-fusarium.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/dashboards-fusarium", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/dashboards/natureos/page.tsx
+++ b/app/docs/dashboards/natureos/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "NatureOS Dashboard",
+  description: "Operator dashboard for fleets, telemetry, and alerts.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="NatureOS Dashboard"
+      description="Operator dashboard for fleets, telemetry, and alerts."
+      section="Dashboards"
+      sectionHref="/docs"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/dashboards-natureos.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/dashboards-natureos", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/defense-government/page.tsx
+++ b/app/docs/defense-government/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "Defense & Government",
+  description: "Federal credentials, CUI handling, contracting vehicles, and operator obligations for government deployments.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("defense-government")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/app/docs/devices/agaric/page.tsx
+++ b/app/docs/devices/agaric/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Agaric",
+  description: "Compact field probe with audio and bioelectric sensing.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Agaric"
+      description="Compact field probe with audio and bioelectric sensing."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-agaric.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-agaric", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/alarm/page.tsx
+++ b/app/docs/devices/alarm/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "ALARM",
+  description: "Biological detection and early-warning sensor with TinyML inference on-device.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="ALARM"
+      description="Biological detection and early-warning sensor with TinyML inference on-device."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-alarm.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-alarm", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/fci-probes/page.tsx
+++ b/app/docs/devices/fci-probes/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "FCI Probes",
+  description: "Fungal Computing Interface probes (research grade). Electrically active substrates, not language-capable systems.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="FCI Probes"
+      description="Fungal Computing Interface probes (research grade). Electrically active substrates, not language-capable systems."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="frontier"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-fci-probes.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-fci-probes", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/hyphae-1/page.tsx
+++ b/app/docs/devices/hyphae-1/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Hyphae 1",
+  description: "Distributed soil and substrate sensor network.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Hyphae 1"
+      description="Distributed soil and substrate sensor network."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-hyphae-1.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-hyphae-1", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/mushroom-1/page.tsx
+++ b/app/docs/devices/mushroom-1/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Mushroom 1",
+  description: "Edge biosignal collector.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Mushroom 1"
+      description="Edge biosignal collector."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-mushroom-1.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-mushroom-1", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/mushroom-2/page.tsx
+++ b/app/docs/devices/mushroom-2/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Mushroom 2",
+  description: "Next-gen consumer and professional variant of Mushroom 1.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Mushroom 2"
+      description="Next-gen consumer and professional variant of Mushroom 1."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-mushroom-2.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-mushroom-2", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/mycobrain/page.tsx
+++ b/app/docs/devices/mycobrain/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "MycoBrain",
+  description: "Edge compute appliance running MYCA workloads on-device.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="MycoBrain"
+      description="Edge compute appliance running MYCA workloads on-device."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-mycobrain.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-mycobrain", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/myconode/page.tsx
+++ b/app/docs/devices/myconode/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "MycoNode",
+  description: "Mesh networking node for fungal-data telemetry.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="MycoNode"
+      description="Mesh networking node for fungal-data telemetry."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-myconode.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-myconode", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/mycotenna/page.tsx
+++ b/app/docs/devices/mycotenna/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "MycoTenna",
+  description: "RF and spectrum sensing array for environmental signals.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="MycoTenna"
+      description="RF and spectrum sensing array for environmental signals."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-mycotenna.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-mycotenna", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/page.tsx
+++ b/app/docs/devices/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "Devices",
+  description: "Hardware reference: probes, edge compute, mesh nodes, and the firmware that runs on them.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("devices")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/app/docs/devices/petraeus/page.tsx
+++ b/app/docs/devices/petraeus/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Petraeus",
+  description: "High-power deployment platform for ruggedized outdoor use.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Petraeus"
+      description="High-power deployment platform for ruggedized outdoor use."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-petraeus.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-petraeus", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/psathyrella/page.tsx
+++ b/app/docs/devices/psathyrella/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Psathyrella",
+  description: "Subsurface and aquatic probe variant.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Psathyrella"
+      description="Subsurface and aquatic probe variant."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-psathyrella.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-psathyrella", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/sporebase/page.tsx
+++ b/app/docs/devices/sporebase/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "SporeBase",
+  description: "Stationary lab and field base station for spore capture and analysis.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="SporeBase"
+      description="Stationary lab and field base station for spore capture and analysis."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-sporebase.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-sporebase", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/devices/tricorder/page.tsx
+++ b/app/docs/devices/tricorder/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { DocStubPage } from "@/components/docs/doc-stub-page"
+
+export const metadata: Metadata = {
+  title: "Tricorder",
+  description: "Handheld multi-sensor unit for field surveys.",
+}
+
+export default function Page() {
+  return (
+    <DocStubPage
+      title="Tricorder"
+      description="Handheld multi-sensor unit for field surveys."
+      section="Devices"
+      sectionHref="/docs/devices"
+      status="coming-soon"
+      sources={[
+        { label: "PDF", href: "/pdf/devices-tricorder.pdf", kind: "pdf" },
+        { label: "GitBook", href: "https://mycosoft.gitbook.io/devices-tricorder", kind: "gitbook" },
+      ]}
+    />
+  )
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next"
+import type { ReactNode } from "react"
+
+export const metadata: Metadata = {
+  title: {
+    template: "%s | Mycosoft Docs",
+    default: "Documentation | Mycosoft",
+  },
+  description:
+    "Developer documentation for the Mycosoft platform — AI stack, devices, APIs, dashboards, and federal compliance.",
+}
+
+/**
+ * Route-segment layout. The visual shell (sidebar + content area) lives in
+ * `components/docs/docs-layout.tsx` and is mounted by each page so that the
+ * existing `app/docs/fci-firmware/page.tsx` keeps its own chrome and is not
+ * disrupted by the new sidebar wrapper.
+ */
+export default function DocsRouteLayout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/app/docs/mas/page.tsx
+++ b/app/docs/mas/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "Multi-Agent System",
+  description: "Agent runtime, communications, audit, and the permission model that gates what can be automated.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("mas")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/app/docs/mindex/page.tsx
+++ b/app/docs/mindex/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "MINDEX Database",
+  description: "The cryptographic mycological database — schemas, access tiers, and recommended query patterns.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("mindex")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/app/docs/open-source/page.tsx
+++ b/app/docs/open-source/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "Open Source",
+  description: "Public Mycosoft repositories, licenses, and how to contribute.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("open-source")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,98 +1,177 @@
-import type { Metadata } from 'next'
 import Link from "next/link"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { FileText, Cpu, Shield, Zap } from "lucide-react"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  DOCS_CATALOG,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
 
-export const metadata: Metadata = {
-  title: 'Documentation | Mycosoft',
-  description: 'Mycosoft developer documentation, API references, and integration guides.',
-  alternates: {
-    canonical: '/docs',
-  },
-  openGraph: {
-    title: 'Documentation | Mycosoft',
-    description: 'Mycosoft developer documentation, API references, and integration guides.',
-    url: '/docs',
-  },
+export const metadata = {
+  title: "Documentation",
+  description:
+    "Mycosoft developer documentation — AI stack, multi-agent system, MINDEX, APIs, devices, apps, open source, defense, and security.",
 }
 
-export default function DocsPage() {
-  return (
-    <div className="container mx-auto max-w-4xl px-4 py-10 md:py-16">
-      <h1 className="text-3xl md:text-4xl font-bold tracking-tight">Developer Documentation</h1>
-      <p className="mt-2 text-lg text-muted-foreground max-w-2xl">
-        API and platform documentation for MYCA, AVANI, NLM, and Mycosoft services. Request access for API keys and full docs.
-      </p>
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
 
-      <div className="mt-10 grid gap-4 sm:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <FileText className="h-6 w-6 text-primary mb-2" />
-            <CardTitle>AI Platform</CardTitle>
-            <CardDescription>MYCA, AVANI, NLM APIs and integration guides</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Link href="/ai">
-              <Button variant="outline" className="w-full sm:w-auto min-h-[44px]">
-                AI Overview
-              </Button>
-            </Link>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <Cpu className="h-6 w-6 text-primary mb-2" />
-            <CardTitle>NatureOS & MINDEX</CardTitle>
-            <CardDescription>Dashboards, data APIs, and search</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Link href="/natureos">
-              <Button variant="outline" className="w-full sm:w-auto min-h-[44px]">
-                NatureOS
-              </Button>
-            </Link>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <Shield className="h-6 w-6 text-primary mb-2" />
-            <CardTitle>APIs & Integrations</CardTitle>
-            <CardDescription>API keys, usage, and onboarding</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground mb-4">
-              Request API access and developer onboarding. Human seats, agent seats, and infrastructure tiers.
-            </p>
-            <Link href="/contact">
-              <Button className="w-full sm:w-auto min-h-[44px]">
-                Request access
-              </Button>
-            </Link>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <Zap className="h-6 w-6 text-primary mb-2" />
-            <CardTitle>Resources</CardTitle>
-            <CardDescription>Apps, devices, and platform tools</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2">
-              <Link href="/apps">
-                <Button variant="ghost" size="sm" className="min-h-[44px]">
-                  Apps
-                </Button>
-              </Link>
-              <Link href="/devices">
-                <Button variant="ghost" size="sm" className="min-h-[44px]">
-                  Devices
-                </Button>
-              </Link>
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function DocsIndexPage() {
+  return (
+    <DocsLayout>
+      <header className="mb-10 max-w-3xl">
+        <p className="text-xs uppercase tracking-wider text-muted-foreground mb-2">
+          Developer documentation
+        </p>
+        <h1 className="text-3xl md:text-4xl font-bold tracking-tight">
+          Mycosoft Developer Documentation
+        </h1>
+        <p className="mt-3 text-base md:text-lg text-muted-foreground">
+          A reference for the entire Mycosoft platform — the AI stack, the
+          multi-agent system, MINDEX, our APIs, every device and app, and the
+          security and compliance posture for federal deployments.
+        </p>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Most pages link out to a canonical PDF and GitBook source. Pages marked
+          <span className="mx-1 inline-block align-middle">
+            <StatusBadge status="coming-soon" />
+          </span>
+          are placeholders whose links will resolve as the artifacts land.
+          Frontier topics (NLM, FCI probes) are deliberately flagged
+          <span className="mx-1 inline-block align-middle">
+            <StatusBadge status="frontier" />
+          </span>
+          — they are research surfaces, not solved capabilities.
+        </p>
+      </header>
+
+      <div className="space-y-12">
+        {DOCS_CATALOG.map((section) => (
+          <section key={section.id} aria-labelledby={`docs-${section.id}`}>
+            <div className="mb-4 border-b border-border pb-2">
+              {section.href ? (
+                <Link
+                  href={section.href}
+                  id={`docs-${section.id}`}
+                  className="group inline-flex items-baseline gap-2 text-2xl font-semibold tracking-tight hover:text-foreground"
+                >
+                  {section.title}
+                  <span
+                    aria-hidden
+                    className="text-sm font-normal text-muted-foreground group-hover:text-foreground"
+                  >
+                    →
+                  </span>
+                </Link>
+              ) : (
+                <h2
+                  id={`docs-${section.id}`}
+                  className="text-2xl font-semibold tracking-tight"
+                >
+                  {section.title}
+                </h2>
+              )}
+              <p className="mt-1 text-sm text-muted-foreground max-w-3xl">
+                {section.description}
+              </p>
             </div>
-          </CardContent>
-        </Card>
+
+            <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {section.entries.map((entry) => (
+                <li key={`${section.id}-${entry.title}`}>
+                  <EntryCard entry={entry} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
       </div>
-    </div>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <StatusBadge status={status} />
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+        {entry.description}
+      </p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s) => (
+            <li key={`${entry.title}-${s.kind}-${s.href}`}>
+              <SourceChip source={s} />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </>
+  )
+
+  if (entry.href) {
+    return (
+      <Link href={entry.href} className={cardClass}>
+        {body}
+      </Link>
+    )
+  }
+  return <div className={cardClass}>{body}</div>
+}
+
+function SourceChip({ source }: { source: DocSource }) {
+  const Icon = SOURCE_ICON[source.kind]
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[source.kind]}`}
+      title={source.href}
+    >
+      <Icon className="h-3 w-3" aria-hidden />
+      {source.label}
+    </span>
+  )
+}
+
+function StatusBadge({ status }: { status: DocStatus }) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}
+    >
+      {STATUS_LABEL[status]}
+    </span>
   )
 }

--- a/app/docs/security/page.tsx
+++ b/app/docs/security/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, BookOpen, ExternalLink, FileText } from "lucide-react"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import {
+  getSectionById,
+  type DocEntry,
+  type DocSource,
+  type DocStatus,
+} from "@/lib/docs-catalog"
+
+export const metadata: Metadata = {
+  title: "Security",
+  description: "Disclosure policy, device integrity, and data-security expectations across the platform.",
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export default function Page() {
+  const section = getSectionById("security")
+  if (!section) {
+    return (
+      <DocsLayout>
+        <p className="text-sm text-muted-foreground">Section not found in catalog.</p>
+      </DocsLayout>
+    )
+  }
+  return (
+    <DocsLayout>
+      <article className="max-w-4xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">Docs</Link>
+        </nav>
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{section.title}</h1>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-3xl">{section.description}</p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {section.entries.map((entry) => (
+            <li key={entry.title}><EntryCard entry={entry} /></li>
+          ))}
+        </ul>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function EntryCard({ entry }: { entry: DocEntry }) {
+  const status: DocStatus = entry.status ?? "coming-soon"
+  const cardClass = `group flex h-full flex-col rounded-lg border border-border bg-card p-4 transition-colors${
+    entry.href ? " hover:border-foreground/20 hover:bg-muted/40" : ""
+  }`
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold tracking-tight">{entry.title}</h3>
+        <span className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[status]}`}>
+          {STATUS_LABEL[status]}
+        </span>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{entry.description}</p>
+      {entry.sources && entry.sources.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {entry.sources.map((s: DocSource) => {
+            const Icon = SOURCE_ICON[s.kind]
+            return (
+              <li key={`${s.kind}-${s.href}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${SOURCE_CLASSES[s.kind]}`}>
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {s.label}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </>
+  )
+  if (entry.href) {
+    return <Link href={entry.href} className={cardClass}>{body}</Link>
+  }
+  return <div className={cardClass}>{body}</div>
+}

--- a/components/docs/doc-stub-page.tsx
+++ b/components/docs/doc-stub-page.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link"
+import type { ReactNode } from "react"
+import { ArrowUpRight, FileText, BookOpen, ExternalLink, Github } from "lucide-react"
+import type { DocSource, DocStatus } from "@/lib/docs-catalog"
+import { DocsLayout } from "./docs-layout"
+
+interface DocStubPageProps {
+  /** Title shown as the H1. */
+  title: string
+  description: string
+  /** Crumb-trail label for the parent section (e.g. "Devices", "AI Stack"). */
+  section: string
+  /** Where the breadcrumb link points (defaults to /docs). */
+  sectionHref?: string
+  sources?: DocSource[]
+  status?: DocStatus
+  children?: ReactNode
+}
+
+const STATUS_LABEL: Record<DocStatus, string> = {
+  stable: "Stable",
+  draft: "Draft",
+  frontier: "Frontier / Research",
+  "coming-soon": "Coming soon",
+}
+
+const STATUS_CLASSES: Record<DocStatus, string> = {
+  stable: "border-emerald-300/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300",
+  draft: "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  frontier: "border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300",
+  "coming-soon": "border-cyan-300/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+}
+
+const SOURCE_ICON = {
+  pdf: FileText,
+  gitbook: BookOpen,
+  internal: ArrowUpRight,
+  external: ExternalLink,
+} as const
+
+const SOURCE_LABEL = {
+  pdf: "PDF",
+  gitbook: "GitBook",
+  internal: "Internal",
+  external: "External",
+} as const
+
+const SOURCE_CLASSES = {
+  pdf: "border-rose-300/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  gitbook: "border-sky-300/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  internal: "border-emerald-300/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  external: "border-slate-300/40 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+} as const
+
+export function DocStubPage({
+  title,
+  description,
+  section,
+  sectionHref = "/docs",
+  sources,
+  status = "coming-soon",
+  children,
+}: DocStubPageProps) {
+  return (
+    <DocsLayout>
+      <article className="max-w-3xl">
+        <nav aria-label="Breadcrumb" className="mb-3 text-xs text-muted-foreground">
+          <Link href="/docs" className="hover:text-foreground">
+            Docs
+          </Link>
+          <span aria-hidden> / </span>
+          <Link href={sectionHref} className="hover:text-foreground">
+            {section}
+          </Link>
+        </nav>
+
+        <header className="mb-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{title}</h1>
+            <StatusPill status={status} />
+          </div>
+          <p className="mt-3 text-base md:text-lg text-muted-foreground">{description}</p>
+        </header>
+
+        {sources && sources.length > 0 ? (
+          <section className="mb-8">
+            <h2 className="text-xs uppercase tracking-wider text-muted-foreground mb-2">
+              Sources
+            </h2>
+            <ul className="flex flex-wrap gap-2">
+              {sources.map((s) => {
+                const Icon = SOURCE_ICON[s.kind]
+                const isInternal = s.kind === "internal"
+                const linkProps = isInternal
+                  ? {}
+                  : ({ target: "_blank", rel: "noopener noreferrer" } as const)
+                return (
+                  <li key={`${s.kind}-${s.href}`}>
+                    <a
+                      href={s.href}
+                      {...linkProps}
+                      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors hover:brightness-110 ${SOURCE_CLASSES[s.kind]}`}
+                    >
+                      <Icon className="h-3.5 w-3.5" aria-hidden />
+                      {s.label || SOURCE_LABEL[s.kind]}
+                    </a>
+                  </li>
+                )
+              })}
+            </ul>
+          </section>
+        ) : null}
+
+        {status === "coming-soon" ? (
+          <section className="mb-8 rounded-lg border border-border bg-card p-5">
+            <h2 className="text-sm font-semibold mb-1">This page is coming soon</h2>
+            <p className="text-sm text-muted-foreground">
+              The reference content for <strong>{title}</strong> is in production.
+              The placeholder PDF and GitBook links above will resolve as soon as
+              Morgan uploads the canonical artifacts. If you need this sooner, file
+              an issue and we will prioritise.
+            </p>
+          </section>
+        ) : null}
+
+        {children ? (
+          <section className="prose prose-neutral dark:prose-invert max-w-none">
+            {children}
+          </section>
+        ) : null}
+
+        <footer className="mt-10 flex flex-wrap items-center gap-3 border-t border-border pt-6">
+          <a
+            href="https://github.com/MycosoftLabs/website/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-sm font-medium hover:bg-muted/60"
+          >
+            <Github className="h-4 w-4" aria-hidden />
+            Suggest an edit / contribute
+          </a>
+          <Link
+            href="/docs"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            ← Back to docs index
+          </Link>
+        </footer>
+      </article>
+    </DocsLayout>
+  )
+}
+
+function StatusPill({ status }: { status: DocStatus }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${STATUS_CLASSES[status]}`}
+    >
+      {STATUS_LABEL[status]}
+    </span>
+  )
+}

--- a/components/docs/docs-layout.tsx
+++ b/components/docs/docs-layout.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import { useMemo, useState, type ReactNode } from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { ChevronDown, ChevronRight, Menu } from "lucide-react"
+import { DOCS_CATALOG, type DocSection } from "@/lib/docs-catalog"
+
+interface DocsLayoutProps {
+  children: ReactNode
+}
+
+/**
+ * Shared shell for every `/docs/**` route. Two-column at md+, single-column on
+ * mobile with a "Browse documentation" disclosure on top.
+ */
+export function DocsLayout({ children }: DocsLayoutProps) {
+  const pathname = usePathname() || "/docs"
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 py-6 md:py-10">
+      {/* Mobile disclosure */}
+      <div className="md:hidden mb-4">
+        <button
+          type="button"
+          onClick={() => setMobileOpen((open) => !open)}
+          className="flex w-full items-center justify-between rounded-lg border border-border bg-card px-4 py-3 text-left text-sm font-medium"
+          aria-expanded={mobileOpen}
+          aria-controls="docs-mobile-sidebar"
+        >
+          <span className="flex items-center gap-2">
+            <Menu className="h-4 w-4" aria-hidden />
+            Browse documentation
+          </span>
+          <ChevronDown
+            className={`h-4 w-4 transition-transform ${mobileOpen ? "rotate-180" : ""}`}
+            aria-hidden
+          />
+        </button>
+        {mobileOpen ? (
+          <div
+            id="docs-mobile-sidebar"
+            className="mt-2 rounded-lg border border-border bg-card p-4"
+          >
+            <DocsSidebar
+              pathname={pathname}
+              onNavigate={() => setMobileOpen(false)}
+            />
+          </div>
+        ) : null}
+      </div>
+
+      <div className="md:grid md:grid-cols-[16rem_1fr] md:gap-10 lg:gap-12">
+        {/* Desktop sidebar */}
+        <aside className="hidden md:block">
+          <div className="sticky top-24 max-h-[calc(100dvh-7rem)] overflow-y-auto pr-2">
+            <DocsSidebar pathname={pathname} />
+          </div>
+        </aside>
+
+        {/* Main content */}
+        <main className="min-w-0">{children}</main>
+      </div>
+    </div>
+  )
+}
+
+interface DocsSidebarProps {
+  pathname: string
+  onNavigate?: () => void
+}
+
+function DocsSidebar({ pathname, onNavigate }: DocsSidebarProps) {
+  // Pre-compute which sections should start expanded: any section whose
+  // href matches, or any section containing a matching entry.
+  const initiallyOpen = useMemo(() => {
+    const map: Record<string, boolean> = {}
+    for (const section of DOCS_CATALOG) {
+      const matchesSection = section.href ? pathname === section.href : false
+      const matchesEntry = section.entries.some(
+        (entry) => entry.href && pathname.startsWith(entry.href),
+      )
+      map[section.id] = matchesSection || matchesEntry
+    }
+    return map
+  }, [pathname])
+
+  return (
+    <nav aria-label="Documentation navigation" className="space-y-1 text-sm">
+      {DOCS_CATALOG.map((section) => (
+        <SidebarSection
+          key={section.id}
+          section={section}
+          pathname={pathname}
+          defaultOpen={initiallyOpen[section.id] ?? false}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </nav>
+  )
+}
+
+interface SidebarSectionProps {
+  section: DocSection
+  pathname: string
+  defaultOpen: boolean
+  onNavigate?: () => void
+}
+
+function SidebarSection({ section, pathname, defaultOpen, onNavigate }: SidebarSectionProps) {
+  const [open, setOpen] = useState(defaultOpen)
+  const hasChildren = section.entries.length > 0
+  const isActiveSection = section.href ? pathname === section.href : false
+
+  return (
+    <div className="py-1">
+      <div className="flex items-center">
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            aria-expanded={open}
+            aria-controls={`docs-section-${section.id}`}
+            className="mr-1 inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted"
+          >
+            {open ? (
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+            )}
+            <span className="sr-only">
+              {open ? "Collapse" : "Expand"} {section.title}
+            </span>
+          </button>
+        ) : (
+          <span className="mr-1 inline-block h-6 w-6" aria-hidden />
+        )}
+
+        {section.href ? (
+          <Link
+            href={section.href}
+            onClick={onNavigate}
+            className={`flex-1 rounded-md px-2 py-1 font-medium transition-colors ${
+              isActiveSection
+                ? "bg-muted text-foreground"
+                : "text-foreground/85 hover:bg-muted/60 hover:text-foreground"
+            }`}
+          >
+            {section.title}
+          </Link>
+        ) : (
+          <span className="flex-1 px-2 py-1 font-medium uppercase tracking-wider text-xs text-muted-foreground">
+            {section.title}
+          </span>
+        )}
+      </div>
+
+      {hasChildren && open ? (
+        <ul
+          id={`docs-section-${section.id}`}
+          className="mt-1 ml-7 space-y-0.5 border-l border-border/60 pl-3"
+        >
+          {section.entries.map((entry) => {
+            if (!entry.href) return null
+            const isActive = pathname === entry.href
+            return (
+              <li key={entry.href}>
+                <Link
+                  href={entry.href}
+                  onClick={onNavigate}
+                  className={`block rounded-md px-2 py-1 text-[13px] transition-colors ${
+                    isActive
+                      ? "bg-primary/10 text-foreground font-medium"
+                      : "text-foreground/75 hover:bg-muted/60 hover:text-foreground"
+                  }`}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {entry.title}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/docs-catalog.ts
+++ b/lib/docs-catalog.ts
@@ -1,0 +1,602 @@
+/**
+ * Developer documentation catalog — single source of truth for both the
+ * `/docs` index page and the docs sidebar.
+ *
+ * Editorial guardrails (carry over from /science):
+ *  - Frontier work (FCI probes, NLM, planetary Wi-Fi sense, biosignal
+ *    "language", interspecies translation) is labelled `status: "frontier"`.
+ *  - We do NOT claim fungi are language-capable computers.
+ *  - We do NOT claim Wi-Fi sense provides planetary perception.
+ *  - We do NOT claim interspecies translation is solved.
+ *
+ * Source URLs use placeholder paths so links work the moment Morgan uploads
+ * the actual PDFs / GitBook pages:
+ *  - PDFs:    /pdf/<slug>.pdf
+ *  - GitBook: https://mycosoft.gitbook.io/<slug>
+ */
+
+export type DocSourceKind = "pdf" | "gitbook" | "internal" | "external"
+
+export type DocSource = {
+  label: string
+  href: string
+  kind: DocSourceKind
+}
+
+export type DocStatus = "stable" | "draft" | "frontier" | "coming-soon"
+
+export type DocEntry = {
+  title: string
+  description: string
+  /** Internal docs route (e.g. `/docs/ai/myca`). Omit for pure-concept entries. */
+  href?: string
+  sources?: DocSource[]
+  status?: DocStatus
+}
+
+export type DocSection = {
+  id: string
+  title: string
+  /** Section landing route (e.g. `/docs/ai`). Omit for pure grouping headers. */
+  href?: string
+  description: string
+  entries: DocEntry[]
+  children?: DocSection[]
+}
+
+/** Default placeholder sources for any "coming-soon" doc. */
+// TODO(morgan): replace placeholder /pdf/<slug>.pdf + GitBook URLs with the
+// real uploaded artifacts as they land.
+const placeholderSources = (slug: string): DocSource[] => [
+  { label: "PDF", href: `/pdf/${slug}.pdf`, kind: "pdf" },
+  { label: "GitBook", href: `https://mycosoft.gitbook.io/${slug}`, kind: "gitbook" },
+]
+
+export const DOCS_CATALOG: DocSection[] = [
+  // ─────────────────────────────────────────────────────────────────────────
+  // 1. Overview
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "overview",
+    title: "Overview",
+    href: "/docs",
+    description:
+      "Start here. What Mycosoft is, how the stack fits together, and the first 15 minutes for a new developer.",
+    entries: [
+      {
+        title: "What is Mycosoft",
+        description: "Company overview, the stack, and who this documentation is for.",
+        status: "coming-soon",
+        sources: placeholderSources("what-is-mycosoft"),
+      },
+      {
+        title: "Quickstart",
+        description:
+          "First 15 minutes: pick a device or API, request access, and see your first data flow.",
+        status: "coming-soon",
+        sources: placeholderSources("quickstart"),
+      },
+      {
+        title: "Glossary",
+        description:
+          "Mycology, AI, and federal-contracting terms in one place — written for newcomers.",
+        status: "coming-soon",
+        sources: placeholderSources("glossary"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 2. AI Stack
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "ai",
+    title: "AI Stack",
+    href: "/docs/ai",
+    description:
+      "MYCA, AVANI, NLM, and the deterministic-vs-stochastic decision framework for field-deployed systems.",
+    entries: [
+      {
+        title: "MYCA",
+        description:
+          "Mycosoft's primary multi-agent AI orchestrator — task automation law, agent roles, deployment patterns.",
+        href: "/docs/ai/myca",
+        status: "coming-soon",
+        sources: [
+          { label: "PDF", href: "/pdf/myca-architecture.pdf", kind: "pdf" },
+          { label: "GitBook", href: "https://mycosoft.gitbook.io/myca", kind: "gitbook" },
+        ],
+      },
+      {
+        title: "AVANI",
+        description: "Voice and conversational interface across Mycosoft products.",
+        href: "/docs/ai/avani",
+        status: "coming-soon",
+        sources: placeholderSources("avani"),
+      },
+      {
+        title: "NLM",
+        description:
+          "Natural Language for Mycology — research model trained on mycological literature and biosignal data.",
+        href: "/docs/ai/nlm",
+        status: "frontier",
+        sources: placeholderSources("nlm"),
+      },
+      {
+        title: "Deterministic vs Stochastic AI",
+        description:
+          "When to use rule-based pipelines, LLMs, or hybrids; reliability tradeoffs in field deployments.",
+        href: "/docs/ai/deterministic-vs-stochastic",
+        status: "coming-soon",
+        sources: placeholderSources("deterministic-vs-stochastic"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 3. Multi-Agent System
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "mas",
+    title: "Multi-Agent System",
+    href: "/docs/mas",
+    description:
+      "Agent runtime, communications, audit, and the permission model that gates what can be automated.",
+    entries: [
+      {
+        title: "MAS Overview",
+        description: "Agent architecture, runtime, and how MYCA composes them.",
+        status: "coming-soon",
+        sources: placeholderSources("mas-overview"),
+      },
+      {
+        title: "MYCA Task Automation Law",
+        description:
+          "The governing rule for what agents may and may not automate — with human-approval gates.",
+        status: "coming-soon",
+        sources: placeholderSources("myca-task-automation-law"),
+      },
+      {
+        title: "Agent communications & logging",
+        description: "Audit-trail expectations, message format, and how to verify agent provenance.",
+        status: "coming-soon",
+        sources: placeholderSources("agent-communications"),
+      },
+      {
+        title: "Permission model",
+        description: "Who can authorize what; final-approval gates and revocation flow.",
+        status: "coming-soon",
+        sources: placeholderSources("mas-permissions"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 4. Dashboards (group only, no section landing page)
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "dashboards",
+    title: "Dashboards",
+    description: "Operator and research dashboards built on the MYCA + MINDEX backbone.",
+    entries: [
+      {
+        title: "NatureOS",
+        description: "Operator dashboard for fleets, telemetry, and alerts.",
+        href: "/docs/dashboards/natureos",
+        status: "coming-soon",
+        sources: placeholderSources("dashboards-natureos"),
+      },
+      {
+        title: "Fusarium",
+        description: "Research dashboard for biosignal analysis and lab work.",
+        href: "/docs/dashboards/fusarium",
+        status: "coming-soon",
+        sources: placeholderSources("dashboards-fusarium"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 5. MINDEX Database
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "mindex",
+    title: "MINDEX Database",
+    href: "/docs/mindex",
+    description:
+      "The cryptographic mycological database — schemas, access tiers, and recommended query patterns.",
+    entries: [
+      {
+        title: "Schema overview",
+        description: "Tables, relationships, and the most common queries operators run.",
+        status: "coming-soon",
+        sources: placeholderSources("mindex-schema"),
+      },
+      {
+        title: "Access tiers",
+        description: "Public, partner, contractor, and classified tiers — what each can read and write.",
+        status: "coming-soon",
+        sources: placeholderSources("mindex-access-tiers"),
+      },
+      {
+        title: "Query patterns",
+        description: "Recommended joins, filters, indexes, and rate-limit considerations.",
+        status: "coming-soon",
+        sources: placeholderSources("mindex-query-patterns"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 6. APIs
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "api",
+    title: "APIs",
+    href: "/docs/api",
+    description: "Reference docs for the REST and GraphQL surfaces, webhooks, quotas, and authentication.",
+    entries: [
+      {
+        title: "REST API reference",
+        description: "Endpoints by product, authentication scheme, and the canonical error model.",
+        status: "coming-soon",
+        sources: placeholderSources("api-rest"),
+      },
+      {
+        title: "GraphQL surface",
+        description: "Schema overview and example queries against the federated graph.",
+        status: "coming-soon",
+        sources: placeholderSources("api-graphql"),
+      },
+      {
+        title: "Webhooks",
+        description: "Event types, delivery semantics, retries, and signature verification.",
+        status: "coming-soon",
+        sources: placeholderSources("api-webhooks"),
+      },
+      {
+        title: "Rate limits and quotas",
+        description: "Per-tier limits, burst behaviour, and how to request a raise.",
+        status: "coming-soon",
+        sources: placeholderSources("api-rate-limits"),
+      },
+      {
+        title: "Authentication",
+        description: "API keys, OAuth, and mTLS for federal deployments.",
+        status: "coming-soon",
+        sources: placeholderSources("api-authentication"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 7. Devices
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "devices",
+    title: "Devices",
+    href: "/docs/devices",
+    description: "Hardware reference: probes, edge compute, mesh nodes, and the firmware that runs on them.",
+    entries: [
+      {
+        title: "Mushroom 1",
+        description: "Edge biosignal collector.",
+        href: "/docs/devices/mushroom-1",
+        status: "coming-soon",
+        sources: placeholderSources("devices-mushroom-1"),
+      },
+      {
+        title: "Hyphae 1",
+        description: "Distributed soil and substrate sensor network.",
+        href: "/docs/devices/hyphae-1",
+        status: "coming-soon",
+        sources: placeholderSources("devices-hyphae-1"),
+      },
+      {
+        title: "MycoNode",
+        description: "Mesh networking node for fungal-data telemetry.",
+        href: "/docs/devices/myconode",
+        status: "coming-soon",
+        sources: placeholderSources("devices-myconode"),
+      },
+      {
+        title: "ALARM",
+        description: "Biological detection and early-warning sensor with TinyML inference on-device.",
+        href: "/docs/devices/alarm",
+        status: "coming-soon",
+        sources: placeholderSources("devices-alarm"),
+      },
+      {
+        title: "MycoBrain",
+        description: "Edge compute appliance running MYCA workloads on-device.",
+        href: "/docs/devices/mycobrain",
+        status: "coming-soon",
+        sources: placeholderSources("devices-mycobrain"),
+      },
+      {
+        title: "Agaric",
+        description: "Compact field probe with audio and bioelectric sensing.",
+        href: "/docs/devices/agaric",
+        status: "coming-soon",
+        sources: placeholderSources("devices-agaric"),
+      },
+      {
+        title: "Psathyrella",
+        description: "Subsurface and aquatic probe variant.",
+        href: "/docs/devices/psathyrella",
+        status: "coming-soon",
+        sources: placeholderSources("devices-psathyrella"),
+      },
+      {
+        title: "SporeBase",
+        description: "Stationary lab and field base station for spore capture and analysis.",
+        href: "/docs/devices/sporebase",
+        status: "coming-soon",
+        sources: placeholderSources("devices-sporebase"),
+      },
+      {
+        title: "FCI Probes",
+        description:
+          "Fungal Computing Interface probes (research grade). Electrically active substrates, not language-capable systems.",
+        href: "/docs/devices/fci-probes",
+        status: "frontier",
+        sources: placeholderSources("devices-fci-probes"),
+      },
+      {
+        title: "FCI Firmware",
+        description: "Firmware reference for the FCI probe family — pin maps, telemetry, OTA flow.",
+        href: "/docs/fci-firmware",
+        status: "stable",
+        sources: [{ label: "Internal", href: "/docs/fci-firmware", kind: "internal" }],
+      },
+      {
+        title: "Tricorder",
+        description: "Handheld multi-sensor unit for field surveys.",
+        href: "/docs/devices/tricorder",
+        status: "coming-soon",
+        sources: placeholderSources("devices-tricorder"),
+      },
+      {
+        title: "Petraeus",
+        description: "High-power deployment platform for ruggedized outdoor use.",
+        href: "/docs/devices/petraeus",
+        status: "coming-soon",
+        sources: placeholderSources("devices-petraeus"),
+      },
+      {
+        title: "MycoTenna",
+        description: "RF and spectrum sensing array for environmental signals.",
+        href: "/docs/devices/mycotenna",
+        status: "coming-soon",
+        sources: placeholderSources("devices-mycotenna"),
+      },
+      {
+        title: "Mushroom 2",
+        description: "Next-gen consumer and professional variant of Mushroom 1.",
+        href: "/docs/devices/mushroom-2",
+        status: "coming-soon",
+        sources: placeholderSources("devices-mushroom-2"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 8. Apps
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "apps",
+    title: "Apps",
+    href: "/docs/apps",
+    description: "Studio tools and simulators built on the Mycosoft platform.",
+    entries: [
+      {
+        title: "Earth Simulator",
+        description: "Planetary-scale environmental modeling.",
+        href: "/docs/apps/earth-simulator",
+        status: "coming-soon",
+        sources: placeholderSources("apps-earth-simulator"),
+      },
+      {
+        title: "Alchemy Lab",
+        description: "Compound design and reaction planning.",
+        href: "/docs/apps/alchemy-lab",
+        status: "coming-soon",
+        sources: placeholderSources("apps-alchemy-lab"),
+      },
+      {
+        title: "Compound Sim",
+        description: "Molecular simulation surface.",
+        href: "/docs/apps/compound-sim",
+        status: "coming-soon",
+        sources: placeholderSources("apps-compound-sim"),
+      },
+      {
+        title: "Digital Twin",
+        description: "Live operational twin of a deployment site.",
+        href: "/docs/apps/digital-twin",
+        status: "coming-soon",
+        sources: placeholderSources("apps-digital-twin"),
+      },
+      {
+        title: "Genetic Circuit",
+        description: "Synthetic-biology circuit design.",
+        href: "/docs/apps/genetic-circuit",
+        status: "coming-soon",
+        sources: placeholderSources("apps-genetic-circuit"),
+      },
+      {
+        title: "Growth Analytics",
+        description: "Cultivation and growth metrics over time.",
+        href: "/docs/apps/growth-analytics",
+        status: "coming-soon",
+        sources: placeholderSources("apps-growth-analytics"),
+      },
+      {
+        title: "Lifecycle Sim",
+        description: "Organism lifecycle modeling.",
+        href: "/docs/apps/lifecycle-sim",
+        status: "coming-soon",
+        sources: placeholderSources("apps-lifecycle-sim"),
+      },
+      {
+        title: "Mushroom Sim",
+        description: "Fungal growth simulation playground.",
+        href: "/docs/apps/mushroom-sim",
+        status: "coming-soon",
+        sources: placeholderSources("apps-mushroom-sim"),
+      },
+      {
+        title: "Petri Dish Sim",
+        description: "Lab-bench virtual experiment surface.",
+        href: "/docs/apps/petri-dish-sim",
+        status: "coming-soon",
+        sources: placeholderSources("apps-petri-dish-sim"),
+      },
+      {
+        title: "Physics Sim",
+        description: "Underlying physics engine for environment modeling.",
+        href: "/docs/apps/physics-sim",
+        status: "coming-soon",
+        sources: placeholderSources("apps-physics-sim"),
+      },
+      {
+        title: "Retrosynthesis",
+        description: "Retrosynthetic route planning for target compounds.",
+        href: "/docs/apps/retrosynthesis",
+        status: "coming-soon",
+        sources: placeholderSources("apps-retrosynthesis"),
+      },
+      {
+        title: "Spore Tracker",
+        description: "Track spore release and dispersion in the field.",
+        href: "/docs/apps/spore-tracker",
+        status: "coming-soon",
+        sources: placeholderSources("apps-spore-tracker"),
+      },
+      {
+        title: "Symbiosis",
+        description: "Multi-organism symbiosis modeling.",
+        href: "/docs/apps/symbiosis",
+        status: "coming-soon",
+        sources: placeholderSources("apps-symbiosis"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 9. Open Source
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "open-source",
+    title: "Open Source",
+    href: "/docs/open-source",
+    description: "Public Mycosoft repositories, licenses, and how to contribute.",
+    entries: [
+      {
+        title: "Repositories",
+        description: "Index of public Mycosoft repos and what each one is for.",
+        status: "coming-soon",
+        sources: placeholderSources("open-source-repositories"),
+      },
+      {
+        title: "Licenses",
+        description: "License-per-repo overview — what is source-available vs. OSI-licensed.",
+        status: "coming-soon",
+        sources: placeholderSources("open-source-licenses"),
+      },
+      {
+        title: "Contributing",
+        description: "How to file issues, propose changes, and sign the CLA.",
+        status: "coming-soon",
+        sources: placeholderSources("open-source-contributing"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 10. Defense & Government
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "defense-government",
+    title: "Defense & Government",
+    href: "/docs/defense-government",
+    description:
+      "Federal credentials, CUI handling, contracting vehicles, and operator obligations for government deployments.",
+    entries: [
+      {
+        title: "SAM.gov & federal credentials",
+        description: "UEI YK3ARVKJ77S9 · CAGE 9KR60 · Mycosoft, LLC entity.",
+        status: "coming-soon",
+        sources: placeholderSources("federal-credentials"),
+      },
+      {
+        title: "CUI & export-controlled data",
+        description: "Handling rules for Controlled Unclassified Information and export-controlled artifacts.",
+        status: "coming-soon",
+        sources: placeholderSources("cui-export-controlled"),
+      },
+      {
+        title: "Contracting vehicles",
+        description: "OTAs, SBIRs, BOOST, and other vehicles — high-level pointer for procurement teams.",
+        status: "coming-soon",
+        sources: placeholderSources("contracting-vehicles"),
+      },
+      {
+        title: "Operator obligations",
+        description: "Field-deployment compliance, training, and reporting requirements.",
+        status: "coming-soon",
+        sources: placeholderSources("operator-obligations"),
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 11. Security
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    id: "security",
+    title: "Security",
+    href: "/docs/security",
+    description: "Disclosure policy, device integrity, and data-security expectations across the platform.",
+    entries: [
+      {
+        title: "Responsible disclosure",
+        description: "How to report a vulnerability, and the response SLAs we hold ourselves to.",
+        status: "coming-soon",
+        sources: placeholderSources("security-disclosure"),
+      },
+      {
+        title: "Reverse engineering & tampering",
+        description: "What is permitted, what is not, and how to coordinate authorized research.",
+        status: "coming-soon",
+        sources: placeholderSources("security-reverse-engineering"),
+      },
+      {
+        title: "Device integrity",
+        description: "Signed firmware, attestation, and the chain-of-custody we enforce.",
+        status: "coming-soon",
+        sources: placeholderSources("security-device-integrity"),
+      },
+      {
+        title: "Data security",
+        description: "Encryption at rest, in transit, and data-classification boundaries.",
+        status: "coming-soon",
+        sources: placeholderSources("security-data"),
+      },
+    ],
+  },
+]
+
+/** Lookup a section by id for type-safe consumption in pages. */
+export function getSectionById(id: string): DocSection | undefined {
+  return DOCS_CATALOG.find((section) => section.id === id)
+}
+
+/** Lookup an entry by its route. */
+export function getEntryByHref(href: string): { section: DocSection; entry: DocEntry } | undefined {
+  for (const section of DOCS_CATALOG) {
+    const entry = section.entries.find((e) => e.href === href)
+    if (entry) return { section, entry }
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary
Rebuilds the `/docs` developer-documentation portal end-to-end. Replaces the 98-line placeholder with a catalog-driven index, adds a sidebar shell, and stands up 41 stub sub-pages covering every section Morgan listed. The existing 537-line `/docs/fci-firmware` page is **untouched**; the footer is **untouched**.

### What's new

**Data**
- `lib/docs-catalog.ts` — single source of truth: 11 sections (Overview, AI Stack, MAS, Dashboards, MINDEX, APIs, Devices, Apps, Open Source, Defense & Government, Security), every entry typed with `title`, `description`, `href`, `sources[]`, `status`. Placeholder sources use `/pdf/<slug>.pdf` and `https://mycosoft.gitbook.io/<slug>` so links resolve the moment Morgan uploads the real artifacts.

**Shell**
- `components/docs/docs-layout.tsx` — two-column shell at `md+` (sticky 16rem sidebar + content), single column on mobile with a "Browse documentation" disclosure. Collapsible nav groups, active-route highlighting via `usePathname()`.
- `components/docs/doc-stub-page.tsx` — shared stub shell with breadcrumb, status pill, source chips (PDF / GitBook / Internal / External), and a "Suggest an edit / contribute" GitHub CTA.
- `app/docs/layout.tsx` — route-segment metadata only. The visual shell is mounted by each page so the existing `fci-firmware` page keeps its own chrome.

**Index**
- `app/docs/page.tsx` rewritten as a dense, Stripe-docs-style index that iterates every section + entry with status badges and source chips. No more 4-card placeholder.

**Stubs (41 new pages)**
- 9 section landings: `/docs/ai`, `/docs/mas`, `/docs/mindex`, `/docs/api`, `/docs/devices`, `/docs/apps`, `/docs/open-source`, `/docs/defense-government`, `/docs/security` — each renders that section's entries as a grid.
- 4 AI Stack: MYCA, AVANI, NLM (frontier), Deterministic vs Stochastic.
- 2 Dashboards: NatureOS, Fusarium.
- 13 Devices (excludes `/docs/fci-firmware` which already exists): Mushroom 1, Hyphae 1, MycoNode, ALARM, MycoBrain, Agaric, Psathyrella, SporeBase, FCI Probes (frontier), Tricorder, Petraeus, MycoTenna, Mushroom 2.
- 13 Apps: Earth Simulator, Alchemy Lab, Compound Sim, Digital Twin, Genetic Circuit, Growth Analytics, Lifecycle Sim, Mushroom Sim, Petri Dish Sim, Physics Sim, Retrosynthesis, Spore Tracker, Symbiosis.

### Editorial guardrails carried over
- `NLM` and `FCI Probes` are `status: "frontier"` everywhere they appear.
- No claim that fungi are language-capable computers.
- No claim that Wi-Fi sense gives planetary perception.
- No claim that interspecies translation is solved.

### Not touched
- `app/docs/fci-firmware/page.tsx` (existing 537-line stable doc — sidebar links to it, content unchanged).
- `components/footer.tsx`.

## Test plan
- [ ] `/docs` renders the new catalog index with sidebar visible at `md+`.
- [ ] Sidebar shows 11 groups; Devices and Apps expand to reveal sub-entries; mobile disclosure opens/closes.
- [ ] Each new stub route loads (e.g. `/docs/devices/mushroom-1`, `/docs/ai/nlm`, `/docs/apps/earth-simulator`).
- [ ] Section landings (e.g. `/docs/devices`, `/docs/apps`) list their entries as cards.
- [ ] `/docs/fci-firmware` still loads with the existing 537-line content.
- [ ] Status pills render: "Stable" on FCI Firmware, "Frontier / Research" on NLM and FCI Probes, "Coming soon" on the rest.
- [ ] PDF and GitBook chips on the catalog point at the placeholder URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rebuild the /docs developer portal around a shared catalog-driven layout with a sidebar, section landings, and stub content pages while preserving the existing FCI firmware doc and footer.

New Features:
- Introduce a centralized docs catalog data model that defines sections, entries, statuses, and source links for the documentation portal.
- Replace the simple /docs landing page with a catalog index that lists all sections and entries with status badges and source chips.
- Add a responsive docs layout shell with a sticky sidebar and mobile disclosure navigation for all /docs routes.
- Create reusable stub page components for individual docs that show breadcrumbs, status, source links, and a GitHub contribution call-to-action.
- Add section landing pages for AI Stack, Multi-Agent System, MINDEX, APIs, Devices, Apps, Open Source, Defense & Government, and Security that render their catalog entries as grids.
- Add stub detail pages for dashboards, devices, and apps referenced in the catalog so routes exist even before full content is written.

Enhancements:
- Standardize documentation metadata and status labelling (stable, draft, frontier, coming-soon) across the docs experience.
- Ensure frontier research topics like NLM and FCI probes are consistently flagged as research rather than production capabilities via catalog status and copy.
- Unify breadcrumb and navigation patterns across docs pages using shared layout and stub components.

Documentation:
- Stand up a structured, navigable developer documentation portal with section overviews and placeholder content for all core platform areas, ready to be filled with canonical PDFs and GitBook sources.