### PR TITLE
feat(docs): Overview docs (What is Mycosoft / Quickstart / Glossary) + TOS formatting pass

### DIFF
--- a/app/docs/glossary/page.tsx
+++ b/app/docs/glossary/page.tsx
@@ -1,0 +1,498 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import { Badge } from "@/components/ui/badge"
+
+export const metadata: Metadata = {
+  title: "Glossary",
+  description:
+    "Every Mycosoft-specific term, plus the AI, mycology, and federal contracting vocabulary you will meet in our documentation — written for newcomers.",
+}
+
+export default function Page() {
+  return (
+    <DocsLayout>
+      <article className="prose prose-neutral dark:prose-invert max-w-3xl prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-14 prose-h2:pt-6 prose-h2:border-t prose-h2:border-border prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-10 prose-h3:text-xl prose-h3:font-semibold prose-p:leading-relaxed prose-li:leading-relaxed prose-ul:my-4 prose-dl:my-6">
+        <div className="not-prose mb-4 flex flex-wrap items-center gap-2 text-sm">
+          <Link href="/docs" className="text-muted-foreground hover:text-foreground">
+            Documentation
+          </Link>
+          <span className="text-muted-foreground">/</span>
+          <span className="text-foreground">Overview</span>
+        </div>
+
+        <h1>Glossary</h1>
+
+        <div className="not-prose my-6 flex flex-wrap items-center gap-2">
+          <Badge variant="outline">Overview</Badge>
+          <Badge variant="default">Stable</Badge>
+          <Badge variant="outline">Living document</Badge>
+        </div>
+
+        <p>
+          One place to look up every term you will hit in the Mycosoft docs. Grouped into five
+          sections — company &amp; products, platform &amp; AI, devices &amp; firmware,
+          mycology &amp; biology, and federal contracting. Cross-references link to the canonical
+          documentation for each concept.
+        </p>
+
+        <div className="not-prose my-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3 text-sm">
+          <a href="#company" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
+            Company &amp; products
+          </a>
+          <a href="#platform" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
+            Platform &amp; AI
+          </a>
+          <a href="#devices" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
+            Devices &amp; firmware
+          </a>
+          <a href="#biology" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
+            Mycology &amp; biology
+          </a>
+          <a href="#federal" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
+            Federal contracting
+          </a>
+          <a href="#status-labels" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
+            Status labels
+          </a>
+        </div>
+
+        <h2 id="company">Company &amp; products</h2>
+
+        <dl>
+          <dt><strong>Mycosoft, Inc.</strong></dt>
+          <dd>
+            Delaware C-Corporation. The parent company, investor-of-record, and licensor of
+            platform intellectual property.
+          </dd>
+
+          <dt><strong>Mycosoft, LLC</strong></dt>
+          <dd>
+            California limited liability company; operating subsidiary. The federal contracting
+            entity and the party that signs most pilot, reseller, and field-deployment
+            agreements. Holds UEI <span className="font-mono">YK3ARVKJ77S9</span> and CAGE{" "}
+            <span className="font-mono">9KR60</span>.
+          </dd>
+
+          <dt><strong>MycoLabs</strong> / <strong>MycosoftLabs</strong></dt>
+          <dd>
+            Public engineering presence on GitHub:{" "}
+            <a href="https://github.com/MycosoftLabs">github.com/MycosoftLabs</a>.
+          </dd>
+
+          <dt><strong>NatureOS</strong></dt>
+          <dd>
+            The Mycosoft operating platform. Cloud + edge services that ingest device signal and
+            public environmental data, store it, model it, and expose it through dashboards,
+            APIs, and agentic interfaces.{" "}
+            <Link href="/docs/dashboards">Dashboards →</Link>
+          </dd>
+
+          <dt><strong>Earth Simulator</strong></dt>
+          <dd>
+            Environmental world-model service inside NatureOS. Used for scenario generation,
+            simulation-backed model training, and what-if analysis against live telemetry.
+          </dd>
+
+          <dt><strong>MINDEX</strong></dt>
+          <dd>
+            The indexed data plane — Postgres-backed store of record for telemetry, specimen
+            records, chain-of-custody, and model outputs.{" "}
+            <Link href="/docs/mindex">MINDEX →</Link>
+          </dd>
+
+          <dt><strong>AI Studio</strong></dt>
+          <dd>
+            Model training, evaluation, and deployment surface for internal and partner ML work.
+          </dd>
+
+          <dt><strong>CREP</strong></dt>
+          <dd>
+            Compliance, Reporting, and Evidence Pipeline. The audit and chain-of-custody layer
+            for regulated work and defence deployments.
+          </dd>
+
+          <dt><strong>OEI</strong></dt>
+          <dd>
+            Open Environmental Intelligence — the public-data ingestion layer covering AIS,
+            ADS-B, satellite imagery, weather, biodiversity records, and other open feeds.
+          </dd>
+
+          <dt><strong>FUSARIUM</strong></dt>
+          <dd>
+            Field intelligence and defence-deployment programme; a named operational stack inside
+            Mycosoft for environmental and biosurveillance use cases.
+          </dd>
+
+          <dt><strong>Mycorrhizae Protocol</strong></dt>
+          <dd>
+            Inter-device protocol for moving signal between Mycosoft devices, edge nodes, and the
+            NatureOS cloud — analogous to how mycorrhizal networks shuttle resources between
+            plants and fungi.
+          </dd>
+
+          <dt><strong>HPL</strong></dt>
+          <dd>
+            Higher-level platform protocol used between NatureOS services and external partner
+            systems.
+          </dd>
+
+          <dt><strong>Apps</strong></dt>
+          <dd>
+            The library of focused web apps on top of NatureOS: <em>earth-simulator</em>,{" "}
+            <em>alchemy-lab</em>, <em>compound-sim</em>, <em>digital-twin</em>,{" "}
+            <em>genetic-circuit</em>, <em>growth-analytics</em>, <em>lifecycle-sim</em>,{" "}
+            <em>mushroom-sim</em>, <em>petri-dish-sim</em>, <em>physics-sim</em>,{" "}
+            <em>retrosynthesis</em>, <em>spore-tracker</em>, and <em>symbiosis</em>.{" "}
+            <Link href="/docs/apps">Apps →</Link>
+          </dd>
+        </dl>
+
+        <h2 id="platform">Platform &amp; AI</h2>
+
+        <dl>
+          <dt><strong>MYCA</strong></dt>
+          <dd>
+            Mycosoft&apos;s multi-agent AI orchestrator. Routes work across specialised agents
+            under the <strong>Task Automation Law</strong> that governs delegation, escalation,
+            and human-in-the-loop checkpoints. <Link href="/docs/ai/myca">MYCA →</Link>
+          </dd>
+
+          <dt><strong>MAS</strong></dt>
+          <dd>
+            Mycosoft Agent Swarm runtime. The deployment-side execution environment that hosts
+            agents in production, including resource limits, retries, and observability.{" "}
+            <Link href="/docs/mas">MAS →</Link>
+          </dd>
+
+          <dt><strong>AVANI</strong></dt>
+          <dd>
+            Voice and conversational interface across Mycosoft products. The layer customers and
+            operators speak to. <Link href="/docs/ai/avani">AVANI →</Link>
+          </dd>
+
+          <dt><strong>NLM</strong></dt>
+          <dd>
+            A frontier research programme on natural-language-to-signal interfaces. Labelled
+            frontier; not a shipping product. <Link href="/docs/ai/nlm">NLM →</Link>
+          </dd>
+
+          <dt><strong>Task Automation Law</strong></dt>
+          <dd>
+            The governance contract every MYCA-orchestrated agent operates under. Defines what an
+            agent may decide on its own, what it must escalate, what it must log, and where
+            human approval is required.
+          </dd>
+
+          <dt><strong>Deterministic vs stochastic AI</strong></dt>
+          <dd>
+            The decision framework Mycosoft uses for field-deployed systems. Deterministic
+            pipelines (rules, classical algorithms) own anything safety-critical or
+            regulated; stochastic systems (LLMs, frontier models) are used for reasoning,
+            drafting, and exploration — never as the sole decision-maker for a field action.{" "}
+            <Link href="/docs/ai/deterministic-vs-stochastic">Read more →</Link>
+          </dd>
+
+          <dt><strong>Chain-of-custody record</strong></dt>
+          <dd>
+            A cryptographically signed log entry that tracks who handled a sample, signal, or
+            artifact and when. CREP produces and stores chain-of-custody records for regulated
+            workflows.
+          </dd>
+
+          <dt><strong>Telemetry</strong></dt>
+          <dd>
+            The continuous stream of measured readings from a device — environmental channels
+            (temperature, humidity, gas), bioelectric channels, and device-health metadata.
+          </dd>
+
+          <dt><strong>Digital twin</strong></dt>
+          <dd>
+            A live, simulation-backed representation of a physical specimen, device, or
+            environment, kept in sync with real telemetry via NatureOS and Earth Simulator.
+          </dd>
+        </dl>
+
+        <h2 id="devices">Devices &amp; firmware</h2>
+
+        <dl>
+          <dt><strong>FCI</strong> — Fungal Computer Interface</dt>
+          <dd>
+            Two meanings: (1) the firmware stack that runs on every Mycosoft device and on
+            partner boards (BME688 / BSEC2 environmental sensing, bioelectric sampling,
+            MQTT/HTTP APIs, OTA updates); and (2) the broader multi-year R&amp;D programme
+            building higher-bandwidth fungal computer interfaces. The firmware is{" "}
+            <em>stable</em>; the broader programme is <em>frontier</em>.{" "}
+            <Link href="/docs/fci-firmware">FCI firmware →</Link>
+          </dd>
+
+          <dt><strong>Mushroom 1</strong></dt>
+          <dd>
+            Flagship Mycosoft device. Substrate-grown mycelium probe that records bioelectric
+            activity and environmental signal, forwarded to NatureOS.
+          </dd>
+
+          <dt><strong>Hyphae 1</strong></dt>
+          <dd>
+            Compact, lower-cost growth and signal node for lab benches, classrooms, and
+            citizen-science deployments.
+          </dd>
+
+          <dt><strong>MycoBrain</strong></dt>
+          <dd>
+            The ESP32-class embedded compute board that runs the FCI firmware inside finished
+            devices.
+          </dd>
+
+          <dt><strong>MycoNode</strong></dt>
+          <dd>
+            Environmental gateway / edge node. Aggregates signal from multiple devices and
+            brokers it to the cloud.
+          </dd>
+
+          <dt><strong>SporeBase</strong></dt>
+          <dd>
+            Spore-sampling and chain-of-custody hardware module used in laboratory and field
+            workflows.
+          </dd>
+
+          <dt><strong>ALARM</strong></dt>
+          <dd>
+            Early-warning sensor unit for biological and environmental anomalies.
+          </dd>
+
+          <dt><strong>Agaric</strong></dt>
+          <dd>
+            Reference development board for partners and integrators building on top of FCI
+            firmware.
+          </dd>
+
+          <dt><strong>Psathyrella</strong> <em className="text-muted-foreground">(draft)</em></dt>
+          <dd>
+            Specialised field-sampling device under partial build; status will move to stable
+            once shipping.
+          </dd>
+
+          <dt><strong>BME688</strong></dt>
+          <dd>
+            Bosch four-in-one environmental sensor (temperature, humidity, pressure, VOC / gas
+            resistance) used throughout the Mycosoft device line.
+          </dd>
+
+          <dt><strong>BSEC2</strong></dt>
+          <dd>
+            Bosch Sensortec Environmental Cluster library, version 2 — the gas-classification and
+            calibration runtime layered on top of BME688.
+          </dd>
+
+          <dt><strong>Bioelectric signal</strong></dt>
+          <dd>
+            Voltage and current measurements taken across or within living tissue — in our case,
+            mycelium. The primary biological channel Mushroom 1 and Hyphae 1 record.
+          </dd>
+
+          <dt><strong>OTA</strong></dt>
+          <dd>
+            Over-the-air firmware update. Mycosoft devices receive signed OTA updates via the
+            NatureOS device-management service.
+          </dd>
+
+          <dt><strong>FCI protocol</strong></dt>
+          <dd>
+            The on-wire and over-network message format that FCI firmware uses to publish
+            samples, sensor frames, and device events.
+          </dd>
+        </dl>
+
+        <h2 id="biology">Mycology &amp; biology</h2>
+
+        <dl>
+          <dt><strong>Mycelium</strong></dt>
+          <dd>
+            The vegetative, thread-like body of a fungus — a network of fine filaments called
+            hyphae. Mushroom 1 grows mycelium on a controlled substrate and records its
+            electrical and environmental activity.
+          </dd>
+
+          <dt><strong>Hyphae</strong></dt>
+          <dd>
+            The individual filaments that make up mycelium. Hyphae 1 takes its name from these.
+          </dd>
+
+          <dt><strong>Fruiting body</strong></dt>
+          <dd>
+            The reproductive structure of a fungus — the &ldquo;mushroom&rdquo; in everyday
+            language. Most of the organism&apos;s mass and information lives below it, in the
+            mycelium.
+          </dd>
+
+          <dt><strong>Substrate</strong></dt>
+          <dd>
+            The growth medium that mycelium colonises — wood chips, grain, agar, controlled
+            blends. Substrate composition directly affects signal quality.
+          </dd>
+
+          <dt><strong>Mycorrhiza</strong></dt>
+          <dd>
+            A symbiotic relationship between fungal mycelium and plant roots. Inspires (and
+            names) the Mycorrhizae Protocol used between Mycosoft devices.
+          </dd>
+
+          <dt><strong>Spore</strong></dt>
+          <dd>
+            The reproductive unit of a fungus. SporeBase and the spore-tracker app deal with
+            collection, identification, and chain-of-custody for spores.
+          </dd>
+
+          <dt><strong>Symbiosis</strong></dt>
+          <dd>
+            A long-term biological interaction between two organisms. The{" "}
+            <em>symbiosis</em> app models and visualises symbiotic systems.
+          </dd>
+
+          <dt><strong>Retrosynthesis</strong></dt>
+          <dd>
+            A chemistry planning technique for working backwards from a target molecule to viable
+            precursors. The <em>retrosynthesis</em> app exposes this for compounds of interest
+            in mycology and biotechnology.
+          </dd>
+
+          <dt><strong>Bioaerosol</strong></dt>
+          <dd>
+            Airborne biological particles — spores, bacteria, fragments. Mycosoft sensor kits
+            include bioaerosol collection in some deployments.
+          </dd>
+        </dl>
+
+        <h2 id="federal">Federal contracting</h2>
+
+        <dl>
+          <dt><strong>SAM.gov</strong></dt>
+          <dd>
+            The U.S. federal System for Award Management. The required registry for any entity
+            receiving federal contracts, grants, or sub-awards. Mycosoft, LLC&apos;s registration
+            is active through April 2027.
+          </dd>
+
+          <dt><strong>UEI</strong> — Unique Entity Identifier</dt>
+          <dd>
+            The 12-character federal identifier that replaced DUNS in 2022. Mycosoft, LLC&apos;s
+            UEI is <span className="font-mono">YK3ARVKJ77S9</span>.
+          </dd>
+
+          <dt><strong>CAGE code</strong></dt>
+          <dd>
+            Commercial And Government Entity code — a 5-character identifier assigned by the
+            Defense Logistics Agency. Mycosoft, LLC&apos;s CAGE is{" "}
+            <span className="font-mono">9KR60</span>.
+          </dd>
+
+          <dt><strong>FAR</strong></dt>
+          <dd>
+            Federal Acquisition Regulation — the primary regulation governing how U.S. federal
+            agencies acquire goods and services.
+          </dd>
+
+          <dt><strong>DFARS</strong></dt>
+          <dd>
+            Defense Federal Acquisition Regulation Supplement — the DoD-specific supplement to
+            the FAR.
+          </dd>
+
+          <dt><strong>OTA</strong> — Other Transaction Authority</dt>
+          <dd>
+            A non-traditional contracting authority used by DoD and select agencies to acquire
+            prototypes and research outside the FAR. Not to be confused with over-the-air
+            firmware updates (also abbreviated OTA in the device section above).
+          </dd>
+
+          <dt><strong>CSO</strong></dt>
+          <dd>
+            Commercial Solutions Opening — a competitive acquisition vehicle that lets agencies
+            solicit innovative solutions on shorter timelines.
+          </dd>
+
+          <dt><strong>SBIR / STTR</strong></dt>
+          <dd>
+            Small Business Innovation Research / Small Business Technology Transfer — federal
+            R&amp;D funding programmes for small businesses; STTR requires a research-institution
+            partner.
+          </dd>
+
+          <dt><strong>SAFE</strong></dt>
+          <dd>
+            Simple Agreement for Future Equity — a startup financing instrument. Used by
+            Mycosoft, Inc. in early-stage rounds. Distinct from federal contracting acronyms.
+          </dd>
+
+          <dt><strong>Capability statement</strong></dt>
+          <dd>
+            A short, structured document a federal vendor uses to introduce itself to a
+            contracting officer — what it does, NAICS codes, past performance, and key
+            differentiators.
+          </dd>
+
+          <dt><strong>Teaming agreement</strong></dt>
+          <dd>
+            A contract between a prime contractor and one or more subcontractors covering how
+            they will jointly pursue and execute a federal opportunity.
+          </dd>
+
+          <dt><strong>Prime contractor / subcontractor</strong></dt>
+          <dd>
+            The prime holds the federal contract directly with the agency; subcontractors hold
+            contracts with the prime. Mycosoft, LLC engages in both roles depending on the
+            programme.
+          </dd>
+
+          <dt><strong>Deployment Sponsor</strong></dt>
+          <dd>
+            Defined in the <Link href="/terms">Mycosoft Terms of Service</Link>: the person or
+            entity responsible for authorising, funding, directing, hosting, purchasing,
+            leasing, permitting, or benefiting from a field deployment.
+          </dd>
+
+          <dt><strong>NAICS code</strong></dt>
+          <dd>
+            North American Industry Classification System code — used by federal procurement to
+            categorise vendors by industry.
+          </dd>
+        </dl>
+
+        <h2 id="status-labels">Status labels used in these docs</h2>
+
+        <dl>
+          <dt><strong>Stable</strong></dt>
+          <dd>
+            Shipping today, supported, and covered by the standard{" "}
+            <Link href="/terms">Terms of Service</Link>.
+          </dd>
+
+          <dt><strong>Draft</strong></dt>
+          <dd>
+            Being built right now; the documentation reflects current direction but specifics
+            will change.
+          </dd>
+
+          <dt><strong>Frontier</strong></dt>
+          <dd>
+            Multi-year research programme. Read as ambition, not roadmap. No product commitment
+            and no shipping date.
+          </dd>
+
+          <dt><strong>Coming soon</strong></dt>
+          <dd>
+            The document exists in outline; the page is being written.
+          </dd>
+        </dl>
+
+        <hr className="my-12" />
+
+        <p className="text-sm text-muted-foreground">
+          Back to: <Link href="/docs/what-is-mycosoft">What is Mycosoft</Link> ·{" "}
+          <Link href="/docs/quickstart">Quickstart</Link>
+        </p>
+      </article>
+    </DocsLayout>
+  )
+}

--- a/app/docs/quickstart/page.tsx
+++ b/app/docs/quickstart/page.tsx
@@ -1,0 +1,335 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import { Badge } from "@/components/ui/badge"
+
+export const metadata: Metadata = {
+  title: "Quickstart",
+  description:
+    "First fifteen minutes with Mycosoft — pick a device or an API, request access, and see your first data flow into NatureOS.",
+}
+
+export default function Page() {
+  return (
+    <DocsLayout>
+      <article className="prose prose-neutral dark:prose-invert max-w-3xl prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-14 prose-h2:pt-6 prose-h2:border-t prose-h2:border-border prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-10 prose-h3:text-xl prose-h3:font-semibold prose-p:leading-relaxed prose-li:leading-relaxed prose-ul:my-4 prose-ol:my-4">
+        <div className="not-prose mb-4 flex flex-wrap items-center gap-2 text-sm">
+          <Link href="/docs" className="text-muted-foreground hover:text-foreground">
+            Documentation
+          </Link>
+          <span className="text-muted-foreground">/</span>
+          <span className="text-foreground">Overview</span>
+        </div>
+
+        <h1>Quickstart</h1>
+
+        <div className="not-prose my-6 flex flex-wrap items-center gap-2">
+          <Badge variant="outline">Overview</Badge>
+          <Badge variant="default">Stable</Badge>
+          <Badge variant="outline">~15 minutes</Badge>
+        </div>
+
+        <p>
+          This page takes you from zero to your first data flowing through a Mycosoft system in
+          about fifteen minutes. There are three entry paths — pick the one that matches what
+          you have today and what you want to do next. You can come back and follow another path
+          later.
+        </p>
+
+        <div className="not-prose my-8 grid gap-4 sm:grid-cols-3">
+          <Link
+            href="#path-device"
+            className="rounded-lg border border-border bg-card p-4 hover:bg-accent transition-colors"
+          >
+            <div className="text-sm font-semibold text-foreground">Path A — Device</div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              You have (or want) a Mushroom 1, Hyphae 1, or Agaric and want signal in a
+              dashboard.
+            </p>
+          </Link>
+          <Link
+            href="#path-api"
+            className="rounded-lg border border-border bg-card p-4 hover:bg-accent transition-colors"
+          >
+            <div className="text-sm font-semibold text-foreground">Path B — API</div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              You are a developer and you want to query NatureOS / OEI from your own code.
+            </p>
+          </Link>
+          <Link
+            href="#path-dashboards"
+            className="rounded-lg border border-border bg-card p-4 hover:bg-accent transition-colors"
+          >
+            <div className="text-sm font-semibold text-foreground">Path C — Dashboards</div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              You want to explore data in NatureOS dashboards without writing code.
+            </p>
+          </Link>
+        </div>
+
+        <h2 id="before-you-start">Before you start</h2>
+
+        <p>You need:</p>
+        <ul>
+          <li>A work email address you can receive mail at.</li>
+          <li>
+            For Path A only — physical device hardware (Mushroom 1, Hyphae 1, an Agaric
+            development board, or a partner board running FCI firmware), a USB-C cable, and
+            Wi-Fi access.
+          </li>
+          <li>
+            For Path B only — a computer with{" "}
+            <span className="font-mono">curl</span> or Node.js / Python installed.
+          </li>
+        </ul>
+
+        <p>
+          By using the Services you agree to the <Link href="/terms">Mycosoft Terms of
+          Service</Link>. The Terms apply to every path below.
+        </p>
+
+        <h2 id="path-device">Path A — From device to first signal</h2>
+
+        <p>Target outcome: your device is paired, online, and streaming readings into NatureOS.</p>
+
+        <h3 id="device-step-1">1. Identify your device</h3>
+        <ul>
+          <li>
+            <strong>Mushroom 1</strong> — flagship; substrate-grown mycelium probe with full FCI
+            firmware. <Link href="/docs/devices">Spec sheet →</Link>
+          </li>
+          <li>
+            <strong>Hyphae 1</strong> — compact growth / signal node; lower-cost classroom and
+            citizen-science deployments.
+          </li>
+          <li>
+            <strong>Agaric</strong> — reference development board for partners and integrators.
+          </li>
+        </ul>
+        <p>
+          Other devices in the lineup (<strong>MycoNode</strong>, <strong>SporeBase</strong>,{" "}
+          <strong>ALARM</strong>, <strong>MycoBrain</strong> board) follow the same flow; consult
+          the device-specific page for any deltas.
+        </p>
+
+        <h3 id="device-step-2">2. Power on and flash (if needed)</h3>
+        <p>
+          Production devices ship with FCI firmware pre-flashed. If you have a development board
+          or want to upgrade:
+        </p>
+        <ol>
+          <li>
+            Install PlatformIO CLI: <span className="font-mono">pip install platformio</span>.
+          </li>
+          <li>
+            Clone the firmware repo:{" "}
+            <span className="font-mono">
+              git clone https://github.com/MycosoftLabs/mycobrain-firmware.git
+            </span>
+          </li>
+          <li>
+            Connect the device by USB-C and run <span className="font-mono">pio run -t upload</span>{" "}
+            from the repo root.
+          </li>
+        </ol>
+        <p>
+          Full reference and troubleshooting:{" "}
+          <Link href="/docs/fci-firmware">FCI firmware documentation</Link>.
+        </p>
+
+        <h3 id="device-step-3">3. Join Wi-Fi and pair</h3>
+        <ol>
+          <li>
+            On first boot the device exposes a captive Wi-Fi network named{" "}
+            <span className="font-mono">mycosoft-setup-XXXX</span>.
+          </li>
+          <li>
+            Join it from your phone or laptop. The pairing page opens automatically.
+          </li>
+          <li>
+            Enter your Wi-Fi credentials and the pairing code printed on the device label.
+          </li>
+          <li>
+            When the device boots into normal mode, it registers with NatureOS and appears in
+            your device list.
+          </li>
+        </ol>
+
+        <h3 id="device-step-4">4. See your first signal</h3>
+        <p>
+          Sign in at <a href="https://natureos.mycosoft.com">natureos.mycosoft.com</a> and open
+          the device. Within a minute or two you should see live bioelectric and environmental
+          channels (temperature, humidity, VOC, gas resistance, bioelectric voltage). The
+          dashboard updates in real time and stores history in MINDEX so you can scrub backwards.
+        </p>
+
+        <div className="not-prose my-6 rounded-lg border border-border bg-muted/40 p-4 text-sm">
+          <p className="m-0">
+            <strong>If you don&apos;t have a device yet:</strong> request one at{" "}
+            <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a> with the use case
+            (research, classroom, commercial pilot, defence) and the deployment environment.
+            Allocation is currently order-by-order.
+          </p>
+        </div>
+
+        <h2 id="path-api">Path B — From zero to first API call</h2>
+
+        <p>Target outcome: you have an API key, made a successful authenticated call, and seen real data come back.</p>
+
+        <h3 id="api-step-1">1. Request developer access</h3>
+        <ol>
+          <li>
+            Email <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a> with the subject{" "}
+            <strong>API access request</strong> and include your name, organisation, intended use
+            case, and whether you need access to your own device data, the OEI public-data layer,
+            or both.
+          </li>
+          <li>
+            Accept the <Link href="/terms">Terms of Service</Link>.
+          </li>
+          <li>
+            You will receive a developer-portal invitation and an initial API key with scoped
+            permissions.
+          </li>
+        </ol>
+
+        <h3 id="api-step-2">2. Make your first call</h3>
+        <p>From a terminal:</p>
+        <pre className="not-prose overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono">
+{`curl -H "Authorization: Bearer YOUR_API_KEY" \\
+     https://api.mycosoft.com/v1/health`}
+        </pre>
+        <p>
+          You should get a JSON <span className="font-mono">200 OK</span> with platform version
+          and your key&apos;s scopes. If you get a 401, your key isn&apos;t active yet — wait a
+          minute and retry; if it persists, contact support.
+        </p>
+
+        <h3 id="api-step-3">3. Query real data</h3>
+        <p>List the devices in your organisation:</p>
+        <pre className="not-prose overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono">
+{`curl -H "Authorization: Bearer YOUR_API_KEY" \\
+     https://api.mycosoft.com/v1/devices`}
+        </pre>
+        <p>Pull the last hour of signal from a device:</p>
+        <pre className="not-prose overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono">
+{`curl -H "Authorization: Bearer YOUR_API_KEY" \\
+     "https://api.mycosoft.com/v1/devices/DEVICE_ID/signal?window=1h"`}
+        </pre>
+        <p>
+          Each row is a timestamped reading. The full schema, rate limits, pagination rules, and
+          OEI public-data endpoints (AIS, ADS-B, weather, biodiversity) are documented under{" "}
+          <Link href="/docs/api">API reference</Link>.
+        </p>
+
+        <h3 id="api-step-4">4. Optional — talk to an agent</h3>
+        <p>
+          If your access scope includes the agent runtime, you can send a task to MYCA from your
+          code. See <Link href="/docs/ai/myca">MYCA</Link> for the request shape, agent roles,
+          and the Task Automation Law that governs what an agent will and will not do
+          autonomously.
+        </p>
+
+        <h2 id="path-dashboards">Path C — Explore in NatureOS dashboards</h2>
+
+        <p>Target outcome: you have a NatureOS account and have opened a live dashboard.</p>
+
+        <ol>
+          <li>
+            Go to <a href="https://natureos.mycosoft.com">natureos.mycosoft.com</a> and sign in
+            with the email used in your pilot, order, or partnership.
+          </li>
+          <li>
+            On the home page, open the <strong>Environment</strong> tile to see public-data
+            feeds (OEI), or the <strong>Devices</strong> tile to see live device telemetry, or
+            the <strong>Apps</strong> tile to launch a simulation (mushroom-sim,
+            petri-dish-sim, earth-simulator, and others).
+          </li>
+          <li>
+            Every chart in NatureOS has an <strong>Export</strong> button — CSV or JSON, with the
+            same data your API key can pull.
+          </li>
+        </ol>
+
+        <p>
+          Dashboard catalogue and deep-links live under{" "}
+          <Link href="/docs/dashboards">Dashboards</Link>.
+        </p>
+
+        <h2 id="what-next">What to do next</h2>
+
+        <h3 id="next-developers">If you&apos;re a developer</h3>
+        <ul>
+          <li>
+            <Link href="/docs/api">API reference</Link> — full endpoint list and SDKs.
+          </li>
+          <li>
+            <Link href="/docs/fci-firmware">FCI firmware</Link> — protocol details, MQTT topics,
+            OTA, custom builds.
+          </li>
+          <li>
+            <Link href="/docs/mas">MAS</Link> — running and hosting agents.
+          </li>
+          <li>
+            <Link href="/docs/open-source">Open source</Link> — what is permissively licensed,
+            source-available, or commercial.
+          </li>
+        </ul>
+
+        <h3 id="next-operators">If you&apos;re an operator or scientist</h3>
+        <ul>
+          <li>
+            <Link href="/docs/devices">Devices</Link> — per-device deployment guides.
+          </li>
+          <li>
+            <Link href="/docs/mindex">MINDEX</Link> — how telemetry is stored and queried.
+          </li>
+          <li>
+            <Link href="/docs/dashboards">Dashboards</Link> — building views and exports.
+          </li>
+          <li>
+            <Link href="/docs/apps">Apps</Link> — the simulation and lab tools on top of
+            NatureOS.
+          </li>
+        </ul>
+
+        <h3 id="next-defense">If you&apos;re a defence or government contact</h3>
+        <ul>
+          <li>
+            <Link href="/docs/defense-government">Defence &amp; Government</Link> — SAM.gov
+            status (UEI <span className="font-mono">YK3ARVKJ77S9</span>, CAGE{" "}
+            <span className="font-mono">9KR60</span>), capability statements, teaming, and the
+            deployment-sponsor model.
+          </li>
+          <li>
+            <Link href="/docs/security">Security</Link> — controls, evidence, and the CREP
+            pipeline.
+          </li>
+        </ul>
+
+        <h2 id="getting-help">Getting help</h2>
+
+        <ul>
+          <li>
+            General — <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a>
+          </li>
+          <li>
+            Engineering — issues and discussions at{" "}
+            <a href="https://github.com/MycosoftLabs">github.com/MycosoftLabs</a>
+          </li>
+          <li>
+            Glossary of every term you&apos;ll meet in these docs:{" "}
+            <Link href="/docs/glossary">Glossary</Link>
+          </li>
+        </ul>
+
+        <hr className="my-12" />
+
+        <p className="text-sm text-muted-foreground">
+          Back to: <Link href="/docs/what-is-mycosoft">What is Mycosoft</Link> · Next:{" "}
+          <Link href="/docs/glossary">Glossary →</Link>
+        </p>
+      </article>
+    </DocsLayout>
+  )
+}

--- a/app/docs/what-is-mycosoft/page.tsx
+++ b/app/docs/what-is-mycosoft/page.tsx
@@ -1,0 +1,361 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { DocsLayout } from "@/components/docs/docs-layout"
+import { Badge } from "@/components/ui/badge"
+
+export const metadata: Metadata = {
+  title: "What is Mycosoft",
+  description:
+    "Company overview, the full Mycosoft stack, and who this documentation is for — written for investors, customers, partners, and developers.",
+}
+
+export default function Page() {
+  return (
+    <DocsLayout>
+      <article className="prose prose-neutral dark:prose-invert max-w-3xl prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-14 prose-h2:pt-6 prose-h2:border-t prose-h2:border-border prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-10 prose-h3:text-xl prose-h3:font-semibold prose-p:leading-relaxed prose-li:leading-relaxed prose-ul:my-4">
+        <div className="not-prose mb-4 flex flex-wrap items-center gap-2 text-sm">
+          <Link href="/docs" className="text-muted-foreground hover:text-foreground">
+            Documentation
+          </Link>
+          <span className="text-muted-foreground">/</span>
+          <span className="text-foreground">Overview</span>
+        </div>
+
+        <h1>What is Mycosoft</h1>
+
+        <div className="not-prose my-6 flex flex-wrap items-center gap-2">
+          <Badge variant="outline">Overview</Badge>
+          <Badge variant="default">Stable</Badge>
+          <Badge variant="outline">For investors · customers · developers</Badge>
+        </div>
+
+        <p>
+          Mycosoft is a biotechnology and software company building the operating layer for
+          biological intelligence — the systems, devices, and services that let humans observe,
+          model, and act on the living world. We design fungal-aware sensors, train AI models on
+          environmental and biological signal, run autonomous agent platforms for science and
+          operations, and deliver this stack to commercial, research, and defense customers under
+          a single software identity called <strong>NatureOS</strong>.
+        </p>
+
+        <p>
+          This page is the canonical, one-stop overview. It is written so an investor can read it
+          end-to-end in fifteen minutes and understand exactly what Mycosoft sells, how the
+          technology is composed, who the customers are, and where the company is in its build.
+          Engineers and partners get the same picture — the rest of the docs site goes deeper into
+          each piece.
+        </p>
+
+        <h2 id="company">The company</h2>
+
+        <h3 id="entities">Legal entities</h3>
+        <p>
+          Mycosoft operates as two entities working in parallel:
+        </p>
+        <ul>
+          <li>
+            <strong>Mycosoft, Inc.</strong> — a Delaware C-Corporation. This is the parent
+            company, the investment vehicle, and the licensor of platform intellectual property.
+          </li>
+          <li>
+            <strong>Mycosoft, LLC</strong> — a California limited liability company and operating
+            subsidiary. This is the federal contracting entity, the manufacturing entity, and the
+            party that signs most field deployment, reseller, and pilot agreements.
+          </li>
+        </ul>
+        <p>
+          Federal credentials are held by Mycosoft, LLC: UEI{" "}
+          <span className="font-mono">YK3ARVKJ77S9</span>, CAGE{" "}
+          <span className="font-mono">9KR60</span>, with an active SAM.gov registration valid
+          through April 2027.
+        </p>
+
+        <h3 id="mission">Mission</h3>
+        <p>
+          Build the substrate that lets biology, sensors, and AI cooperate at planetary scale —
+          starting with fungi, because mycelium is already the world&apos;s most distributed
+          biological network and the most undersampled signal source on Earth. Every Mycosoft
+          product earns its place by feeding, modelling, or acting on that signal.
+        </p>
+
+        <h3 id="how-we-talk">How we talk about what we do</h3>
+        <p>
+          We are deliberate about claims. Mycosoft ships measurable systems — sensors that record
+          bioelectric activity, dashboards that visualise environmental telemetry, agents that
+          execute defined workflows. We do <em>not</em> claim that fungi are language-capable
+          computers, that Wi-Fi sensing gives planetary perception, or that interspecies
+          translation is a solved problem. Research that explores those frontiers is labelled{" "}
+          <em>frontier</em> throughout the documentation; commercial work is labelled{" "}
+          <em>stable</em>.
+        </p>
+
+        <h2 id="stack">The stack at a glance</h2>
+
+        <p>
+          Mycosoft is built in five layers. Each layer is independently usable, but the customer
+          value compounds when they are combined.
+        </p>
+
+        <h3 id="layer-devices">1. Devices — biological and environmental sensing</h3>
+        <p>
+          Field hardware that captures signal from living systems and their environments.
+          Production lineup today:
+        </p>
+        <ul>
+          <li>
+            <strong>Mushroom 1</strong> — the flagship fungal computer interface device; records
+            bioelectric activity from substrate-grown mycelium and forwards it to NatureOS.
+          </li>
+          <li>
+            <strong>Hyphae 1</strong> — a smaller, lower-cost growth and signal node intended for
+            lab benches, classrooms, and citizen-science deployments.
+          </li>
+          <li>
+            <strong>MycoBrain</strong> — the embedded compute board (ESP32-class) that runs the
+            FCI firmware and ships inside Mushroom 1 and Hyphae 1.
+          </li>
+          <li>
+            <strong>MycoNode</strong> — an environmental gateway / edge node that aggregates
+            signal from multiple devices and brokers it to the cloud.
+          </li>
+          <li>
+            <strong>SporeBase</strong> — a spore-sampling and chain-of-custody hardware module
+            used in laboratory and field workflows.
+          </li>
+          <li>
+            <strong>ALARM</strong> — early-warning sensor unit for biological and environmental
+            anomalies.
+          </li>
+          <li>
+            <strong>Agaric</strong> — the developer board / reference hardware for partners
+            building on the FCI firmware stack.
+          </li>
+        </ul>
+        <p>
+          <strong>Draft:</strong> <em>Psathyrella</em>, a partial-build device for specialised
+          field sampling.{" "}
+          <strong>Frontier:</strong> the broader <em>FCI</em> programme — multi-year R&amp;D into
+          higher-bandwidth fungal computer interfaces.
+        </p>
+        <p>
+          See <Link href="/docs/devices">Devices documentation</Link> for technical specs, sensor
+          channels, power profiles, and deployment guides.
+        </p>
+
+        <h3 id="layer-firmware">2. Firmware — FCI</h3>
+        <p>
+          Every Mycosoft device runs <strong>FCI</strong> (Fungal Computer Interface) firmware —
+          an open, source-available firmware stack covering BME688 / BSEC2 environmental sensing,
+          bioelectric sampling, FCI protocol for signal transport, MQTT and HTTP APIs, OTA
+          updates, and on-device safety controls. FCI is the same firmware whether you bought a
+          finished Mushroom 1 or you are building on an Agaric reference board.{" "}
+          <Link href="/docs/fci-firmware">FCI firmware docs →</Link>
+        </p>
+
+        <h3 id="layer-platform">3. Platform — NatureOS</h3>
+        <p>
+          <strong>NatureOS</strong> is the cloud and edge platform that ingests device signal,
+          stores it, models it, and exposes it through dashboards and APIs. NatureOS is composed
+          of several named services that you will see referenced throughout the docs:
+        </p>
+        <ul>
+          <li>
+            <strong>MINDEX</strong> — the indexed data plane. The Postgres-backed store of record
+            for telemetry, specimen records, chain-of-custody, and model outputs.
+          </li>
+          <li>
+            <strong>AI Studio</strong> — model training, evaluation, and deployment surface for
+            internal and partner ML work.
+          </li>
+          <li>
+            <strong>Earth Simulator</strong> — environmental world-model service used for
+            scenario generation, simulation-backed training, and what-if analysis against live
+            telemetry.
+          </li>
+          <li>
+            <strong>CREP</strong> — Compliance, Reporting, and Evidence Pipeline; the audit and
+            chain-of-custody layer for regulated work.
+          </li>
+          <li>
+            <strong>OEI</strong> — Open Environmental Intelligence; the public-data ingestion
+            layer (AIS, ADS-B, satellite, weather, biodiversity records).
+          </li>
+          <li>
+            <strong>Mycorrhizae Protocol</strong> and <strong>HPL</strong> — the inter-device and
+            inter-platform protocols that move signal between edge and cloud.
+          </li>
+        </ul>
+
+        <h3 id="layer-ai">4. AI — MYCA, AVANI, NLM, MAS</h3>
+        <p>
+          The agentic layer. Four named systems, each with a clear role:
+        </p>
+        <ul>
+          <li>
+            <strong>MYCA</strong> — the multi-agent orchestrator. Routes work across specialised
+            agents under a single Task Automation Law that governs delegation, escalation, and
+            human-in-the-loop checkpoints.
+          </li>
+          <li>
+            <strong>MAS</strong> — the Mycosoft Agent Swarm runtime; the deployment-side execution
+            environment that hosts agents in production.
+          </li>
+          <li>
+            <strong>AVANI</strong> — voice and conversational interface across products; the layer
+            customers and operators speak to.
+          </li>
+          <li>
+            <strong>NLM</strong> — a frontier research programme on natural-language-to-signal
+            interfaces. Labelled frontier; not a shipping product.
+          </li>
+        </ul>
+        <p>
+          We are explicit about a separation that matters in the field:{" "}
+          <Link href="/docs/ai/deterministic-vs-stochastic">deterministic vs stochastic AI</Link>.
+          Pipelines that affect physical equipment, regulated workflows, or chain-of-custody
+          records are deterministic by default. LLMs and frontier models are used for reasoning,
+          drafting, and exploration — never as the sole decision-maker for a field action.
+        </p>
+
+        <h3 id="layer-apps">5. Apps — the simulation and lab tools</h3>
+        <p>
+          A library of focused web apps that sit on top of NatureOS for scientists, students, and
+          operators: <em>earth-simulator</em>, <em>alchemy-lab</em>,{" "}
+          <em>compound-sim</em>, <em>digital-twin</em>, <em>genetic-circuit</em>,{" "}
+          <em>growth-analytics</em>, <em>lifecycle-sim</em>, <em>mushroom-sim</em>,{" "}
+          <em>petri-dish-sim</em>, <em>physics-sim</em>, <em>retrosynthesis</em>,{" "}
+          <em>spore-tracker</em>, and <em>symbiosis</em>. Each app is a thin client over the
+          NatureOS APIs.
+        </p>
+
+        <h2 id="who-its-for">Who Mycosoft is for</h2>
+
+        <h3 id="customers">Customers and use cases</h3>
+        <ul>
+          <li>
+            <strong>Defence and government</strong> — environmental intelligence, biosurveillance,
+            chain-of-custody-grade evidence pipelines, autonomous field deployment programmes.
+            Mycosoft, LLC is the federal contracting entity.
+          </li>
+          <li>
+            <strong>Research institutions</strong> — universities, national labs, and
+            biotech/agtech R&amp;D groups using the devices and NatureOS APIs for
+            mycology, soil science, and environmental monitoring.
+          </li>
+          <li>
+            <strong>Commercial operators</strong> — agriculture, food and beverage, indoor
+            cultivation, and industrial fermentation customers using the devices for process
+            monitoring.
+          </li>
+          <li>
+            <strong>Educators and citizen scientists</strong> — schools and individual makers
+            using Hyphae 1 and the open FCI firmware to teach and explore.
+          </li>
+          <li>
+            <strong>Developers and integrators</strong> — partners building on top of the APIs,
+            firmware, and MAS agent runtime.
+          </li>
+        </ul>
+
+        <h3 id="for-investors">If you&apos;re an investor</h3>
+        <p>
+          The short version: Mycosoft is a vertically integrated stack — devices, firmware,
+          platform, AI, and apps — sold into defence, research, and commercial customers.
+          Hardware revenue funds the platform; platform contracts compound the device base.
+          Federal contracting credentials are active and current. For financing materials,
+          structure, and cap-table details, the investor packet is shared under NDA — contact{" "}
+          <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a>.
+        </p>
+
+        <h3 id="for-customers">If you&apos;re a customer</h3>
+        <p>
+          Start with <Link href="/docs/quickstart">Quickstart</Link>. It takes you from
+          &ldquo;I&apos;ve heard of Mycosoft&rdquo; to your first data flowing in fifteen minutes
+          — including which device or API to choose, how to request access, and where the data
+          lands.
+        </p>
+
+        <h3 id="for-developers">If you&apos;re a developer or partner</h3>
+        <p>
+          Read the <Link href="/docs/fci-firmware">FCI firmware</Link>,{" "}
+          <Link href="/docs/api">API</Link>, and <Link href="/docs/mas">MAS</Link> docs. The
+          firmware is source-available; the APIs are documented and versioned; MAS is the
+          deployment runtime if you are building or hosting agents on the platform.
+        </p>
+
+        <h3 id="for-defense">If you&apos;re a defence or government contact</h3>
+        <p>
+          The <Link href="/docs/defense-government">Defence &amp; Government</Link> section
+          covers SAM.gov status, prime/sub teaming, capability statements, and the
+          deployment-sponsor model for regulated field work.
+        </p>
+
+        <h2 id="status">Status, openness, and how to engage</h2>
+
+        <h3 id="status-labels">Status labels you will see in these docs</h3>
+        <ul>
+          <li>
+            <strong>Stable</strong> — shipping today, supported, and covered by the standard
+            terms of service.
+          </li>
+          <li>
+            <strong>Draft</strong> — being built right now; documentation reflects current
+            direction but specifics will change.
+          </li>
+          <li>
+            <strong>Frontier</strong> — multi-year research; no product commitment, no shipping
+            date. Read as ambition, not roadmap.
+          </li>
+          <li>
+            <strong>Coming soon</strong> — the document exists in outline; the page is being
+            written.
+          </li>
+        </ul>
+
+        <h3 id="openness">Open source and source-available</h3>
+        <p>
+          FCI firmware is source-available. Selected platform components and SDKs ship under
+          permissive licences; others are commercial. See{" "}
+          <Link href="/docs/open-source">Open Source</Link> for the full matrix of what is open,
+          what is source-available, and what is commercial.
+        </p>
+
+        <h3 id="terms">Legal</h3>
+        <p>
+          Use of any Mycosoft website, device, platform, agent, or API is governed by the{" "}
+          <Link href="/terms">Mycosoft Terms of Service</Link>. The Terms are the canonical legal
+          document; this overview is informational.
+        </p>
+
+        <h3 id="contact">Contact</h3>
+        <ul>
+          <li>
+            General — <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a>
+          </li>
+          <li>
+            Federal / defence —{" "}
+            <Link href="/docs/defense-government">/docs/defense-government</Link>
+          </li>
+          <li>
+            Engineering — <a href="https://github.com/MycosoftLabs">github.com/MycosoftLabs</a>
+          </li>
+          <li>
+            Public channels —{" "}
+            <a href="https://www.linkedin.com/company/mycosoft">LinkedIn</a>,{" "}
+            <a href="https://x.com/Mycosoft">X</a>,{" "}
+            <a href="https://www.youtube.com/channel/UCUUEOg35426XDmZ9sPXbDYg">YouTube</a>,{" "}
+            <a href="https://www.crunchbase.com/organization/mycosoft">Crunchbase</a>
+          </li>
+        </ul>
+
+        <hr className="my-12" />
+
+        <p className="text-sm text-muted-foreground">
+          Next: <Link href="/docs/quickstart">Quickstart →</Link>{" "}
+          ·{" "}
+          <Link href="/docs/glossary">Glossary →</Link>
+        </p>
+      </article>
+    </DocsLayout>
+  )
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -10,7 +10,7 @@ export default function TermsPage() {
   return (
     <div className="container py-6 md:py-10">
       <div className="max-w-4xl mx-auto px-4 sm:px-6">
-        <article className="prose prose-neutral dark:prose-invert max-w-none prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-12 prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-8 prose-h3:text-xl prose-h3:font-semibold prose-p:leading-relaxed prose-li:leading-relaxed prose-ul:my-4">
+        <article className="prose prose-neutral dark:prose-invert max-w-none prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-16 prose-h2:pt-8 prose-h2:border-t prose-h2:border-border prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-10 prose-h3:text-xl prose-h3:font-semibold prose-p:my-5 prose-p:leading-relaxed prose-li:leading-relaxed prose-li:my-1.5 prose-ul:my-5 prose-ul:pl-6 prose-ol:my-5 prose-ol:pl-6">
           <h1>{`MYCOSOFT TERMS OF SERVICE`}</h1>
           <div className="not-prose my-6 rounded-lg border border-border bg-muted/40 p-4 text-sm">
             <dl className="grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-x-4 gap-y-1">
@@ -48,15 +48,17 @@ export default function TermsPage() {
           <h3 id="sub-1-3">{`1.3 No Use Without Agreement`}</h3>
           <p>{`If you do not agree to these Terms, you may not access, use, deploy, operate, integrate, resell, connect to, receive data from, or otherwise interact with the Services.`}</p>
           <h3 id="sub-1-4">{`1.4 Supplemental Terms`}</h3>
-          <p>{`Certain Services may be subject to additional terms, including order forms, procurement addenda, hardware terms, beta terms, research agreements, data processing agreements, open-source licenses, government contract clauses, reseller agreements, field deployment authorizations, export control notices, and safety documentation. Supplemental terms control`}</p>
-          <p>{`only for the specific Service, transaction, or deployment they cover. These Terms control all other matters.`}</p>
+          <p>{`Certain Services may be subject to additional terms, including order forms, procurement addenda, hardware terms, beta terms, research agreements, data processing agreements, open-source licenses, government contract clauses, reseller agreements, field deployment authorizations, export control notices, and safety documentation. Supplemental terms control only for the specific Service, transaction, or deployment they cover. These Terms control all other matters.`}</p>
           <h3 id="sub-1-5">{`1.5 Hierarchy of Terms`}</h3>
-          <p>{`Unless otherwise expressly stated in a signed writing by an authorized officer of Mycosoft, conflicts are resolved in this order: 1. written enterprise, government, procurement, or master services agreement signed by Mycosoft;`}</p>
-          <p>{`2. signed order form, statement of work, pilot agreement, reseller agreement, or deployment agreement;`}</p>
-          <p>{`3. applicable product-specific supplemental terms;`}</p>
-          <p>{`4. open-source license for specific open-source code only;`}</p>
-          <p>{`5. these Terms;`}</p>
-          <p>{`6. documentation, marketing materials, FAQs, or website statements.`}</p>
+          <p>{`Unless otherwise expressly stated in a signed writing by an authorized officer of Mycosoft, conflicts are resolved in this order:`}</p>
+          <ol>
+            <li>{`written enterprise, government, procurement, or master services agreement signed by Mycosoft;`}</li>
+            <li>{`signed order form, statement of work, pilot agreement, reseller agreement, or deployment agreement;`}</li>
+            <li>{`applicable product-specific supplemental terms;`}</li>
+            <li>{`open-source license for specific open-source code only;`}</li>
+            <li>{`these Terms;`}</li>
+            <li>{`documentation, marketing materials, FAQs, or website statements.`}</li>
+          </ol>
           <h2 id="section-2">{`2. Company Identity; Corporate Structure; Affiliates`}</h2>
           <h3 id="sub-2-1">{`2.1 Mycosoft Entity`}</h3>
           <p>{`“Mycosoft,” “Company,” “we,” “us,” or “our” means Mycosoft, Inc., a Delaware corporation, together with its subsidiaries, affiliates, controlled entities, operating divisions, field deployment programs, labs, research programs, software platforms, autonomous agents, device fleets, contractors, subcontractors, and representatives, as applicable.`}</p>
@@ -149,8 +151,7 @@ export default function TermsPage() {
           <h3 id="sub-8-3">{`8.3 Human Oversight`}</h3>
           <p>{`You must maintain appropriate human oversight for any AI-assisted operation that may affect safety, property, legal rights, privacy, environment, public infrastructure, financial decisions, regulated activities, government decisions, aircraft, vessels, vehicles, robotics, field devices, biological systems, or public alerts.`}</p>
           <h3 id="sub-8-4">{`8.4 Autonomous Workflows`}</h3>
-          <p>{`By using AI Systems, you authorize Mycosoft systems to process inputs, route tasks among agents, call tools, interact with APIs, generate plans, summarize data, recommend actions,`}</p>
-          <p>{`create tickets, modify dashboards, queue commands, communicate status, and perform other automated actions within the permissions you configure or authorize.`}</p>
+          <p>{`By using AI Systems, you authorize Mycosoft systems to process inputs, route tasks among agents, call tools, interact with APIs, generate plans, summarize data, recommend actions, create tickets, modify dashboards, queue commands, communicate status, and perform other automated actions within the permissions you configure or authorize.`}</p>
           <h3 id="sub-8-5">{`8.5 No Fully Autonomous High-Risk Reliance Without Separate Agreement`}</h3>
           <p>{`You may not use AI Systems as the sole basis for high-risk decisions, including life safety, targeting, law enforcement, employment, credit, housing, insurance, medical, legal, military action, public benefits, biometric identification, or rights-impacting decisions, without a separate written agreement and required legal, technical, and human oversight controls.`}</p>
           <h3 id="sub-8-6">{`8.6 AI Identity and Disclosure`}</h3>
@@ -170,8 +171,7 @@ export default function TermsPage() {
           <h3 id="sub-10-1">{`10.1 Device Use`}</h3>
           <p>{`You may use Devices only in accordance with documentation, safety instructions, deployment instructions, applicable law, and any written authorization. You are responsible for site selection, installation, operation, maintenance, inspection, recovery, disposal, and safe use.`}</p>
           <h3 id="sub-10-2">{`10.2 Experimental and Environmental Conditions`}</h3>
-          <p>{`Devices may be exposed to rain, dust, soil, animals, insects, fungi, corrosion, saltwater, UV, temperature extremes, RF interference, GPS degradation, cellular dead zones, satellite delays,`}</p>
-          <p>{`power loss, tampering, vandalism, theft, wildlife interaction, collision, flooding, marine growth, battery degradation, sensor drift, and other environmental conditions. Mycosoft does not guarantee uninterrupted operation.`}</p>
+          <p>{`Devices may be exposed to rain, dust, soil, animals, insects, fungi, corrosion, saltwater, UV, temperature extremes, RF interference, GPS degradation, cellular dead zones, satellite delays, power loss, tampering, vandalism, theft, wildlife interaction, collision, flooding, marine growth, battery degradation, sensor drift, and other environmental conditions. Mycosoft does not guarantee uninterrupted operation.`}</p>
           <h3 id="sub-10-3">{`10.3 No Unauthorized Modifications`}</h3>
           <p>{`You may not modify, disassemble, open, reverse engineer, bypass, tamper with, clone, counterfeit, reflash, jailbreak, patch, unlock, alter, or disable Devices, firmware, secure boot, encryption, tamper switches, telemetry, identity modules, safety systems, or data integrity systems except as expressly authorized.`}</p>
           <h3 id="sub-10-4">{`10.4 Device Recovery`}</h3>
@@ -188,8 +188,7 @@ export default function TermsPage() {
           <h3 id="sub-11-3">{`11.3 BLM and DOI Lands`}</h3>
           <p>{`Use of Devices on lands managed by the Bureau of Land Management, Department of the Interior, or other public agencies must comply with all applicable federal, state, local, tribal, and agency-specific requirements, including rules governing access, surface disturbance, cultural resources, endangered species, reclamation, rights-of-way, mining operations, grazing allotments, range improvements, roads, utilities, environmental review, and public safety.`}</p>
           <h3 id="sub-11-4">{`11.4 Mining Claims`}</h3>
-          <p>{`A mining claim, prospecting right, mineral lease, or related interest does not automatically authorize Device deployment, surface occupancy, environmental sensing, data extraction, digging, drilling, installation, power connection, communications infrastructure, biological`}</p>
-          <p>{`sampling, public access, or long-term placement. Operators must confirm the scope of rights and obtain any required surface-use, occupancy, environmental, reclamation, or agency approvals.`}</p>
+          <p>{`A mining claim, prospecting right, mineral lease, or related interest does not automatically authorize Device deployment, surface occupancy, environmental sensing, data extraction, digging, drilling, installation, power connection, communications infrastructure, biological sampling, public access, or long-term placement. Operators must confirm the scope of rights and obtain any required surface-use, occupancy, environmental, reclamation, or agency approvals.`}</p>
           <h3 id="sub-11-5">{`11.5 Homestead-Derived Property`}</h3>
           <p>{`References to homesteading, homestead-derived title, patents, historic land grants, or rural property rights do not create any new right to deploy Devices. Deployments on such property require permission from the current lawful owner or authorized holder and compliance with all applicable law.`}</p>
           <h3 id="sub-11-6">{`11.6 Grazing Allotments and Range Concepts`}</h3>
@@ -226,8 +225,7 @@ export default function TermsPage() {
           <p>{`Aerial data collection may implicate privacy, surveillance, trespass, nuisance, critical infrastructure, data protection, law enforcement, wildlife, environmental, and public-safety laws. You are responsible for compliance.`}</p>
           <h2 id="section-14">{`14. Maritime, Inland Waters, International Waters, Buoys, Vessels, Aids to Navigation, and Ocean Deployments`}</h2>
           <h3 id="sub-14-1">{`14.1 Maritime Compliance`}</h3>
-          <p>{`All maritime, inland waterway, underwater, buoy, vessel, USV, UUV, hydrophone, mooring, anchor, floating platform, submerged sensor, surface gateway, or coastal Deployment must comply with applicable maritime law, Coast Guard rules, COLREGS, Inland Navigation Rules, port rules, state waters rules, coastal state law, flag state law, environmental law, fisheries law,`}</p>
-          <p>{`marine mammal law, protected area rules, navigation requirements, and local harbor authority requirements.`}</p>
+          <p>{`All maritime, inland waterway, underwater, buoy, vessel, USV, UUV, hydrophone, mooring, anchor, floating platform, submerged sensor, surface gateway, or coastal Deployment must comply with applicable maritime law, Coast Guard rules, COLREGS, Inland Navigation Rules, port rules, state waters rules, coastal state law, flag state law, environmental law, fisheries law, marine mammal law, protected area rules, navigation requirements, and local harbor authority requirements.`}</p>
           <h3 id="sub-14-2">{`14.2 Private Aids to Navigation`}</h3>
           <p>{`No Device may be represented, used, placed, marked, lighted, signaled, or maintained as an aid to navigation unless all required Coast Guard, state, Army Corps, local, port, or other approvals have been obtained.`}</p>
           <h3 id="sub-14-3">{`14.3 Moorings, Anchors, and Fixed Structures`}</h3>
@@ -302,8 +300,7 @@ export default function TermsPage() {
           <h3 id="sub-19-4">{`19.4 California Privacy`}</h3>
           <p>{`For California residents and California-regulated processing, Mycosoft will comply with applicable California privacy laws to the extent they apply. Customers using the Services to process California personal information are responsible for determining whether they are businesses, service providers, contractors, third parties, or other regulated actors and for entering any required data processing terms.`}</p>
           <h3 id="sub-19-5">{`19.5 EU, UK, and International Privacy`}</h3>
-          <p>{`For EU, UK, or other international data, you are responsible for lawful basis, notices, data transfer mechanisms, data processing agreements, data subject rights, automated`}</p>
-          <p>{`decision-making obligations, AI transparency, and other required compliance unless a separate agreement assigns responsibility to Mycosoft.`}</p>
+          <p>{`For EU, UK, or other international data, you are responsible for lawful basis, notices, data transfer mechanisms, data processing agreements, data subject rights, automated decision-making obligations, AI transparency, and other required compliance unless a separate agreement assigns responsibility to Mycosoft.`}</p>
           <h3 id="sub-19-6">{`19.6 Sensitive Locations`}</h3>
           <p>{`You may not use the Services to collect, infer, or publish personal data from sensitive locations, including homes, schools, medical facilities, places of worship, shelters, protests, political gatherings, union activity, protected cultural sites, or other sensitive areas without lawful basis and appropriate safeguards.`}</p>
           <h2 id="section-20">{`20. Acceptable Use Policy`}</h2>
@@ -362,8 +359,7 @@ export default function TermsPage() {
           <h3 id="sub-23-1">{`23.1 Open-Source Components`}</h3>
           <p>{`Some Mycosoft code, libraries, SDKs, protocols, dashboards, examples, integrations, blockchain-facing tools, data-ledger tools, public financial tools, or security-sensitive public interfaces may be released under open-source or source-available licenses.`}</p>
           <h3 id="sub-23-2">{`23.2 Open-Source License Controls`}</h3>
-          <p>{`Open-source components are licensed under their specific repository license. Those licenses govern only the specific code identified as open source and do not grant rights to Mycosoft`}</p>
-          <p>{`proprietary software, firmware, hardware, schematics, device designs, trademarks, patents, trade secrets, or confidential materials.`}</p>
+          <p>{`Open-source components are licensed under their specific repository license. Those licenses govern only the specific code identified as open source and do not grant rights to Mycosoft proprietary software, firmware, hardware, schematics, device designs, trademarks, patents, trade secrets, or confidential materials.`}</p>
           <h3 id="sub-23-3">{`23.3 Security-Driven Open Source`}</h3>
           <p>{`Mycosoft may open source certain public-facing, blockchain-facing, API-facing, or financial-data-facing systems for transparency and security. That does not convert related firmware, hardware, internal APIs, models, schematics, device interiors, manufacturing methods, or backend systems into open-source materials.`}</p>
           <h3 id="sub-23-4">{`23.4 No Implied License`}</h3>

--- a/lib/docs-catalog.ts
+++ b/lib/docs-catalog.ts
@@ -66,21 +66,24 @@ export const DOCS_CATALOG: DocSection[] = [
       {
         title: "What is Mycosoft",
         description: "Company overview, the stack, and who this documentation is for.",
-        status: "coming-soon",
+        href: "/docs/what-is-mycosoft",
+        status: "stable",
         sources: placeholderSources("what-is-mycosoft"),
       },
       {
         title: "Quickstart",
         description:
           "First 15 minutes: pick a device or API, request access, and see your first data flow.",
-        status: "coming-soon",
+        href: "/docs/quickstart",
+        status: "stable",
         sources: placeholderSources("quickstart"),
       },
       {
         title: "Glossary",
         description:
           "Mycology, AI, and federal-contracting terms in one place — written for newcomers.",
-        status: "coming-soon",
+        href: "/docs/glossary",
+        status: "stable",
         sources: placeholderSources("glossary"),
       },
     ],


### PR DESCRIPTION
## Summary

Adds three full-detail Overview docs and applies a typography-only formatting pass to the Terms of Service.

### New docs
- `/docs/what-is-mycosoft` — company + platform overview written for investors, customers, partners, and developers. Covers entities (Mycosoft Inc / Mycosoft LLC), federal credentials (UEI `YK3ARVKJ77S9`, CAGE `9KR60`, SAM through Apr 2027 — **no EIN published**), the 5-layer stack (devices, FCI firmware, NatureOS platform, AI: MYCA/MAS/AVANI/NLM, apps), and audience-routed links into the rest of /docs.
- `/docs/quickstart` — three paths to first signal: device (Mushroom 1 / Hyphae 1 / Agaric flash + pair), API (curl examples against `api.mycosoft.com`), and dashboards (`natureos.mycosoft.com`).
- `/docs/glossary` — five grouped sections (company & products, platform & AI, devices & firmware, mycology & biology, federal contracting) plus the status-label legend.

### TOS formatting pass (`app/terms/page.tsx`)
**No words added, removed, or changed.** HTML structure / typography only:
- Stronger vertical rhythm: `prose-h2:mt-16 pt-8`, top-border dividers between top-level sections, `prose-h3:mt-10`, `prose-p:my-5`, indented `prose-ul/ol:pl-6`.
- Section 1.5 "Hierarchy of Terms" — the split numbered paragraphs converted into a proper `<ol>` (same words).
- Merged 7 mid-sentence paragraph splits into single `<p>` elements (1.4, 8.4, 10.2, 11.4, 14.1, 19.5, 23.2) — same words.

### Catalog
`lib/docs-catalog.ts` — the 3 Overview entries gain `href` fields and flip from `coming-soon` → `stable`.

### Guardrails preserved
- Frontier work (NLM, broader FCI programme) still labelled frontier.
- No claim that fungi are language-capable computers, that Wi-Fi sense gives planetary perception, or that interspecies translation is solved.
- Untouched: `app/devices/**`, `app/natureos/**`, `app/fusarium/**`, `app/apps/**`, `components/footer.tsx`.

### Verification
- esbuild parse of all 4 modified/added files: OK.
- CI will run the full type-check and build.

## Summary by Sourcery

Add three stable overview documentation pages and improve typography and structure of the Terms of Service page.

New Features:
- Introduce a detailed 'What is Mycosoft' overview page describing the company structure, product stack, audiences, and engagement paths.
- Add a 'Quickstart' guide that walks users through three primary onboarding paths: devices, APIs, and dashboards.
- Add a comprehensive 'Glossary' page covering company, platform, device, biological, and federal contracting terminology plus documentation status labels.

Enhancements:
- Update the documentation catalog to link to the new overview pages and mark them as stable instead of coming soon.
- Refine the Terms of Service page layout with improved heading spacing, list semantics, and paragraph grouping for better readability without changing legal text.

Documentation:
- Expand user-facing documentation with high-level company overview, onboarding, and glossary content targeted at investors, customers, partners, and developers.