### PR TITLE
fix(tos,docs): restore section spacing — prose-* modifiers do nothing without @tailwindcss/typography

### DIFF
--- a/app/docs/glossary/page.tsx
+++ b/app/docs/glossary/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <DocsLayout>
-      <article className="prose prose-neutral dark:prose-invert max-w-3xl prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-14 prose-h2:pt-6 prose-h2:border-t prose-h2:border-border prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-10 prose-h3:text-xl prose-h3:font-semibold prose-p:leading-relaxed prose-li:leading-relaxed prose-ul:my-4 prose-dl:my-6">
+      <article className="max-w-3xl text-foreground [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mb-6 [&_h1]:scroll-mt-24 [&_h2]:mt-14 [&_h2]:pt-6 [&_h2]:mb-4 [&_h2]:border-t [&_h2]:border-border [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:scroll-mt-24 [&_h3]:mt-10 [&_h3]:mb-3 [&_h3]:text-xl [&_h3]:font-semibold [&_h3]:scroll-mt-24 [&_p]:my-4 [&_p]:leading-relaxed [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal [&_ol]:space-y-2 [&_li]:leading-relaxed [&_dl]:my-6 [&_dt]:mt-5 [&_dt]:font-medium [&_dd]:mb-3 [&_dd]:ml-4 [&_dd]:text-muted-foreground [&_dd]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80 [&_strong]:font-semibold [&_strong]:text-foreground [&_em]:italic [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:bg-muted [&_code]:text-sm [&_hr]:my-12 [&_hr]:border-border">
         <div className="not-prose mb-4 flex flex-wrap items-center gap-2 text-sm">
           <Link href="/docs" className="text-muted-foreground hover:text-foreground">
             Documentation

--- a/app/docs/quickstart/page.tsx
+++ b/app/docs/quickstart/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <DocsLayout>
-      <article className="prose prose-neutral dark:prose-invert max-w-3xl prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-14 prose-h2:pt-6 prose-h2:border-t prose-h2:border-border prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-10 prose-h3:text-xl prose-h3:font-semibold prose-p:leading-relaxed prose-li:leading-relaxed prose-ul:my-4 prose-ol:my-4">
+      <article className="max-w-3xl text-foreground [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mb-6 [&_h1]:scroll-mt-24 [&_h2]:mt-14 [&_h2]:pt-6 [&_h2]:mb-4 [&_h2]:border-t [&_h2]:border-border [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:scroll-mt-24 [&_h3]:mt-10 [&_h3]:mb-3 [&_h3]:text-xl [&_h3]:font-semibold [&_h3]:scroll-mt-24 [&_p]:my-4 [&_p]:leading-relaxed [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal [&_ol]:space-y-2 [&_li]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80 [&_strong]:font-semibold [&_strong]:text-foreground [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:bg-muted [&_code]:text-sm [&_hr]:my-12 [&_hr]:border-border">
         <div className="not-prose mb-4 flex flex-wrap items-center gap-2 text-sm">
           <Link href="/docs" className="text-muted-foreground hover:text-foreground">
             Documentation

--- a/app/docs/what-is-mycosoft/page.tsx
+++ b/app/docs/what-is-mycosoft/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <DocsLayout>
-      <article className="prose prose-neutral dark:prose-invert max-w-3xl prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-14 prose-h2:pt-6 prose-h2:border-t prose-h2:border-border prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-10 prose-h3:text-xl prose-h3:font-semibold prose-p:leading-relaxed prose-li:leading-relaxed prose-ul:my-4">
+      <article className="max-w-3xl text-foreground [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mb-6 [&_h1]:scroll-mt-24 [&_h2]:mt-14 [&_h2]:pt-6 [&_h2]:mb-4 [&_h2]:border-t [&_h2]:border-border [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:scroll-mt-24 [&_h3]:mt-10 [&_h3]:mb-3 [&_h3]:text-xl [&_h3]:font-semibold [&_h3]:scroll-mt-24 [&_p]:my-4 [&_p]:leading-relaxed [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal [&_ol]:space-y-2 [&_li]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80 [&_strong]:font-semibold [&_strong]:text-foreground [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:bg-muted [&_code]:text-sm [&_hr]:my-12 [&_hr]:border-border">
         <div className="not-prose mb-4 flex flex-wrap items-center gap-2 text-sm">
           <Link href="/docs" className="text-muted-foreground hover:text-foreground">
             Documentation

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -10,7 +10,7 @@ export default function TermsPage() {
   return (
     <div className="container py-6 md:py-10">
       <div className="max-w-4xl mx-auto px-4 sm:px-6">
-        <article className="prose prose-neutral dark:prose-invert max-w-none prose-headings:scroll-mt-24 prose-h1:text-4xl prose-h2:mt-16 prose-h2:pt-8 prose-h2:border-t prose-h2:border-border prose-h2:text-2xl prose-h2:font-bold prose-h3:mt-10 prose-h3:text-xl prose-h3:font-semibold prose-p:my-5 prose-p:leading-relaxed prose-li:leading-relaxed prose-li:my-1.5 prose-ul:my-5 prose-ul:pl-6 prose-ol:my-5 prose-ol:pl-6">
+        <article className="max-w-none text-foreground [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mb-8 [&_h1]:scroll-mt-24 [&_h2]:mt-16 [&_h2]:pt-8 [&_h2]:mb-4 [&_h2]:border-t [&_h2]:border-border [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:scroll-mt-24 [&_h3]:mt-10 [&_h3]:mb-3 [&_h3]:text-xl [&_h3]:font-semibold [&_h3]:scroll-mt-24 [&_p]:my-5 [&_p]:leading-relaxed [&_p]:text-base [&_ul]:my-5 [&_ul]:pl-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ol]:my-5 [&_ol]:pl-6 [&_ol]:list-decimal [&_ol]:space-y-2 [&_li]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80 [&_strong]:font-semibold [&_strong]:text-foreground">
           <h1>{`MYCOSOFT TERMS OF SERVICE`}</h1>
           <div className="not-prose my-6 rounded-lg border border-border bg-muted/40 p-4 text-sm">
             <dl className="grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-x-4 gap-y-1">


### PR DESCRIPTION
## What you reported

The TOS page on production has no spacing between sections — sections 1, 2, 3, etc. stack with zero margin and no visual separation. Same issue silently affects the three overview docs.

## Root cause

The repo uses **Tailwind v4** and **does not have `@tailwindcss/typography` installed** (confirmed in `package.json`). The TOS and overview docs were authored with prose modifier classes:

- `prose-h2:mt-16 prose-h2:pt-8 prose-h2:border-t prose-h2:border-border`
- `prose-h3:mt-10`
- `prose-p:my-5 prose-p:leading-relaxed`
- `prose-ul:my-5 prose-ol:my-5`

Without the typography plugin Tailwind doesn't know what `prose-h2:` means, so it generates **zero CSS** for any of those rules. Verified by greppig the live bundle at `/_next/static/css/7350b0cc34a095e5.css` — no matches for any prose-* spacing rule.

## Fix

Replace every prose-* modifier with a Tailwind v4 arbitrary-variant child selector that compiles without any plugin:

```
[&_h2]:mt-16 [&_h2]:pt-8 [&_h2]:border-t [&_h2]:border-border ...
[&_h3]:mt-10 [&_h3]:text-xl [&_h3]:font-semibold ...
[&_p]:my-5 [&_p]:leading-relaxed
[&_ul]:my-5 [&_ul]:pl-6 [&_ul]:list-disc [&_ul]:space-y-2
[&_ol]:my-5 [&_ol]:pl-6 [&_ol]:list-decimal [&_ol]:space-y-2
[&_dl]:my-6 [&_dt]:mt-5 [&_dd]:mb-3 [&_dd]:ml-4
[&_a]:text-primary [&_a]:underline ...
[&_strong]:font-semibold [&_code]:bg-muted ...
[&_hr]:my-12
```

These compile into real CSS rules and produce exactly the intended typography hierarchy with section spacing, list indentation, link color, code block styling, and horizontal rule margins.

## Pages touched

- `app/terms/page.tsx`
- `app/docs/what-is-mycosoft/page.tsx`
- `app/docs/quickstart/page.tsx`
- `app/docs/glossary/page.tsx`

## What is NOT changed

- Zero legal/content changes to TOS — only the article wrapper className.
- Zero content changes to the three docs.
- No device pages, NatureOS, FUSARIUM, or anything else.

## Local checks

- `next lint` on all four files — clean, no warnings.

## Follow-up

We could install `@tailwindcss/typography` v4-compatible package and use `prose` legitimately, but explicit child selectors are simpler, plugin-free, and identical in output.

## Summary by Sourcery

Enhancements:
- Standardize article typography and spacing on terms and documentation pages using Tailwind v4-compatible child selector variants instead of prose-* utilities.