### PR TITLE
fix(docs): rewrite 3 overview docs with accurate stack (devices, MYCA, AVANI, CREP)

### DIFF
--- a/app/docs/glossary/page.tsx
+++ b/app/docs/glossary/page.tsx
@@ -30,8 +30,8 @@ export default function Page() {
         </div>
 
         <p>
-          One place to look up every term you will hit in the Mycosoft docs. Grouped into five
-          sections — company &amp; products, platform &amp; AI, devices &amp; firmware,
+          One place to look up every term you will hit in the Mycosoft docs. Grouped into six
+          sections — company &amp; products, platform &amp; AI, devices &amp; firmware, protocols,
           mycology &amp; biology, and federal contracting. Cross-references link to the canonical
           documentation for each concept.
         </p>
@@ -46,451 +46,516 @@ export default function Page() {
           <a href="#devices" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
             Devices &amp; firmware
           </a>
+          <a href="#protocols" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
+            Protocols
+          </a>
           <a href="#biology" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
             Mycology &amp; biology
           </a>
           <a href="#federal" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
             Federal contracting
           </a>
-          <a href="#status-labels" className="rounded-md border border-border bg-card px-3 py-2 hover:bg-accent">
-            Status labels
-          </a>
         </div>
 
         <h2 id="company">Company &amp; products</h2>
-
         <dl>
-          <dt><strong>Mycosoft, Inc.</strong></dt>
+          <dt>
+            <strong>Mycosoft</strong>
+          </dt>
           <dd>
-            Delaware C-Corporation. The parent company, investor-of-record, and licensor of
-            platform intellectual property.
+            The biotechnology and software company building the operating layer for biological
+            intelligence. See <Link href="/docs/what-is-mycosoft">What is Mycosoft</Link>.
           </dd>
 
-          <dt><strong>Mycosoft, LLC</strong></dt>
+          <dt>
+            <strong>Mycosoft, Inc.</strong>
+          </dt>
+          <dd>Delaware C-Corporation. Parent company, investment vehicle, IP licensor.</dd>
+
+          <dt>
+            <strong>Mycosoft, LLC</strong>
+          </dt>
           <dd>
-            California limited liability company; operating subsidiary. The federal contracting
-            entity and the party that signs most pilot, reseller, and field-deployment
-            agreements. Holds UEI <span className="font-mono">YK3ARVKJ77S9</span> and CAGE{" "}
-            <span className="font-mono">9KR60</span>.
+            California limited liability company (CA Entity No. 202253910565). Operating subsidiary,
+            federal contracting entity, manufacturing entity. All federal submissions are 100%
+            self-performed.
           </dd>
 
-          <dt><strong>MycoLabs</strong> / <strong>MycosoftLabs</strong></dt>
+          <dt>
+            <strong>NatureOS</strong>
+          </dt>
           <dd>
-            Public engineering presence on GitHub:{" "}
-            <a href="https://github.com/MycosoftLabs">github.com/MycosoftLabs</a>.
+            The single software identity for the Mycosoft platform — cloud and edge services for
+            ingestion, storage, modelling, dashboards, and apps.
           </dd>
 
-          <dt><strong>NatureOS</strong></dt>
+          <dt>
+            <strong>MYCO DAO</strong>
+          </dt>
           <dd>
-            The Mycosoft operating platform. Cloud + edge services that ingest device signal and
-            public environmental data, store it, model it, and expose it through dashboards,
-            APIs, and agentic interfaces.{" "}
-            <Link href="/docs/dashboards">Dashboards →</Link>
+            Tokenised community vehicle on Solana. Raised approximately $500k in 48 hours by selling
+            15% of the MYCO token. Funds community-aligned research and tooling; operating contracts
+            remain with Mycosoft, LLC.
           </dd>
 
-          <dt><strong>Earth Simulator</strong></dt>
+          <dt>
+            <strong>FUSARIUM</strong>
+          </dt>
           <dd>
-            Environmental world-model service inside NatureOS. Used for scenario generation,
-            simulation-backed model training, and what-if analysis against live telemetry.
-          </dd>
-
-          <dt><strong>MINDEX</strong></dt>
-          <dd>
-            The indexed data plane — Postgres-backed store of record for telemetry, specimen
-            records, chain-of-custody, and model outputs.{" "}
-            <Link href="/docs/mindex">MINDEX →</Link>
-          </dd>
-
-          <dt><strong>AI Studio</strong></dt>
-          <dd>
-            Model training, evaluation, and deployment surface for internal and partner ML work.
-          </dd>
-
-          <dt><strong>CREP</strong></dt>
-          <dd>
-            Compliance, Reporting, and Evidence Pipeline. The audit and chain-of-custody layer
-            for regulated work and defence deployments.
-          </dd>
-
-          <dt><strong>OEI</strong></dt>
-          <dd>
-            Open Environmental Intelligence — the public-data ingestion layer covering AIS,
-            ADS-B, satellite imagery, weather, biodiversity records, and other open feeds.
-          </dd>
-
-          <dt><strong>FUSARIUM</strong></dt>
-          <dd>
-            Field intelligence and defence-deployment programme; a named operational stack inside
-            Mycosoft for environmental and biosurveillance use cases.
-          </dd>
-
-          <dt><strong>Mycorrhizae Protocol</strong></dt>
-          <dd>
-            Inter-device protocol for moving signal between Mycosoft devices, edge nodes, and the
-            NatureOS cloud — analogous to how mycorrhizal networks shuttle resources between
-            plants and fungi.
-          </dd>
-
-          <dt><strong>HPL</strong></dt>
-          <dd>
-            Higher-level platform protocol used between NatureOS services and external partner
-            systems.
-          </dd>
-
-          <dt><strong>Apps</strong></dt>
-          <dd>
-            The library of focused web apps on top of NatureOS: <em>earth-simulator</em>,{" "}
-            <em>alchemy-lab</em>, <em>compound-sim</em>, <em>digital-twin</em>,{" "}
-            <em>genetic-circuit</em>, <em>growth-analytics</em>, <em>lifecycle-sim</em>,{" "}
-            <em>mushroom-sim</em>, <em>petri-dish-sim</em>, <em>physics-sim</em>,{" "}
-            <em>retrosynthesis</em>, <em>spore-tracker</em>, and <em>symbiosis</em>.{" "}
-            <Link href="/docs/apps">Apps →</Link>
+            Mycosoft&rsquo;s defence programme name. Subject of the Mycosoft submission against DARPA
+            BAA HR001125S0011. Integrates MycoBrain devices, MYCA agents, and NatureOS into a
+            non-kinetic environmental intelligence stack.
           </dd>
         </dl>
 
         <h2 id="platform">Platform &amp; AI</h2>
-
         <dl>
-          <dt><strong>MYCA</strong></dt>
+          <dt>
+            <strong>MYCA</strong>
+          </dt>
           <dd>
-            Mycosoft&apos;s multi-agent AI orchestrator. Routes work across specialised agents
-            under the <strong>Task Automation Law</strong> that governs delegation, escalation,
-            and human-in-the-loop checkpoints. <Link href="/docs/ai/myca">MYCA →</Link>
+            MYCOSOFT Environmental Super Intelligence. An edge-native multi-agent system
+            orchestrating <strong>over 1,000 specialised agents</strong> across{" "}
+            <strong>14 categories</strong>, governed by a three-tier permission model: <em>Read</em>{" "}
+            (auto-approved), <em>Write</em> (requires approval), and <em>Execute</em> (requires
+            explicit yes). Powered by NVIDIA Nemotron, PersonaPlex, and designed for
+            Blackwell-generation edge GPUs. Open source at{" "}
+            <a href="https://github.com/MycosoftLabs/mycosoft-mas">
+              github.com/MycosoftLabs/mycosoft-mas
+            </a>
+            .
           </dd>
 
-          <dt><strong>MAS</strong></dt>
+          <dt>
+            <strong>MAS</strong>
+          </dt>
           <dd>
-            Mycosoft Agent Swarm runtime. The deployment-side execution environment that hosts
-            agents in production, including resource limits, retries, and observability.{" "}
-            <Link href="/docs/mas">MAS →</Link>
+            Multi-Agent System. The open-source runtime for MYCA agents. The repo name is{" "}
+            <code>mycosoft-mas</code>.
           </dd>
 
-          <dt><strong>AVANI</strong></dt>
+          <dt>
+            <strong>AVANI</strong>
+          </dt>
           <dd>
-            Voice and conversational interface across Mycosoft products. The layer customers and
-            operators speak to. <Link href="/docs/ai/avani">AVANI →</Link>
+            The Live Earth Substrate. A dedicated backend next to MYCA that ingests and harmonises
+            planetary-scale signals — climate, sensor networks, infrastructure telemetry, remote
+            sensing — and serves them to MYCA through privacy-respecting APIs. If MYCA is the hand,
+            AVANI is the palm that grounds every action in real, continuous environmental context.
           </dd>
 
-          <dt><strong>NLM</strong></dt>
+          <dt>
+            <strong>MycaPLEX</strong>
+          </dt>
           <dd>
-            A frontier research programme on natural-language-to-signal interfaces. Labelled
-            frontier; not a shipping product. <Link href="/docs/ai/nlm">NLM →</Link>
+            Full-duplex voice-to-voice and voice-to-agent interface for MYCA. A modified PersonaPlex
+            stack used in operator headsets, vehicles, and conversational dashboards.
           </dd>
 
-          <dt><strong>Task Automation Law</strong></dt>
+          <dt>
+            <strong>NLM</strong>
+          </dt>
           <dd>
-            The governance contract every MYCA-orchestrated agent operates under. Defines what an
-            agent may decide on its own, what it must escalate, what it must log, and where
-            human approval is required.
+            Natural Language Model. Mycosoft&rsquo;s frontier research programme on bioelectric and
+            environmental signal interfaces. Labelled <em>frontier</em>; not a shipping product.
           </dd>
 
-          <dt><strong>Deterministic vs stochastic AI</strong></dt>
+          <dt>
+            <strong>MINDEX</strong>
+          </dt>
           <dd>
-            The decision framework Mycosoft uses for field-deployed systems. Deterministic
-            pipelines (rules, classical algorithms) own anything safety-critical or
-            regulated; stochastic systems (LLMs, frontier models) are used for reasoning,
-            drafting, and exploration — never as the sole decision-maker for a field action.{" "}
-            <Link href="/docs/ai/deterministic-vs-stochastic">Read more →</Link>
+            The indexed data plane. Postgres-backed store of record for telemetry, specimen records,
+            chain-of-custody, and model outputs.
           </dd>
 
-          <dt><strong>Chain-of-custody record</strong></dt>
+          <dt>
+            <strong>AI Studio</strong>
+          </dt>
           <dd>
-            A cryptographically signed log entry that tracks who handled a sample, signal, or
-            artifact and when. CREP produces and stores chain-of-custody records for regulated
-            workflows.
+            Model training, evaluation, and deployment surface for internal and partner ML work.
+            Sits inside NatureOS.
           </dd>
 
-          <dt><strong>Telemetry</strong></dt>
+          <dt>
+            <strong>Earth Simulator</strong>
+          </dt>
           <dd>
-            The continuous stream of measured readings from a device — environmental channels
-            (temperature, humidity, gas), bioelectric channels, and device-health metadata.
+            Environmental world-model service for scenario generation, simulation-backed training,
+            and what-if analysis against live telemetry.
           </dd>
 
-          <dt><strong>Digital twin</strong></dt>
+          <dt>
+            <strong>CREP</strong>
+          </dt>
           <dd>
-            A live, simulation-backed representation of a physical specimen, device, or
-            environment, kept in sync with real telemetry via NatureOS and Earth Simulator.
+            Common Relevant Environmental Picture. The fused, time-aligned operational view of an
+            area of interest — combining device telemetry, public data, and model output into a
+            single shared picture used by operators and partners.
+          </dd>
+
+          <dt>
+            <strong>OEI</strong>
+          </dt>
+          <dd>
+            Open Environmental Intelligence. Public-data ingestion (AIS, ADS-B, satellite, weather,
+            biodiversity).
+          </dd>
+
+          <dt>
+            <strong>Deterministic vs Stochastic AI</strong>
+          </dt>
+          <dd>
+            A hard line Mycosoft draws in production. Any pipeline that affects physical equipment,
+            regulated workflows, or chain-of-custody records is <em>deterministic</em>. Frontier
+            models reason, draft, and explore — they are never the sole decision-maker for a field
+            action.
+          </dd>
+
+          <dt>
+            <strong>Task Automation Law</strong>
+          </dt>
+          <dd>
+            MYCA&rsquo;s governing rule for delegation, escalation, and human-in-the-loop
+            checkpoints. Combined with the three-tier permission model, it defines what an agent may
+            do without sign-off, what requires approval, and what requires an explicit yes.
           </dd>
         </dl>
 
         <h2 id="devices">Devices &amp; firmware</h2>
-
         <dl>
-          <dt><strong>FCI</strong> — Fungal Computer Interface</dt>
+          <dt>
+            <strong>Mushroom 1</strong>
+          </dt>
           <dd>
-            Two meanings: (1) the firmware stack that runs on every Mycosoft device and on
-            partner boards (BME688 / BSEC2 environmental sensing, bioelectric sampling,
-            MQTT/HTTP APIs, OTA updates); and (2) the broader multi-year R&amp;D programme
-            building higher-bandwidth fungal computer interfaces. The firmware is{" "}
-            <em>stable</em>; the broader programme is <em>frontier</em>.{" "}
-            <Link href="/docs/fci-firmware">FCI firmware →</Link>
+            The flagship Mycosoft device. A solar-powered quadruped walker with four articulated
+            carbon-fibre legs, a 2-metre multi-depth soil probe, dual Bosch BME688 environmental
+            sensors, a long-range 915 MHz mesh radio, and ~6 months of battery life with solar
+            recharge. Designed to self-site on uneven terrain.
           </dd>
 
-          <dt><strong>Mushroom 1</strong></dt>
+          <dt>
+            <strong>Hyphae 1</strong>
+          </dt>
           <dd>
-            Flagship Mycosoft device. Substrate-grown mycelium probe that records bioelectric
-            activity and environmental signal, forwarded to NatureOS.
+            An on-ground distributed edge datacenter in a shelter-grade enclosure. Air, light,
+            sound, and gas sensors plus radar, lidar, and radio (including jamming and anti-jamming)
+            capability. Aggregates clusters of Mushroom 1, MycoNode, SporeBase, and Agaric units and
+            runs local compute.
           </dd>
 
-          <dt><strong>Hyphae 1</strong></dt>
+          <dt>
+            <strong>MycoBrain</strong>
+          </dt>
           <dd>
-            Compact, lower-cost growth and signal node for lab benches, classrooms, and
-            citizen-science deployments.
+            The ESP32-S3 edge compute module that ships inside every Mycosoft device. Dual BME688 +
+            BSEC2, runs the firmware stack, processes all sensor inputs locally before they leave
+            the device.
           </dd>
 
-          <dt><strong>MycoBrain</strong></dt>
+          <dt>
+            <strong>MycoNode</strong>
+          </dt>
           <dd>
-            The ESP32-class embedded compute board that runs the FCI firmware inside finished
-            devices.
+            A subsurface bioelectric probe with a 5-mile broadcast range. Hand placement or
+            drone-deployed. Captures fungal and root-zone electrical signal and forwards it through
+            the mesh.
           </dd>
 
-          <dt><strong>MycoNode</strong></dt>
+          <dt>
+            <strong>SporeBase v4</strong>
+          </dt>
           <dd>
-            Environmental gateway / edge node. Aggregates signal from multiple devices and
-            brokers it to the cloud.
+            A bioaerosol collector. A stepper-driven sealed tape cassette captures pollen, spores,
+            fungal, bacterial, and viral particulates in time-indexed 15- to 60-minute segments (up
+            to 2,880 segments over 30 days). Dual ESP32-S3, LoRa, fan-driven sampling, Bosch BME69x
+            gas sensing, solar + battery.
           </dd>
 
-          <dt><strong>SporeBase</strong></dt>
+          <dt>
+            <strong>Agaric</strong>
+          </dt>
           <dd>
-            Spore-sampling and chain-of-custody hardware module used in laboratory and field
-            workflows.
+            A flying sensor hub (drone) in Mini, Standard, and Heavy-Lift variants. Six-point
+            coaxial propulsion, tangential flight control, MAVLink, LoRa mesh, and satellite options
+            for over-the-horizon work.
           </dd>
 
-          <dt><strong>ALARM</strong></dt>
+          <dt>
+            <strong>ALARM</strong>
+          </dt>
           <dd>
-            Early-warning sensor unit for biological and environmental anomalies.
+            An incident signaling device. Dual smoke (ionisation + photoelectric), MOS VOC, PM1.0 /
+            2.5 / 10 particulates, NDIR CO₂ (400–5,000 ppm), BME688 climate, mold warning, ESP32-S3
+            + on-device TinyML for early-warning classification.
           </dd>
 
-          <dt><strong>Agaric</strong></dt>
+          <dt>
+            <strong>MycoDrone</strong>
+          </dt>
           <dd>
-            Reference development board for partners and integrators building on top of FCI
-            firmware.
+            A flying carrier drone that deploys Mushroom 1, MycoNode, or SporeBase to remote terrain
+            and supports mesh extension.
           </dd>
 
-          <dt><strong>Psathyrella</strong> <em className="text-muted-foreground">(draft)</em></dt>
+          <dt>
+            <strong>Psathyrella</strong> <Badge variant="outline">Draft</Badge>
+          </dt>
           <dd>
-            Specialised field-sampling device under partial build; status will move to stable
-            once shipping.
+            A water buoy for undersea cable monitoring, boat and submarine deterrence, cameras, and
+            laser comms. Solar + battery, four turbopropellers. Surface-deployed from USVs, manned
+            vessels, or shore.
           </dd>
 
-          <dt><strong>BME688</strong></dt>
+          <dt>
+            <strong>BME688 / BSEC2</strong>
+          </dt>
           <dd>
-            Bosch four-in-one environmental sensor (temperature, humidity, pressure, VOC / gas
-            resistance) used throughout the Mycosoft device line.
+            Bosch&rsquo;s integrated environmental sensor (temperature, humidity, pressure, gas) and
+            its software library. Used across the Mycosoft device line for atmospheric and VOC
+            sensing.
           </dd>
 
-          <dt><strong>BSEC2</strong></dt>
+          <dt>
+            <strong>ESP32-S3</strong>
+          </dt>
           <dd>
-            Bosch Sensortec Environmental Cluster library, version 2 — the gas-classification and
-            calibration runtime layered on top of BME688.
+            The dual-core Xtensa LX7 microcontroller with Wi-Fi and Bluetooth used as the host
+            silicon for MycoBrain and every shipping Mycosoft device.
           </dd>
 
-          <dt><strong>Bioelectric signal</strong></dt>
+          <dt>
+            <strong>Status LEDs</strong>
+          </dt>
           <dd>
-            Voltage and current measurements taken across or within living tissue — in our case,
-            mycelium. The primary biological channel Mushroom 1 and Hyphae 1 record.
-          </dd>
-
-          <dt><strong>OTA</strong></dt>
-          <dd>
-            Over-the-air firmware update. Mycosoft devices receive signed OTA updates via the
-            NatureOS device-management service.
-          </dd>
-
-          <dt><strong>FCI protocol</strong></dt>
-          <dd>
-            The on-wire and over-network message format that FCI firmware uses to publish
-            samples, sensor frames, and device events.
+            Mycosoft devices use a standard convention: <strong>green</strong> normal operation,{" "}
+            <strong>blue</strong> network connectivity, <strong>red</strong> alert or warning,{" "}
+            <strong>amber</strong> charging.
           </dd>
         </dl>
 
-        <h2 id="biology">Mycology &amp; biology</h2>
-
+        <h2 id="protocols">Protocols</h2>
         <dl>
-          <dt><strong>Mycelium</strong></dt>
+          <dt>
+            <strong>MDP — Mycosoft Data Protocol</strong>
+          </dt>
           <dd>
-            The vegetative, thread-like body of a fungus — a network of fine filaments called
-            hyphae. Mushroom 1 grows mycelium on a controlled substrate and records its
-            electrical and environmental activity.
+            Device-level transport. COBS-framed with CRC-16. Low-overhead, lossy-link tolerant,
+            suitable for radio mesh and serial bus. Moves data between sensors, MycoBrain, and the
+            upstream gateway.
           </dd>
 
-          <dt><strong>Hyphae</strong></dt>
+          <dt>
+            <strong>MMP — Mycosoft Mycorrhizae Protocol</strong>
+          </dt>
           <dd>
-            The individual filaments that make up mycelium. Hyphae 1 takes its name from these.
+            Gateway-to-cloud mesh transport. Handles store-and-forward, prioritisation, and platform
+            attestation between field gateways and NatureOS.
           </dd>
 
-          <dt><strong>Fruiting body</strong></dt>
+          <dt>
+            <strong>HPL — Hypha Programming Language</strong>
+          </dt>
           <dd>
-            The reproductive structure of a fungus — the &ldquo;mushroom&rdquo; in everyday
-            language. Most of the organism&apos;s mass and information lives below it, in the
-            mycelium.
+            A programming language Mycosoft is developing for biological and environmental
+            workflows. See the introduction on{" "}
+            <a href="https://medium.com/@mycosoft.inc/introduction-to-the-hypha-programming-language-hpl-069567239474">
+              Mycosoft Labs on Medium
+            </a>
+            .
           </dd>
 
-          <dt><strong>Substrate</strong></dt>
+          <dt>
+            <strong>OTA</strong>
+          </dt>
+          <dd>Over-the-air firmware updates. All Mycosoft devices support signed OTA.</dd>
+        </dl>
+
+        <h2 id="biology">Mycology &amp; biology</h2>
+        <dl>
+          <dt>
+            <strong>Mycelium</strong>
+          </dt>
           <dd>
-            The growth medium that mycelium colonises — wood chips, grain, agar, controlled
-            blends. Substrate composition directly affects signal quality.
+            The vegetative body of a fungus: a network of fine filaments (hyphae) that grow through
+            soil, wood, and other substrates. The world&rsquo;s most distributed biological network
+            and the substrate Mycosoft devices most frequently sample.
           </dd>
 
-          <dt><strong>Mycorrhiza</strong></dt>
+          <dt>
+            <strong>Hypha (pl. hyphae)</strong>
+          </dt>
+          <dd>A single filament of fungal cells. Many hyphae together form mycelium.</dd>
+
+          <dt>
+            <strong>Substrate</strong>
+          </dt>
           <dd>
-            A symbiotic relationship between fungal mycelium and plant roots. Inspires (and
-            names) the Mycorrhizae Protocol used between Mycosoft devices.
+            The medium fungi grow on or through — soil, wood, agar, grain, straw, sawdust. Mycosoft
+            devices read environmental signal from and around substrate.
           </dd>
 
-          <dt><strong>Spore</strong></dt>
+          <dt>
+            <strong>Spore</strong>
+          </dt>
           <dd>
-            The reproductive unit of a fungus. SporeBase and the spore-tracker app deal with
-            collection, identification, and chain-of-custody for spores.
+            The reproductive unit of a fungus. Captured by SporeBase as part of bioaerosol sampling.
           </dd>
 
-          <dt><strong>Symbiosis</strong></dt>
+          <dt>
+            <strong>Bioaerosol</strong>
+          </dt>
           <dd>
-            A long-term biological interaction between two organisms. The{" "}
-            <em>symbiosis</em> app models and visualises symbiotic systems.
+            Airborne biological particulates — pollen, fungal spores, bacteria, viruses. SporeBase
+            v4 collects these on a time-indexed sealed tape for laboratory analysis.
           </dd>
 
-          <dt><strong>Retrosynthesis</strong></dt>
+          <dt>
+            <strong>Bioelectric signal</strong>
+          </dt>
           <dd>
-            A chemistry planning technique for working backwards from a target molecule to viable
-            precursors. The <em>retrosynthesis</em> app exposes this for compounds of interest
-            in mycology and biotechnology.
+            Electrical activity measured in or near living tissue. MycoNode samples bioelectric
+            activity in the subsurface root and mycelial zone.
           </dd>
 
-          <dt><strong>Bioaerosol</strong></dt>
+          <dt>
+            <strong>FCI — Fungal Computer Interface</strong>
+          </dt>
           <dd>
-            Airborne biological particles — spores, bacteria, fragments. Mycosoft sensor kits
-            include bioaerosol collection in some deployments.
+            A long-running Mycosoft research programme exploring direct interfaces between fungal
+            networks and digital systems. Labelled <em>frontier</em>. See the FCI article on{" "}
+            <a href="https://medium.com/@mycosoft.inc/fungal-computer-interface-fci-c0c444611cc1">
+              Mycosoft Labs on Medium
+            </a>
+            .
           </dd>
         </dl>
 
         <h2 id="federal">Federal contracting</h2>
-
         <dl>
-          <dt><strong>SAM.gov</strong></dt>
+          <dt>
+            <strong>UEI</strong>
+          </dt>
           <dd>
-            The U.S. federal System for Award Management. The required registry for any entity
-            receiving federal contracts, grants, or sub-awards. Mycosoft, LLC&apos;s registration
-            is active through April 2027.
+            Unique Entity Identifier. Replaces the legacy DUNS number. Mycosoft, LLC&apos;s UEI is{" "}
+            <span className="font-mono">YK3ARVKJ77S9</span>.
           </dd>
 
-          <dt><strong>UEI</strong> — Unique Entity Identifier</dt>
+          <dt>
+            <strong>CAGE Code</strong>
+          </dt>
           <dd>
-            The 12-character federal identifier that replaced DUNS in 2022. Mycosoft, LLC&apos;s
-            UEI is <span className="font-mono">YK3ARVKJ77S9</span>.
-          </dd>
-
-          <dt><strong>CAGE code</strong></dt>
-          <dd>
-            Commercial And Government Entity code — a 5-character identifier assigned by the
-            Defense Logistics Agency. Mycosoft, LLC&apos;s CAGE is{" "}
+            Commercial and Government Entity code. Mycosoft, LLC&apos;s CAGE is{" "}
             <span className="font-mono">9KR60</span>.
           </dd>
 
-          <dt><strong>FAR</strong></dt>
+          <dt>
+            <strong>SAM.gov</strong>
+          </dt>
           <dd>
-            Federal Acquisition Regulation — the primary regulation governing how U.S. federal
-            agencies acquire goods and services.
+            The federal System for Award Management. Mycosoft, LLC&apos;s registration is active
+            through April 9, 2027.
           </dd>
 
-          <dt><strong>DFARS</strong></dt>
+          <dt>
+            <strong>NAICS</strong>
+          </dt>
           <dd>
-            Defense Federal Acquisition Regulation Supplement — the DoD-specific supplement to
-            the FAR.
+            North American Industry Classification System. Codes used in federal procurement to
+            describe the type of work being procured.
           </dd>
 
-          <dt><strong>OTA</strong> — Other Transaction Authority</dt>
+          <dt>
+            <strong>DARPA</strong>
+          </dt>
           <dd>
-            A non-traditional contracting authority used by DoD and select agencies to acquire
-            prototypes and research outside the FAR. Not to be confused with over-the-air
-            firmware updates (also abbreviated OTA in the device section above).
+            Defense Advanced Research Projects Agency. Primary federal research customer for the
+            FUSARIUM programme.
           </dd>
 
-          <dt><strong>CSO</strong></dt>
+          <dt>
+            <strong>ITDX</strong>
+          </dt>
           <dd>
-            Commercial Solutions Opening — a competitive acquisition vehicle that lets agencies
-            solicit innovative solutions on shorter timelines.
+            Information Technology Defense Experiment (Army). Mycosoft submitted ITDX 2026 white
+            paper W91RUSI-FCID260001.
           </dd>
 
-          <dt><strong>SBIR / STTR</strong></dt>
+          <dt>
+            <strong>Navy TAC-O</strong>
+          </dt>
           <dd>
-            Small Business Innovation Research / Small Business Technology Transfer — federal
-            R&amp;D funding programmes for small businesses; STTR requires a research-institution
-            partner.
+            Tactical Operations. The U.S. Navy track Mycosoft engages on for undersea monitoring and
+            surface intelligence (Psathyrella).
           </dd>
 
-          <dt><strong>SAFE</strong></dt>
+          <dt>
+            <strong>Black Dart</strong>
+          </dt>
           <dd>
-            Simple Agreement for Future Equity — a startup financing instrument. Used by
-            Mycosoft, Inc. in early-stage rounds. Distinct from federal contracting acronyms.
+            The U.S. military counter-UAS demonstration programme. Mycosoft&rsquo;s non-kinetic EW
+            focus — jamming and anti-jamming, microwave, laser, radar — aligns with Black Dart.
           </dd>
 
-          <dt><strong>Capability statement</strong></dt>
+          <dt>
+            <strong>BAA</strong>
+          </dt>
           <dd>
-            A short, structured document a federal vendor uses to introduce itself to a
-            contracting officer — what it does, NAICS codes, past performance, and key
-            differentiators.
+            Broad Agency Announcement. The standard federal solicitation mechanism for research
+            programmes such as DARPA HR001125S0011 (FUSARIUM).
           </dd>
 
-          <dt><strong>Teaming agreement</strong></dt>
+          <dt>
+            <strong>OTA</strong> <em>(contracting)</em>
+          </dt>
           <dd>
-            A contract between a prime contractor and one or more subcontractors covering how
-            they will jointly pursue and execute a federal opportunity.
+            Other Transaction Authority. A flexible non-FAR-based contracting vehicle the DoD uses
+            for prototyping and research. Distinct from over-the-air firmware updates of the same
+            acronym.
           </dd>
 
-          <dt><strong>Prime contractor / subcontractor</strong></dt>
+          <dt>
+            <strong>CSO</strong>
+          </dt>
           <dd>
-            The prime holds the federal contract directly with the agency; subcontractors hold
-            contracts with the prime. Mycosoft, LLC engages in both roles depending on the
-            programme.
+            Commercial Solutions Opening. A solicitation mechanism used by federal customers to
+            acquire commercial technology rapidly.
           </dd>
 
-          <dt><strong>Deployment Sponsor</strong></dt>
+          <dt>
+            <strong>SBIR / STTR</strong>
+          </dt>
           <dd>
-            Defined in the <Link href="/terms">Mycosoft Terms of Service</Link>: the person or
-            entity responsible for authorising, funding, directing, hosting, purchasing,
-            leasing, permitting, or benefiting from a field deployment.
-          </dd>
-
-          <dt><strong>NAICS code</strong></dt>
-          <dd>
-            North American Industry Classification System code — used by federal procurement to
-            categorise vendors by industry.
-          </dd>
-        </dl>
-
-        <h2 id="status-labels">Status labels used in these docs</h2>
-
-        <dl>
-          <dt><strong>Stable</strong></dt>
-          <dd>
-            Shipping today, supported, and covered by the standard{" "}
-            <Link href="/terms">Terms of Service</Link>.
-          </dd>
-
-          <dt><strong>Draft</strong></dt>
-          <dd>
-            Being built right now; the documentation reflects current direction but specifics
-            will change.
-          </dd>
-
-          <dt><strong>Frontier</strong></dt>
-          <dd>
-            Multi-year research programme. Read as ambition, not roadmap. No product commitment
-            and no shipping date.
-          </dd>
-
-          <dt><strong>Coming soon</strong></dt>
-          <dd>
-            The document exists in outline; the page is being written.
+            Small Business Innovation Research / Small Business Technology Transfer. Federal
+            programmes funding small-business R&amp;D. Sequenced after Mycosoft&rsquo;s primary DARPA
+            and Army engagements.
           </dd>
         </dl>
+
+        <h2 id="status-labels">Status labels in our docs</h2>
+        <ul>
+          <li>
+            <strong>Stable</strong> — shipping today, supported, covered by the standard Terms of
+            Service.
+          </li>
+          <li>
+            <strong>Draft</strong> — being built right now; documentation reflects current direction
+            but specifics will change.
+          </li>
+          <li>
+            <strong>Frontier</strong> — multi-year research; no product commitment, no shipping
+            date. Read as ambition, not roadmap.
+          </li>
+          <li>
+            <strong>Coming soon</strong> — the document exists in outline; the page is being
+            written.
+          </li>
+        </ul>
 
         <hr className="my-12" />
 
         <p className="text-sm text-muted-foreground">
-          Back to: <Link href="/docs/what-is-mycosoft">What is Mycosoft</Link> ·{" "}
-          <Link href="/docs/quickstart">Quickstart</Link>
+          Previous: <Link href="/docs/quickstart">← Quickstart</Link> · See also:{" "}
+          <Link href="/docs/what-is-mycosoft">What is Mycosoft</Link>
         </p>
       </article>
     </DocsLayout>

--- a/app/docs/quickstart/page.tsx
+++ b/app/docs/quickstart/page.tsx
@@ -30,303 +30,316 @@ export default function Page() {
         </div>
 
         <p>
-          This page takes you from zero to your first data flowing through a Mycosoft system in
-          about fifteen minutes. There are three entry paths — pick the one that matches what
-          you have today and what you want to do next. You can come back and follow another path
-          later.
+          This page takes you from zero to your first data flowing through a Mycosoft system in about
+          fifteen minutes. There are four entry paths — pick the one that matches what you have
+          today and what you want to do next. You can come back and follow another path later.
         </p>
 
-        <div className="not-prose my-8 grid gap-4 sm:grid-cols-3">
+        <div className="not-prose my-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <Link
             href="#path-device"
             className="rounded-lg border border-border bg-card p-4 hover:bg-accent transition-colors"
           >
             <div className="text-sm font-semibold text-foreground">Path A — Device</div>
             <p className="mt-1 text-sm text-muted-foreground">
-              You have (or want) a Mushroom 1, Hyphae 1, or Agaric and want signal in a
-              dashboard.
+              You have (or want) a Mushroom 1, Hyphae 1, MycoNode, SporeBase, Agaric, or ALARM and
+              want telemetry in a dashboard.
             </p>
           </Link>
           <Link
-            href="#path-api"
+            href="#path-platform"
             className="rounded-lg border border-border bg-card p-4 hover:bg-accent transition-colors"
           >
-            <div className="text-sm font-semibold text-foreground">Path B — API</div>
+            <div className="text-sm font-semibold text-foreground">Path B — Platform</div>
             <p className="mt-1 text-sm text-muted-foreground">
-              You are a developer and you want to query NatureOS / OEI from your own code.
+              You want NatureOS for dashboards, AI Studio, MINDEX, and the apps without rolling out
+              hardware yet.
             </p>
           </Link>
           <Link
-            href="#path-dashboards"
+            href="#path-agents"
             className="rounded-lg border border-border bg-card p-4 hover:bg-accent transition-colors"
           >
-            <div className="text-sm font-semibold text-foreground">Path C — Dashboards</div>
+            <div className="text-sm font-semibold text-foreground">Path C — MYCA / Agents</div>
             <p className="mt-1 text-sm text-muted-foreground">
-              You want to explore data in NatureOS dashboards without writing code.
+              You want to build on, host, or run agents in the MYCA multi-agent system (MAS).
+            </p>
+          </Link>
+          <Link
+            href="#path-defense"
+            className="rounded-lg border border-border bg-card p-4 hover:bg-accent transition-colors"
+          >
+            <div className="text-sm font-semibold text-foreground">Path D — Defence / Gov</div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              You are a federal customer evaluating Mycosoft for an OTA, BAA, SBIR, or programme of
+              record.
             </p>
           </Link>
         </div>
 
-        <h2 id="before-you-start">Before you start</h2>
+        <h2 id="path-device">Path A — Start with a device</h2>
 
-        <p>You need:</p>
+        <h3 id="device-pick">1. Pick the device that matches your use case</h3>
         <ul>
-          <li>A work email address you can receive mail at.</li>
           <li>
-            For Path A only — physical device hardware (Mushroom 1, Hyphae 1, an Agaric
-            development board, or a partner board running FCI firmware), a USB-C cable, and
-            Wi-Fi access.
+            <strong>Mushroom 1</strong> — solar-powered quadruped walker. 2-metre soil probe, dual
+            BME688 environmental sensors, 915 MHz mesh radio, six-month battery life with solar
+            recharge. For forests, farms, parks, and field sites where you want a mobile, self-sited
+            sensor that can reposition itself.
           </li>
           <li>
-            For Path B only — a computer with{" "}
-            <span className="font-mono">curl</span> or Node.js / Python installed.
+            <strong>Hyphae 1</strong> — distributed edge datacenter. Air, light, sound, gas, radar,
+            lidar, and radio (incl. jamming and anti-jamming) in a shelter-grade enclosure.
+            Aggregates clusters of other Mycosoft devices and runs local compute.
+          </li>
+          <li>
+            <strong>MycoNode</strong> — subsurface bioelectric probe, 5-mile broadcast range. Hand
+            placement or drone-deployed for fungal and root-zone signal.
+          </li>
+          <li>
+            <strong>SporeBase v4</strong> — bioaerosol collector. Time-indexed sealed tape captures
+            pollen, spores, fungal, bacterial, and viral particulates in 15- to 60-minute segments.
+            For air-quality, biosurveillance, and longitudinal studies.
+          </li>
+          <li>
+            <strong>Agaric</strong> — flying sensor hub (Mini / Standard / Heavy-Lift). For aerial
+            survey, mesh extension, and over-the-horizon work.
+          </li>
+          <li>
+            <strong>ALARM</strong> — incident signaling device. Dual smoke (ionisation +
+            photoelectric), VOC, particulates, CO₂, BME688, mold warning, on-device TinyML. For
+            facilities, vehicles, and early-warning deployments.
+          </li>
+          <li>
+            <strong>MycoDrone</strong> — carrier drone that deploys Mushroom 1, MycoNode, or
+            SporeBase to remote terrain.
+          </li>
+          <li>
+            <strong>Psathyrella</strong> <em>(draft)</em> — water buoy with undersea cable
+            monitoring, cameras, laser comms, and turbopropellers. Surface-deployed from USVs,
+            manned vessels, or shore.
           </li>
         </ul>
-
         <p>
-          By using the Services you agree to the <Link href="/terms">Mycosoft Terms of
-          Service</Link>. The Terms apply to every path below.
+          Full spec sheets, dimensions, sensor channels, and power profiles live at{" "}
+          <Link href="/devices">/devices</Link>.
         </p>
 
-        <h2 id="path-device">Path A — From device to first signal</h2>
-
-        <p>Target outcome: your device is paired, online, and streaming readings into NatureOS.</p>
-
-        <h3 id="device-step-1">1. Identify your device</h3>
-        <ul>
-          <li>
-            <strong>Mushroom 1</strong> — flagship; substrate-grown mycelium probe with full FCI
-            firmware. <Link href="/docs/devices">Spec sheet →</Link>
-          </li>
-          <li>
-            <strong>Hyphae 1</strong> — compact growth / signal node; lower-cost classroom and
-            citizen-science deployments.
-          </li>
-          <li>
-            <strong>Agaric</strong> — reference development board for partners and integrators.
-          </li>
-        </ul>
-        <p>
-          Other devices in the lineup (<strong>MycoNode</strong>, <strong>SporeBase</strong>,{" "}
-          <strong>ALARM</strong>, <strong>MycoBrain</strong> board) follow the same flow; consult
-          the device-specific page for any deltas.
-        </p>
-
-        <h3 id="device-step-2">2. Power on and flash (if needed)</h3>
-        <p>
-          Production devices ship with FCI firmware pre-flashed. If you have a development board
-          or want to upgrade:
-        </p>
+        <h3 id="device-order">2. Order or request a unit</h3>
         <ol>
           <li>
-            Install PlatformIO CLI: <span className="font-mono">pip install platformio</span>.
+            Email <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a> with the device, the
+            quantity, the deployment site, and the use case.
           </li>
           <li>
-            Clone the firmware repo:{" "}
-            <span className="font-mono">
-              git clone https://github.com/MycosoftLabs/mycobrain-firmware.git
-            </span>
+            For research or pilot pricing, ask for the <strong>pilot programme</strong>. For
+            classroom and citizen-science, mention <strong>educational pricing</strong>.
           </li>
           <li>
-            Connect the device by USB-C and run <span className="font-mono">pio run -t upload</span>{" "}
-            from the repo root.
-          </li>
-        </ol>
-        <p>
-          Full reference and troubleshooting:{" "}
-          <Link href="/docs/fci-firmware">FCI firmware documentation</Link>.
-        </p>
-
-        <h3 id="device-step-3">3. Join Wi-Fi and pair</h3>
-        <ol>
-          <li>
-            On first boot the device exposes a captive Wi-Fi network named{" "}
-            <span className="font-mono">mycosoft-setup-XXXX</span>.
-          </li>
-          <li>
-            Join it from your phone or laptop. The pairing page opens automatically.
-          </li>
-          <li>
-            Enter your Wi-Fi credentials and the pairing code printed on the device label.
-          </li>
-          <li>
-            When the device boots into normal mode, it registers with NatureOS and appears in
-            your device list.
+            Defence and government customers should follow{" "}
+            <Link href="#path-defense">Path D</Link> instead — federal contracting has its own
+            pathway.
           </li>
         </ol>
 
-        <h3 id="device-step-4">4. See your first signal</h3>
-        <p>
-          Sign in at <a href="https://natureos.mycosoft.com">natureos.mycosoft.com</a> and open
-          the device. Within a minute or two you should see live bioelectric and environmental
-          channels (temperature, humidity, VOC, gas resistance, bioelectric voltage). The
-          dashboard updates in real time and stores history in MINDEX so you can scrub backwards.
-        </p>
-
-        <div className="not-prose my-6 rounded-lg border border-border bg-muted/40 p-4 text-sm">
-          <p className="m-0">
-            <strong>If you don&apos;t have a device yet:</strong> request one at{" "}
-            <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a> with the use case
-            (research, classroom, commercial pilot, defence) and the deployment environment.
-            Allocation is currently order-by-order.
-          </p>
-        </div>
-
-        <h2 id="path-api">Path B — From zero to first API call</h2>
-
-        <p>Target outcome: you have an API key, made a successful authenticated call, and seen real data come back.</p>
-
-        <h3 id="api-step-1">1. Request developer access</h3>
+        <h3 id="device-onboarding">3. Onboard the device</h3>
         <ol>
           <li>
-            Email <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a> with the subject{" "}
-            <strong>API access request</strong> and include your name, organisation, intended use
-            case, and whether you need access to your own device data, the OEI public-data layer,
-            or both.
+            Power on. Mushroom 1, Hyphae 1, MycoNode, SporeBase, and Agaric all run our firmware on
+            ESP32-S3 silicon (MycoBrain) and ship pre-flashed and pre-paired to your NatureOS
+            organisation.
           </li>
           <li>
-            Accept the <Link href="/terms">Terms of Service</Link>.
+            The device joins your local mesh via 915 MHz LoRa and the upstream gateway over Wi-Fi,
+            cellular, or satellite — whichever you provisioned.
           </li>
           <li>
-            You will receive a developer-portal invitation and an initial API key with scoped
-            permissions.
-          </li>
-        </ol>
-
-        <h3 id="api-step-2">2. Make your first call</h3>
-        <p>From a terminal:</p>
-        <pre className="not-prose overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono">
-{`curl -H "Authorization: Bearer YOUR_API_KEY" \\
-     https://api.mycosoft.com/v1/health`}
-        </pre>
-        <p>
-          You should get a JSON <span className="font-mono">200 OK</span> with platform version
-          and your key&apos;s scopes. If you get a 401, your key isn&apos;t active yet — wait a
-          minute and retry; if it persists, contact support.
-        </p>
-
-        <h3 id="api-step-3">3. Query real data</h3>
-        <p>List the devices in your organisation:</p>
-        <pre className="not-prose overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono">
-{`curl -H "Authorization: Bearer YOUR_API_KEY" \\
-     https://api.mycosoft.com/v1/devices`}
-        </pre>
-        <p>Pull the last hour of signal from a device:</p>
-        <pre className="not-prose overflow-x-auto rounded-lg border border-border bg-muted/40 p-4 text-sm font-mono">
-{`curl -H "Authorization: Bearer YOUR_API_KEY" \\
-     "https://api.mycosoft.com/v1/devices/DEVICE_ID/signal?window=1h"`}
-        </pre>
-        <p>
-          Each row is a timestamped reading. The full schema, rate limits, pagination rules, and
-          OEI public-data endpoints (AIS, ADS-B, weather, biodiversity) are documented under{" "}
-          <Link href="/docs/api">API reference</Link>.
-        </p>
-
-        <h3 id="api-step-4">4. Optional — talk to an agent</h3>
-        <p>
-          If your access scope includes the agent runtime, you can send a task to MYCA from your
-          code. See <Link href="/docs/ai/myca">MYCA</Link> for the request shape, agent roles,
-          and the Task Automation Law that governs what an agent will and will not do
-          autonomously.
-        </p>
-
-        <h2 id="path-dashboards">Path C — Explore in NatureOS dashboards</h2>
-
-        <p>Target outcome: you have a NatureOS account and have opened a live dashboard.</p>
-
-        <ol>
-          <li>
-            Go to <a href="https://natureos.mycosoft.com">natureos.mycosoft.com</a> and sign in
-            with the email used in your pilot, order, or partnership.
-          </li>
-          <li>
-            On the home page, open the <strong>Environment</strong> tile to see public-data
-            feeds (OEI), or the <strong>Devices</strong> tile to see live device telemetry, or
-            the <strong>Apps</strong> tile to launch a simulation (mushroom-sim,
-            petri-dish-sim, earth-simulator, and others).
-          </li>
-          <li>
-            Every chart in NatureOS has an <strong>Export</strong> button — CSV or JSON, with the
-            same data your API key can pull.
-          </li>
-        </ol>
-
-        <p>
-          Dashboard catalogue and deep-links live under{" "}
-          <Link href="/docs/dashboards">Dashboards</Link>.
-        </p>
-
-        <h2 id="what-next">What to do next</h2>
-
-        <h3 id="next-developers">If you&apos;re a developer</h3>
-        <ul>
-          <li>
-            <Link href="/docs/api">API reference</Link> — full endpoint list and SDKs.
-          </li>
-          <li>
-            <Link href="/docs/fci-firmware">FCI firmware</Link> — protocol details, MQTT topics,
-            OTA, custom builds.
-          </li>
-          <li>
-            <Link href="/docs/mas">MAS</Link> — running and hosting agents.
-          </li>
-          <li>
-            <Link href="/docs/open-source">Open source</Link> — what is permissively licensed,
-            source-available, or commercial.
-          </li>
-        </ul>
-
-        <h3 id="next-operators">If you&apos;re an operator or scientist</h3>
-        <ul>
-          <li>
-            <Link href="/docs/devices">Devices</Link> — per-device deployment guides.
-          </li>
-          <li>
-            <Link href="/docs/mindex">MINDEX</Link> — how telemetry is stored and queried.
-          </li>
-          <li>
-            <Link href="/docs/dashboards">Dashboards</Link> — building views and exports.
-          </li>
-          <li>
-            <Link href="/docs/apps">Apps</Link> — the simulation and lab tools on top of
+            Telemetry flows over <strong>MDP</strong> (Mycosoft Data Protocol — COBS-framed,
+            CRC-16, device transport) into the upstream gateway, which forwards it over{" "}
+            <strong>MMP</strong> (Mycosoft Mycorrhizae Protocol — gateway-to-cloud mesh) into
             NatureOS.
           </li>
-        </ul>
+          <li>
+            Watch your NatureOS dashboard. First readings typically appear within five minutes of
+            power-on in coverage.
+          </li>
+        </ol>
 
-        <h3 id="next-defense">If you&apos;re a defence or government contact</h3>
+        <p>
+          If anything stalls — no telemetry after 15 minutes — check the device&apos;s status LEDs
+          (green: normal · blue: network · red: alert · amber: charging) and email{" "}
+          <a href="mailto:support@mycosoft.com">support@mycosoft.com</a> with the device serial.
+        </p>
+
+        <h2 id="path-platform">Path B — Start with NatureOS</h2>
+
+        <h3 id="platform-access">1. Request platform access</h3>
+        <p>
+          NatureOS is the cloud and edge platform: dashboards, AI Studio, MINDEX (data plane), Earth
+          Simulator (environmental world model), CREP (Common Relevant Environmental Picture), and
+          the apps. Request a workspace at{" "}
+          <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a> with your team, intended
+          users, and use case.
+        </p>
+
+        <h3 id="platform-data">2. Bring data in</h3>
+        <ol>
+          <li>
+            <strong>Public data first.</strong> OEI (Open Environmental Intelligence) ingests AIS,
+            ADS-B, satellite, weather, and biodiversity feeds out of the box. Turn the channels you
+            need on in your workspace and see the data populate within minutes.
+          </li>
+          <li>
+            <strong>Existing telemetry.</strong> Bring your own CSV, Parquet, or live stream over the
+            NatureOS ingestion API. MINDEX stores the canonical record; AI Studio reads from it.
+          </li>
+          <li>
+            <strong>Mycosoft devices.</strong> If you add devices later (Path A), they appear
+            alongside your imported data without changes to dashboards.
+          </li>
+        </ol>
+
+        <h3 id="platform-first-app">3. Open your first app</h3>
+        <p>
+          Pick one of the focused apps that matches your work — <em>earth-simulator</em>,{" "}
+          <em>spore-tracker</em>, <em>growth-analytics</em>, <em>digital-twin</em>,{" "}
+          <em>petri-dish-sim</em>, <em>retrosynthesis</em>, <em>symbiosis</em>, and so on. Each app
+          is a thin client over the NatureOS APIs, so anything you do there shows up everywhere else
+          in the platform.
+        </p>
+
+        <h2 id="path-agents">Path C — Start with MYCA / agents</h2>
+
+        <p>
+          <strong>MYCA</strong> is the MYCOSOFT Environmental Super Intelligence: an edge-native
+          multi-agent system orchestrating <strong>over 1,000 agents</strong> across{" "}
+          <strong>14 categories</strong>, governed by a three-tier permission model. MYCA is what
+          you build on if you want autonomous workflows running against environmental and biological
+          signal.
+        </p>
+
+        <h3 id="agents-clone">1. Clone the agent runtime</h3>
+        <ol>
+          <li>
+            Clone the open-source MAS repo:{" "}
+            <a href="https://github.com/MycosoftLabs/mycosoft-mas">
+              github.com/MycosoftLabs/mycosoft-mas
+            </a>
+            .
+          </li>
+          <li>
+            Follow the repo&apos;s README to bring up a local MAS instance. You will be running a
+            scoped subset of MYCA against test data.
+          </li>
+          <li>
+            Each agent operates under one of three permission tiers — <em>Read</em>{" "}
+            (auto-approved), <em>Write</em> (requires approval), <em>Execute</em> (requires explicit
+            yes). The permission model is non-negotiable for production deployments.
+          </li>
+        </ol>
+
+        <h3 id="agents-connect">2. Connect to MYCA in production</h3>
+        <ol>
+          <li>
+            For hosted MYCA access, request a workspace at{" "}
+            <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a>.
+          </li>
+          <li>
+            Your local agents connect over the MYCA APIs into the production fleet. AVANI provides
+            the Live Earth Substrate that grounds agent actions in real, continuous planetary
+            context.
+          </li>
+          <li>
+            For voice and conversational interfaces, integrate <strong>MycaPLEX</strong> — our
+            modified PersonaPlex full-duplex voice-to-agent stack.
+          </li>
+        </ol>
+
+        <h3 id="agents-deploy">3. Deploy with discipline</h3>
+        <p>
+          Mycosoft draws a hard line between <em>deterministic</em> and <em>stochastic</em>{" "}
+          pipelines. Any agent action that touches physical equipment, regulated workflows, or
+          chain-of-custody records is deterministic by default — frontier models reason, draft, and
+          explore, but they are never the sole decision-maker for a field action.
+        </p>
+
+        <h2 id="path-defense">Path D — Defence and government</h2>
+
+        <h3 id="defense-credentials">1. Verify our credentials</h3>
         <ul>
           <li>
-            <Link href="/docs/defense-government">Defence &amp; Government</Link> — SAM.gov
-            status (UEI <span className="font-mono">YK3ARVKJ77S9</span>, CAGE{" "}
-            <span className="font-mono">9KR60</span>), capability statements, teaming, and the
-            deployment-sponsor model.
+            UEI: <span className="font-mono">YK3ARVKJ77S9</span>
           </li>
           <li>
-            <Link href="/docs/security">Security</Link> — controls, evidence, and the CREP
-            pipeline.
+            CAGE: <span className="font-mono">9KR60</span>
+          </li>
+          <li>SAM.gov: active through April 9, 2027</li>
+          <li>
+            Contracting entity: <strong>Mycosoft, LLC</strong> (CA Entity No. 202253910565). All
+            federal submissions are 100% self-performed.
           </li>
         </ul>
 
-        <h2 id="getting-help">Getting help</h2>
-
+        <h3 id="defense-fit">2. Confirm programme fit</h3>
+        <p>
+          Mycosoft focuses on <strong>non-kinetic environmental intelligence and electronic
+          warfare</strong> — jamming and anti-jamming, microwave, laser, radar, and software-defined
+          radio — aligned with the U.S. military Black Dart programme. Current priorities:
+        </p>
         <ul>
           <li>
-            General — <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a>
+            <strong>DARPA</strong> and <strong>U.S. Army</strong> first. ITDX 2026 white paper
+            (W91RUSI-FCID260001) submitted; DARPA submission against HR001125S0011 covering the
+            FUSARIUM programme submitted.
           </li>
           <li>
-            Engineering — issues and discussions at{" "}
-            <a href="https://github.com/MycosoftLabs">github.com/MycosoftLabs</a>
+            <strong>USAF</strong> — engagement around MycoDrone as a deployment platform for
+            Mushroom 1, MycoNode, and SporeBase.
           </li>
           <li>
-            Glossary of every term you&apos;ll meet in these docs:{" "}
-            <Link href="/docs/glossary">Glossary</Link>
+            <strong>U.S. Navy</strong> — Tactical Operations (TAC-O) and undersea monitoring via the
+            Psathyrella buoy.
+          </li>
+          <li>
+            <strong>DoD SBIR</strong> — sequenced after the primary programmes.
+          </li>
+        </ul>
+
+        <h3 id="defense-request">3. Request a capability statement and demo</h3>
+        <p>
+          Email <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a> with the agency, the
+          programme, and the contact point. We will provide the capability statement, programme
+          alignment notes, and schedule a CREP and device walkthrough.
+        </p>
+
+        <h2 id="what-next">What to read next</h2>
+        <ul>
+          <li>
+            <Link href="/docs/what-is-mycosoft">What is Mycosoft</Link> — the canonical company and
+            stack overview.
+          </li>
+          <li>
+            <Link href="/docs/glossary">Glossary</Link> — every Mycosoft term in one place: MYCA,
+            AVANI, NLM, MAS, MycaPLEX, CREP, MDP, MMP, every device, and every protocol.
+          </li>
+          <li>
+            <Link href="/devices">/devices</Link> — full specifications page for every shipping
+            device.
+          </li>
+          <li>
+            <Link href="/docs/defense-government">Defence &amp; Government</Link> — federal-only
+            engagement.
+          </li>
+          <li>
+            <a href="https://github.com/MycosoftLabs/mycosoft-mas">mycosoft-mas on GitHub</a> — the
+            open-source MYCA agent runtime.
           </li>
         </ul>
 
         <hr className="my-12" />
 
         <p className="text-sm text-muted-foreground">
-          Back to: <Link href="/docs/what-is-mycosoft">What is Mycosoft</Link> · Next:{" "}
+          Previous: <Link href="/docs/what-is-mycosoft">← What is Mycosoft</Link> · Next:{" "}
           <Link href="/docs/glossary">Glossary →</Link>
         </p>
       </article>

--- a/app/docs/what-is-mycosoft/page.tsx
+++ b/app/docs/what-is-mycosoft/page.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge"
 export const metadata: Metadata = {
   title: "What is Mycosoft",
   description:
-    "Company overview, the full Mycosoft stack, and who this documentation is for — written for investors, customers, partners, and developers.",
+    "Company overview and the full Mycosoft stack — devices, firmware, NatureOS, MYCA, AVANI, and apps. Written for investors, customers, partners, and developers.",
 }
 
 export default function Page() {
@@ -30,202 +30,225 @@ export default function Page() {
         </div>
 
         <p>
-          Mycosoft is a biotechnology and software company building the operating layer for
-          biological intelligence — the systems, devices, and services that let humans observe,
-          model, and act on the living world. We design fungal-aware sensors, train AI models on
-          environmental and biological signal, run autonomous agent platforms for science and
-          operations, and deliver this stack to commercial, research, and defense customers under
-          a single software identity called <strong>NatureOS</strong>.
+          Mycosoft is a biotechnology and software company building the operating layer for biological
+          intelligence — the devices, models, and services that let humans observe, model, and act on
+          the living world. We design environmental sensing hardware, train AI on environmental and
+          biological signal, run a planetary-scale edge intelligence called <strong>MYCA</strong>, and
+          deliver this stack to commercial, research, and defense customers under a single software
+          identity called <strong>NatureOS</strong>.
         </p>
 
         <p>
-          This page is the canonical, one-stop overview. It is written so an investor can read it
-          end-to-end in fifteen minutes and understand exactly what Mycosoft sells, how the
-          technology is composed, who the customers are, and where the company is in its build.
-          Engineers and partners get the same picture — the rest of the docs site goes deeper into
-          each piece.
+          This page is the canonical, one-stop overview. An investor can read it end-to-end in fifteen
+          minutes and understand exactly what Mycosoft sells, how the stack is composed, who the
+          customers are, and where the company is in its build. Engineers and partners get the same
+          picture — the rest of the docs go deeper into each piece.
         </p>
 
         <h2 id="company">The company</h2>
 
         <h3 id="entities">Legal entities</h3>
-        <p>
-          Mycosoft operates as two entities working in parallel:
-        </p>
+        <p>Mycosoft operates as two entities working in parallel:</p>
         <ul>
           <li>
-            <strong>Mycosoft, Inc.</strong> — a Delaware C-Corporation. This is the parent
-            company, the investment vehicle, and the licensor of platform intellectual property.
+            <strong>Mycosoft, Inc.</strong> — a Delaware C-Corporation. Parent company, investment
+            vehicle, and licensor of platform intellectual property.
           </li>
           <li>
-            <strong>Mycosoft, LLC</strong> — a California limited liability company and operating
-            subsidiary. This is the federal contracting entity, the manufacturing entity, and the
-            party that signs most field deployment, reseller, and pilot agreements.
+            <strong>Mycosoft, LLC</strong> — a California limited liability company (CA Entity No.
+            202253910565) and operating subsidiary. This is the federal contracting entity, the
+            manufacturing entity, and the party that signs pilot, deployment, and reseller agreements.
+            All federal submissions are 100% self-performed by Mycosoft, LLC.
           </li>
         </ul>
         <p>
           Federal credentials are held by Mycosoft, LLC: UEI{" "}
           <span className="font-mono">YK3ARVKJ77S9</span>, CAGE{" "}
-          <span className="font-mono">9KR60</span>, with an active SAM.gov registration valid
-          through April 2027.
+          <span className="font-mono">9KR60</span>, with an active SAM.gov registration valid through
+          April 9, 2027.
         </p>
 
         <h3 id="mission">Mission</h3>
         <p>
           Build the substrate that lets biology, sensors, and AI cooperate at planetary scale —
-          starting with fungi, because mycelium is already the world&apos;s most distributed
-          biological network and the most undersampled signal source on Earth. Every Mycosoft
-          product earns its place by feeding, modelling, or acting on that signal.
+          starting with the most distributed and under-sampled signal sources on Earth: soil, air,
+          water, and the fungal networks woven through them. Every Mycosoft product earns its place
+          by feeding, modelling, or acting on that signal.
         </p>
 
         <h3 id="how-we-talk">How we talk about what we do</h3>
         <p>
           We are deliberate about claims. Mycosoft ships measurable systems — sensors that record
-          bioelectric activity, dashboards that visualise environmental telemetry, agents that
+          environmental and bioelectric activity, dashboards that visualise telemetry, agents that
           execute defined workflows. We do <em>not</em> claim that fungi are language-capable
-          computers, that Wi-Fi sensing gives planetary perception, or that interspecies
-          translation is a solved problem. Research that explores those frontiers is labelled{" "}
-          <em>frontier</em> throughout the documentation; commercial work is labelled{" "}
-          <em>stable</em>.
+          computers, that Wi-Fi sensing gives planetary perception, or that interspecies translation
+          is a solved problem. Research that explores those frontiers is labelled <em>frontier</em>{" "}
+          throughout the documentation; commercial work is labelled <em>stable</em>.
         </p>
 
         <h2 id="stack">The stack at a glance</h2>
 
         <p>
-          Mycosoft is built in five layers. Each layer is independently usable, but the customer
-          value compounds when they are combined.
+          Mycosoft is built in five layers. Each layer is independently usable; customer value
+          compounds when they are combined.
         </p>
 
-        <h3 id="layer-devices">1. Devices — biological and environmental sensing</h3>
+        <h3 id="layer-devices">1. Devices — environmental and biological sensing</h3>
         <p>
-          Field hardware that captures signal from living systems and their environments.
-          Production lineup today:
+          Purpose-built field hardware. Each device is a sealed, solar-capable, mesh-networked
+          compute node running our firmware over ESP32-S3 class silicon. Production lineup:
         </p>
         <ul>
           <li>
-            <strong>Mushroom 1</strong> — the flagship fungal computer interface device; records
-            bioelectric activity from substrate-grown mycelium and forwards it to NatureOS.
+            <strong>Mushroom 1</strong> — the flagship. A solar-powered <em>quadruped walker</em>{" "}
+            with four articulated carbon-fibre legs, a 2-metre multi-depth soil probe, dual Bosch
+            BME688 environmental sensors, and a long-range 915 MHz mesh radio. Walks itself to
+            optimal terrain, reads soil and air, and joins the local network. Designed for forests,
+            farms, parks, and remote field sites.
           </li>
           <li>
-            <strong>Hyphae 1</strong> — a smaller, lower-cost growth and signal node intended for
-            lab benches, classrooms, and citizen-science deployments.
+            <strong>Hyphae 1</strong> — an on-ground distributed edge datacenter. Air, light, sound,
+            and gas sensors plus radar, lidar, and radio (including jamming and anti-jamming) in a
+            single shelter-grade enclosure. Aggregates and computes locally for clusters of
+            Mushroom 1, MycoNode, SporeBase, and Agaric units.
           </li>
           <li>
-            <strong>MycoBrain</strong> — the embedded compute board (ESP32-class) that runs the
-            FCI firmware and ships inside Mushroom 1 and Hyphae 1.
+            <strong>MycoBrain</strong> — the ESP32-S3 edge compute module that ships inside every
+            Mycosoft device. Dual BME688 + BSEC2, runs the firmware stack, processes all sensor
+            inputs locally before they leave the device.
           </li>
           <li>
-            <strong>MycoNode</strong> — an environmental gateway / edge node that aggregates
-            signal from multiple devices and brokers it to the cloud.
+            <strong>MycoNode</strong> — a subsurface bioelectric probe with a 5-mile broadcast range.
+            Deployed by hand or dropped from a MycoDrone, it captures fungal and root-zone electrical
+            signal and forwards it through the mesh.
           </li>
           <li>
-            <strong>SporeBase</strong> — a spore-sampling and chain-of-custody hardware module
-            used in laboratory and field workflows.
+            <strong>SporeBase v4</strong> — a bioaerosol collector. A stepper-driven sealed tape
+            cassette captures pollen, spores, fungal, bacterial, and viral particulates in
+            time-indexed 15- to 60-minute segments (up to 2,880 segments over 30 days). Dual ESP32-S3,
+            LoRa, fan-driven sampling, Bosch BME69x gas sensing, solar + battery.
           </li>
           <li>
-            <strong>ALARM</strong> — early-warning sensor unit for biological and environmental
-            anomalies.
+            <strong>Agaric</strong> — a flying sensor hub (drone) available in Mini, Standard, and
+            Heavy-Lift variants. Six-point coaxial propulsion, tangential flight control, MAVLink,
+            LoRa mesh, and satellite options for over-the-horizon work.
           </li>
           <li>
-            <strong>Agaric</strong> — the developer board / reference hardware for partners
-            building on the FCI firmware stack.
+            <strong>ALARM</strong> — an incident signaling device. Dual smoke detection (ionisation +
+            photoelectric), MOS VOC, PM1.0 / 2.5 / 10 particulates, NDIR CO₂ (400–5,000 ppm), BME688
+            climate, mold warning, ESP32-S3 + on-device TinyML for early-warning classification.
+          </li>
+          <li>
+            <strong>MycoDrone</strong> — a flying carrier that deploys Mushroom 1, MycoNode, or
+            SporeBase to remote terrain.
           </li>
         </ul>
         <p>
-          <strong>Draft:</strong> <em>Psathyrella</em>, a partial-build device for specialised
-          field sampling.{" "}
-          <strong>Frontier:</strong> the broader <em>FCI</em> programme — multi-year R&amp;D into
-          higher-bandwidth fungal computer interfaces.
+          <strong>Draft:</strong> <em>Psathyrella</em> — a water buoy for undersea cable monitoring,
+          boat and submarine deterrence, cameras, and laser comms. Surface-deployed from USVs, manned
+          vessels, or shore. Solar + battery, four turbopropellers.
         </p>
         <p>
-          See <Link href="/docs/devices">Devices documentation</Link> for technical specs, sensor
-          channels, power profiles, and deployment guides.
+          See <Link href="/devices">/devices</Link> for the full specifications page.
         </p>
 
-        <h3 id="layer-firmware">2. Firmware — FCI</h3>
+        <h3 id="layer-firmware">2. Firmware and protocols</h3>
         <p>
-          Every Mycosoft device runs <strong>FCI</strong> (Fungal Computer Interface) firmware —
-          an open, source-available firmware stack covering BME688 / BSEC2 environmental sensing,
-          bioelectric sampling, FCI protocol for signal transport, MQTT and HTTP APIs, OTA
-          updates, and on-device safety controls. FCI is the same firmware whether you bought a
-          finished Mushroom 1 or you are building on an Agaric reference board.{" "}
-          <Link href="/docs/fci-firmware">FCI firmware docs →</Link>
+          Every Mycosoft device runs the same firmware stack and speaks two protocols designed for
+          biological and environmental telemetry:
+        </p>
+        <ul>
+          <li>
+            <strong>MDP</strong> — Mycosoft Data Protocol. Device-level transport. COBS-framed with
+            CRC-16. Low-overhead, lossy-link tolerant, suitable for radio mesh and serial bus.
+          </li>
+          <li>
+            <strong>MMP</strong> — Mycosoft Mycorrhizae Protocol. Gateway-to-cloud mesh transport.
+            Handles store-and-forward, prioritisation, and platform attestation.
+          </li>
+        </ul>
+        <p>
+          On-device features include BME688 / BSEC2 environmental processing, bioelectric sampling,
+          OTA updates, signed attestation, and on-device safety controls.
         </p>
 
         <h3 id="layer-platform">3. Platform — NatureOS</h3>
         <p>
-          <strong>NatureOS</strong> is the cloud and edge platform that ingests device signal,
-          stores it, models it, and exposes it through dashboards and APIs. NatureOS is composed
-          of several named services that you will see referenced throughout the docs:
+          <strong>NatureOS</strong> is the cloud and edge platform that ingests device signal, stores
+          it, models it, and exposes it through dashboards and APIs. Named services you will see
+          across the docs:
         </p>
         <ul>
           <li>
-            <strong>MINDEX</strong> — the indexed data plane. The Postgres-backed store of record
-            for telemetry, specimen records, chain-of-custody, and model outputs.
+            <strong>MINDEX</strong> — the indexed data plane. Postgres-backed store of record for
+            telemetry, specimen records, chain-of-custody, and model outputs.
           </li>
           <li>
-            <strong>AI Studio</strong> — model training, evaluation, and deployment surface for
-            internal and partner ML work.
+            <strong>AI Studio</strong> — model training, evaluation, and deployment for internal and
+            partner ML work.
           </li>
           <li>
-            <strong>Earth Simulator</strong> — environmental world-model service used for
-            scenario generation, simulation-backed training, and what-if analysis against live
-            telemetry.
+            <strong>Earth Simulator</strong> — environmental world-model service for scenario
+            generation, simulation-backed training, and what-if analysis against live telemetry.
           </li>
           <li>
-            <strong>CREP</strong> — Compliance, Reporting, and Evidence Pipeline; the audit and
-            chain-of-custody layer for regulated work.
+            <strong>CREP</strong> — Common Relevant Environmental Picture. The fused, time-aligned
+            operational view of an area of interest — combining device telemetry, public data, and
+            model output into a single shared picture used by operators and partners.
           </li>
           <li>
-            <strong>OEI</strong> — Open Environmental Intelligence; the public-data ingestion
-            layer (AIS, ADS-B, satellite, weather, biodiversity records).
-          </li>
-          <li>
-            <strong>Mycorrhizae Protocol</strong> and <strong>HPL</strong> — the inter-device and
-            inter-platform protocols that move signal between edge and cloud.
+            <strong>OEI</strong> — Open Environmental Intelligence. Public-data ingestion (AIS,
+            ADS-B, satellite, weather, biodiversity).
           </li>
         </ul>
 
-        <h3 id="layer-ai">4. AI — MYCA, AVANI, NLM, MAS</h3>
+        <h3 id="layer-ai">4. AI — MYCA, AVANI, NLM</h3>
         <p>
-          The agentic layer. Four named systems, each with a clear role:
+          The intelligence layer is paired: <strong>MYCA</strong> is the hand that acts, <strong>AVANI</strong>{" "}
+          is the palm that senses.
         </p>
         <ul>
           <li>
-            <strong>MYCA</strong> — the multi-agent orchestrator. Routes work across specialised
-            agents under a single Task Automation Law that governs delegation, escalation, and
-            human-in-the-loop checkpoints.
+            <strong>MYCA</strong> — the MYCOSOFT Environmental Super Intelligence. An edge-native
+            multi-agent system orchestrating <strong>over 1,000 specialised agents</strong> across{" "}
+            <strong>14 categories</strong>, governed by a three-tier permission model: <em>Read</em>{" "}
+            (auto-approved), <em>Write</em> (requires approval), and <em>Execute</em> (requires
+            explicit yes). Powered by NVIDIA Nemotron foundation models and PersonaPlex, designed for
+            Blackwell-generation edge GPUs. Self-trains from NLM, MDP, MMP, and open-source models.
+            Repo: <a href="https://github.com/MycosoftLabs/mycosoft-mas">github.com/MycosoftLabs/mycosoft-mas</a>.
           </li>
           <li>
-            <strong>MAS</strong> — the Mycosoft Agent Swarm runtime; the deployment-side execution
-            environment that hosts agents in production.
+            <strong>AVANI</strong> — the Live Earth Substrate. A dedicated backend next to MYCA that
+            ingests and harmonises planetary-scale signals — climate, sensor networks, infrastructure
+            telemetry, remote sensing — and serves them to MYCA through privacy-respecting APIs so
+            agents always act with environmental and societal context.
           </li>
           <li>
-            <strong>AVANI</strong> — voice and conversational interface across products; the layer
-            customers and operators speak to.
+            <strong>MycaPLEX</strong> — full-duplex voice-to-voice and voice-to-agent interface for
+            MYCA. A modified PersonaPlex stack that lets operators converse with agents naturally,
+            including on the field, in vehicles, and through hardware headsets.
           </li>
           <li>
-            <strong>NLM</strong> — a frontier research programme on natural-language-to-signal
-            interfaces. Labelled frontier; not a shipping product.
+            <strong>NLM</strong> — Natural Language Model. Mycosoft&rsquo;s frontier research
+            programme on bioelectric and environmental signal interfaces. Labelled <em>frontier</em>;
+            not a shipping product.
           </li>
         </ul>
         <p>
-          We are explicit about a separation that matters in the field:{" "}
-          <Link href="/docs/ai/deterministic-vs-stochastic">deterministic vs stochastic AI</Link>.
-          Pipelines that affect physical equipment, regulated workflows, or chain-of-custody
-          records are deterministic by default. LLMs and frontier models are used for reasoning,
-          drafting, and exploration — never as the sole decision-maker for a field action.
+          We are explicit about a separation that matters in the field: pipelines that affect
+          physical equipment, regulated workflows, or chain-of-custody records are{" "}
+          <em>deterministic</em> by default. Frontier models reason, draft, and explore — they are
+          never the sole decision-maker for a field action.
         </p>
 
-        <h3 id="layer-apps">5. Apps — the simulation and lab tools</h3>
+        <h3 id="layer-apps">5. Apps — simulation and lab tools</h3>
         <p>
-          A library of focused web apps that sit on top of NatureOS for scientists, students, and
-          operators: <em>earth-simulator</em>, <em>alchemy-lab</em>,{" "}
-          <em>compound-sim</em>, <em>digital-twin</em>, <em>genetic-circuit</em>,{" "}
-          <em>growth-analytics</em>, <em>lifecycle-sim</em>, <em>mushroom-sim</em>,{" "}
-          <em>petri-dish-sim</em>, <em>physics-sim</em>, <em>retrosynthesis</em>,{" "}
-          <em>spore-tracker</em>, and <em>symbiosis</em>. Each app is a thin client over the
-          NatureOS APIs.
+          Focused web apps that sit on top of NatureOS for scientists, students, and operators:{" "}
+          <em>earth-simulator</em>, <em>alchemy-lab</em>, <em>compound-sim</em>, <em>digital-twin</em>,{" "}
+          <em>genetic-circuit</em>, <em>growth-analytics</em>, <em>lifecycle-sim</em>,{" "}
+          <em>mushroom-sim</em>, <em>petri-dish-sim</em>, <em>physics-sim</em>, <em>retrosynthesis</em>,{" "}
+          <em>spore-tracker</em>, and <em>symbiosis</em>. Each app is a thin client over the NatureOS
+          APIs.
         </p>
 
         <h2 id="who-its-for">Who Mycosoft is for</h2>
@@ -233,61 +256,80 @@ export default function Page() {
         <h3 id="customers">Customers and use cases</h3>
         <ul>
           <li>
-            <strong>Defence and government</strong> — environmental intelligence, biosurveillance,
-            chain-of-custody-grade evidence pipelines, autonomous field deployment programmes.
-            Mycosoft, LLC is the federal contracting entity.
+            <strong>Defence and government</strong> — non-kinetic environmental intelligence,
+            biosurveillance, common relevant environmental picture (CREP) generation,
+            chain-of-custody evidence pipelines, and autonomous field-deployment programmes. Mycosoft
+            focuses on non-kinetic electronic warfare capabilities — jamming and anti-jamming,
+            microwave, laser, radar — aligned with the U.S. military Black Dart programme. Mycosoft,
+            LLC is the federal contracting entity; all submissions are self-performed.
           </li>
           <li>
-            <strong>Research institutions</strong> — universities, national labs, and
-            biotech/agtech R&amp;D groups using the devices and NatureOS APIs for
-            mycology, soil science, and environmental monitoring.
+            <strong>Research institutions</strong> — universities, national labs, and biotech / agtech
+            R&amp;D groups using the devices and NatureOS APIs for mycology, soil science, and
+            environmental monitoring.
           </li>
           <li>
-            <strong>Commercial operators</strong> — agriculture, food and beverage, indoor
-            cultivation, and industrial fermentation customers using the devices for process
-            monitoring.
+            <strong>Commercial operators</strong> — agriculture, food and beverage, indoor cultivation,
+            and industrial fermentation customers using the devices for process monitoring.
           </li>
           <li>
-            <strong>Educators and citizen scientists</strong> — schools and individual makers
-            using Hyphae 1 and the open FCI firmware to teach and explore.
+            <strong>Educators and citizen scientists</strong> — schools and individual makers using
+            the devices and firmware to teach and explore.
           </li>
           <li>
-            <strong>Developers and integrators</strong> — partners building on top of the APIs,
-            firmware, and MAS agent runtime.
+            <strong>Developers and integrators</strong> — partners building on the APIs, firmware,
+            and the MYCA multi-agent runtime.
           </li>
         </ul>
 
+        <h3 id="federal-programs">Federal program focus</h3>
+        <p>
+          Mycosoft is actively pursuing DARPA and U.S. Army programmes first, with USAF engagement
+          around MycoDrone and U.S. Navy engagement on Tactical Operations (TAC-O) and undersea
+          monitoring. Notable submissions: Army <em>ITDX 2026</em> white paper
+          (W91RUSI-FCID260001) and a DARPA submission against HR001125S0011 covering the FUSARIUM
+          programme. DoD SBIR engagement is sequenced after these primary programmes.
+        </p>
+
+        <h3 id="capital">Capital and community</h3>
+        <p>
+          Mycosoft maintains two capital tracks: traditional equity through Mycosoft, Inc., and a
+          tokenised community track through <strong>MYCO DAO</strong>. The DAO raised approximately
+          $500,000 in its first 48 hours by selling 15% of the MYCO token on Solana, funding
+          community-aligned research and tooling. Operating contracts and federal programmes continue
+          to be executed through Mycosoft, LLC.
+        </p>
+
         <h3 id="for-investors">If you&apos;re an investor</h3>
         <p>
-          The short version: Mycosoft is a vertically integrated stack — devices, firmware,
-          platform, AI, and apps — sold into defence, research, and commercial customers.
-          Hardware revenue funds the platform; platform contracts compound the device base.
-          Federal contracting credentials are active and current. For financing materials,
-          structure, and cap-table details, the investor packet is shared under NDA — contact{" "}
+          The short version: Mycosoft is a vertically integrated stack — devices, firmware, platform,
+          AI, and apps — sold into defence, research, and commercial customers. Hardware revenue
+          funds the platform; platform contracts compound the device base. Federal contracting
+          credentials are active. For financing materials, structure, and cap-table details, the
+          investor packet is shared under NDA — contact{" "}
           <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a>.
         </p>
 
         <h3 id="for-customers">If you&apos;re a customer</h3>
         <p>
           Start with <Link href="/docs/quickstart">Quickstart</Link>. It takes you from
-          &ldquo;I&apos;ve heard of Mycosoft&rdquo; to your first data flowing in fifteen minutes
-          — including which device or API to choose, how to request access, and where the data
-          lands.
+          &ldquo;I&apos;ve heard of Mycosoft&rdquo; to your first data flowing in fifteen minutes —
+          which device or API to choose, how to request access, and where the data lands.
         </p>
 
         <h3 id="for-developers">If you&apos;re a developer or partner</h3>
         <p>
-          Read the <Link href="/docs/fci-firmware">FCI firmware</Link>,{" "}
-          <Link href="/docs/api">API</Link>, and <Link href="/docs/mas">MAS</Link> docs. The
-          firmware is source-available; the APIs are documented and versioned; MAS is the
-          deployment runtime if you are building or hosting agents on the platform.
+          The agent runtime is open-source at{" "}
+          <a href="https://github.com/MycosoftLabs/mycosoft-mas">github.com/MycosoftLabs/mycosoft-mas</a>.
+          API and firmware references are linked from <Link href="/docs">/docs</Link>; protocol
+          specifications for MDP and MMP are part of the same documentation set.
         </p>
 
         <h3 id="for-defense">If you&apos;re a defence or government contact</h3>
         <p>
-          The <Link href="/docs/defense-government">Defence &amp; Government</Link> section
-          covers SAM.gov status, prime/sub teaming, capability statements, and the
-          deployment-sponsor model for regulated field work.
+          See <Link href="/docs/defense-government">Defence &amp; Government</Link> for SAM.gov
+          credentials, capability statement, programme alignment (DARPA, Army ITDX, USAF, Navy TAC-O,
+          Black Dart), and the deployment-sponsor model for regulated field work.
         </p>
 
         <h2 id="status">Status, openness, and how to engage</h2>
@@ -295,29 +337,27 @@ export default function Page() {
         <h3 id="status-labels">Status labels you will see in these docs</h3>
         <ul>
           <li>
-            <strong>Stable</strong> — shipping today, supported, and covered by the standard
-            terms of service.
+            <strong>Stable</strong> — shipping today, supported, covered by the standard Terms of
+            Service.
           </li>
           <li>
-            <strong>Draft</strong> — being built right now; documentation reflects current
-            direction but specifics will change.
+            <strong>Draft</strong> — being built right now; documentation reflects current direction
+            but specifics will change.
           </li>
           <li>
-            <strong>Frontier</strong> — multi-year research; no product commitment, no shipping
-            date. Read as ambition, not roadmap.
+            <strong>Frontier</strong> — multi-year research; no product commitment, no shipping date.
+            Read as ambition, not roadmap.
           </li>
           <li>
-            <strong>Coming soon</strong> — the document exists in outline; the page is being
-            written.
+            <strong>Coming soon</strong> — the document exists in outline; the page is being written.
           </li>
         </ul>
 
         <h3 id="openness">Open source and source-available</h3>
         <p>
-          FCI firmware is source-available. Selected platform components and SDKs ship under
-          permissive licences; others are commercial. See{" "}
-          <Link href="/docs/open-source">Open Source</Link> for the full matrix of what is open,
-          what is source-available, and what is commercial.
+          The MYCA multi-agent system (MAS) is open source. Firmware is source-available. Selected
+          platform components and SDKs ship under permissive licences; others are commercial. See{" "}
+          <Link href="/docs/open-source">Open Source</Link> for the full matrix.
         </p>
 
         <h3 id="terms">Legal</h3>
@@ -340,6 +380,10 @@ export default function Page() {
             Engineering — <a href="https://github.com/MycosoftLabs">github.com/MycosoftLabs</a>
           </li>
           <li>
+            Research writing —{" "}
+            <a href="https://medium.com/@mycosoft.inc">medium.com/@mycosoft.inc</a>
+          </li>
+          <li>
             Public channels —{" "}
             <a href="https://www.linkedin.com/company/mycosoft">LinkedIn</a>,{" "}
             <a href="https://x.com/Mycosoft">X</a>,{" "}
@@ -351,8 +395,7 @@ export default function Page() {
         <hr className="my-12" />
 
         <p className="text-sm text-muted-foreground">
-          Next: <Link href="/docs/quickstart">Quickstart →</Link>{" "}
-          ·{" "}
+          Next: <Link href="/docs/quickstart">Quickstart →</Link> ·{" "}
           <Link href="/docs/glossary">Glossary →</Link>
         </p>
       </article>


### PR DESCRIPTION
Follow-up to #158. The overview docs that shipped used loose, sometimes incorrect descriptions of the device line, MYCA's scope, AVANI's role, and several acronyms. This PR grounds every claim in the canonical sources we already publish on the marketing site and in our internal product memos.

## Why this PR

PR #158 got the structure and TOS formatting right, but the doc bodies referred to:

- Mushroom 1 as an FCI bioelectric device (it is a solar-powered **quadruped walker** with a 2m soil probe and dual BME688)
- Hyphae 1 as a "classroom node" (it is an **on-ground distributed edge datacenter** with radar / lidar / radio incl. jamming and anti-jamming)
- MycoNode as a "gateway / edge node" (it is a **subsurface bioelectric probe** with 5-mile broadcast)
- Agaric as a "developer board" (it is the **flying sensor hub / drone** — Mini / Standard / Heavy-Lift)
- AVANI as a "voice and conversational interface" (the voice layer is **MycaPLEX**; AVANI is the **Live Earth Substrate**)
- CREP as "Compliance, Reporting, and Evidence Pipeline" (it is **Common Relevant Environmental Picture**)
- MYCA's scope as a generic "multi-agent orchestrator" (it is the **MYCOSOFT Environmental Super Intelligence** — 1,000+ agents across 14 categories with a three-tier permission model)

## What changes

### `/docs/what-is-mycosoft`
- Devices section rewritten against `components/devices/*-details.tsx`.
- MYCA section aligned with `/myca` public framing.
- AVANI section aligned with `/ai/avani` — Live Earth Substrate, yin-yang with MYCA.
- Added MycaPLEX, MycoDrone, Psathyrella (draft).
- New "Capital and community" section calling out MYCO DAO and the Solana raise.
- New "Federal program focus" section: DARPA HR001125S0011 (FUSARIUM), Army ITDX 2026 (W91RUSI-FCID260001), USAF MycoDrone, Navy TAC-O.

### `/docs/quickstart`
- Added Path D (Defence / Government).
- All device descriptions corrected against the device detail components.
- MDP and MMP introduced inline.
- Path C points at `mycosoft-mas` and explains the three-tier permission model and MycaPLEX.

### `/docs/glossary`
- New "Protocols" section: MDP, MMP, HPL, OTA.
- CREP definition fixed.
- AVANI redefined; MycaPLEX added; NLM clarified as frontier.
- Every device redefined to match its detail page.
- Federal contracting: added ITDX, Navy TAC-O, Black Dart, BAA, CSO; OTA disambiguated.

## What stays out

- EIN is deliberately not published anywhere.
- No device pages, NatureOS pages, or FUSARIUM pages are touched.

## Follow-up (not in this PR)
- Branded `<DocPageShell>` template with per-class accents.
- `/docs/research` section ingesting the 5 Mycosoft Labs Medium articles.

## Summary by Sourcery

Clarify and expand core documentation explaining what Mycosoft is, how the stack is composed (devices, firmware/protocols, NatureOS, MYCA/AVANI, apps), and how different audiences should get started.

New Features:
- Introduce a dedicated Quickstart path for defence and government customers and restructure the existing quickstart paths around devices, platform, and MYCA agents.
- Add a new Protocols section to the glossary defining MDP, MMP, HPL, and OTA, and link it from the navigation.
- Document MYCO DAO and capital/community structure in the main company overview.

Enhancements:
- Rewrite the company, platform, AI, and device descriptions in the What is Mycosoft overview to align with current product reality, including accurate roles for MYCA, AVANI, MycaPLEX, CREP, and each device in the lineup.
- Refresh glossary entries for company entities, devices, AI systems, federal terms, and status labels to match canonical naming, scopes, and current federal programme focus.
- Reorganise the Quickstart page to be more use-case driven, with clearer device selection guidance, on-boarding flow, and entry points for NatureOS and the MYCA agent runtime.
- Tighten internal navigation between What is Mycosoft, Quickstart, and Glossary to reflect the new structure and recommended reading order.

Documentation:
- Update user-facing docs to accurately describe Mushroom 1, Hyphae 1, MycoNode, SporeBase, Agaric, ALARM, MycoDrone, Psathyrella, and MycoBrain, as well as MYCA, AVANI, MycaPLEX, NLM, and CREP.
- Expand documentation of federal programmes and contracting context (DARPA HR001125S0011 FUSARIUM, Army ITDX 2026, USAF MycoDrone, Navy TAC-O, Black Dart, SBIR/STTR) across the overview and glossary pages.