### PR TITLE
docs: rewrite /docs/what-is-mycosoft per audit; reconcile Agaric and Earth Simulator/CREP

### DIFF
--- a/app/docs/glossary/page.tsx
+++ b/app/docs/glossary/page.tsx
@@ -177,20 +177,15 @@ export default function Page() {
           </dd>
 
           <dt>
-            <strong>Earth Simulator</strong>
+            <strong>Earth Simulator / CREP</strong>
           </dt>
           <dd>
-            Environmental world-model service for scenario generation, simulation-backed training,
-            and what-if analysis against live telemetry.
-          </dd>
-
-          <dt>
-            <strong>CREP</strong>
-          </dt>
-          <dd>
-            Common Relevant Environmental Picture. The fused, time-aligned operational view of an
-            area of interest — combining device telemetry, public data, and model output into a
-            single shared picture used by operators and partners.
+            Two names for the same surface. <strong>Earth Simulator</strong> is the runtime: an
+            environmental world-model for scenario generation, simulation-backed training, and
+            what-if analysis against live telemetry. <strong>CREP</strong> — Common Relevant
+            Environmental Picture — is what it produces and how it is used: a fused, time-aligned
+            operational view of an area of interest, combining device telemetry, public data, and
+            model output into a single shared picture for operators and partners.
           </dd>
 
           <dt>

--- a/app/docs/what-is-mycosoft/page.tsx
+++ b/app/docs/what-is-mycosoft/page.tsx
@@ -6,13 +6,13 @@ import { Badge } from "@/components/ui/badge"
 export const metadata: Metadata = {
   title: "What is Mycosoft",
   description:
-    "Company overview and the full Mycosoft stack — devices, firmware, NatureOS, MYCA, AVANI, and apps. Written for investors, customers, partners, and developers.",
+    "Mycosoft is an environmental-intelligence and biological-interface company building a connected stack of field hardware, edge compute, AI orchestration, mycological data infrastructure, and simulation software.",
 }
 
 export default function Page() {
   return (
     <DocsLayout>
-      <article className="max-w-3xl text-foreground [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mb-6 [&_h1]:scroll-mt-24 [&_h2]:mt-14 [&_h2]:pt-6 [&_h2]:mb-4 [&_h2]:border-t [&_h2]:border-border [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:scroll-mt-24 [&_h3]:mt-10 [&_h3]:mb-3 [&_h3]:text-xl [&_h3]:font-semibold [&_h3]:scroll-mt-24 [&_p]:my-4 [&_p]:leading-relaxed [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal [&_ol]:space-y-2 [&_li]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80 [&_strong]:font-semibold [&_strong]:text-foreground [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:bg-muted [&_code]:text-sm [&_hr]:my-12 [&_hr]:border-border">
+      <article className="max-w-3xl text-foreground [&_h1]:text-4xl [&_h1]:font-bold [&_h1]:mb-6 [&_h1]:scroll-mt-24 [&_h2]:mt-14 [&_h2]:pt-6 [&_h2]:mb-4 [&_h2]:border-t [&_h2]:border-border [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:scroll-mt-24 [&_h3]:mt-10 [&_h3]:mb-3 [&_h3]:text-xl [&_h3]:font-semibold [&_h3]:scroll-mt-24 [&_p]:my-4 [&_p]:leading-relaxed [&_ul]:my-4 [&_ul]:pl-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ol]:my-4 [&_ol]:pl-6 [&_ol]:list-decimal [&_ol]:space-y-2 [&_li]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80 [&_strong]:font-semibold [&_strong]:text-foreground [&_em]:italic [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:bg-muted [&_code]:text-sm [&_hr]:my-12 [&_hr]:border-border">
         <div className="not-prose mb-4 flex flex-wrap items-center gap-2 text-sm">
           <Link href="/docs" className="text-muted-foreground hover:text-foreground">
             Documentation
@@ -26,319 +26,330 @@ export default function Page() {
         <div className="not-prose my-6 flex flex-wrap items-center gap-2">
           <Badge variant="outline">Overview</Badge>
           <Badge variant="default">Stable</Badge>
-          <Badge variant="outline">For investors · customers · developers</Badge>
+          <Badge variant="outline">Public site basis</Badge>
         </div>
 
         <p>
-          Mycosoft is a biotechnology and software company building the operating layer for biological
-          intelligence — the devices, models, and services that let humans observe, model, and act on
-          the living world. We design environmental sensing hardware, train AI on environmental and
-          biological signal, run a planetary-scale edge intelligence called <strong>MYCA</strong>, and
-          deliver this stack to commercial, research, and defense customers under a single software
-          identity called <strong>NatureOS</strong>.
+          Mycosoft is an environmental-intelligence and biological-interface company building a
+          connected stack of field hardware, edge compute, AI orchestration, mycological data
+          infrastructure, and simulation and analysis software. The platform senses environmental and
+          fungal signals, moves them through a telemetry and provenance layer, indexes and stores
+          them, and exposes them to operators and researchers through dashboards, APIs, and AI
+          systems.
         </p>
 
         <p>
-          This page is the canonical, one-stop overview. An investor can read it end-to-end in fifteen
-          minutes and understand exactly what Mycosoft sells, how the stack is composed, who the
-          customers are, and where the company is in its build. Engineers and partners get the same
-          picture — the rest of the docs go deeper into each piece.
+          This page is the canonical overview. It is written to match what is publicly visible on{" "}
+          <a href="https://mycosoft.com/">mycosoft.com</a> today and to be honest about what is
+          shipping, what is gated behind sign-in, and what is research-stage. The rest of the
+          documentation goes deeper into each part.
         </p>
 
-        <h2 id="company">The company</h2>
+        <h2 id="thesis">The thesis: Nature Compute</h2>
 
-        <h3 id="entities">Legal entities</h3>
-        <p>Mycosoft operates as two entities working in parallel:</p>
-        <ul>
-          <li>
-            <strong>Mycosoft, Inc.</strong> — a Delaware C-Corporation. Parent company, investment
-            vehicle, and licensor of platform intellectual property.
-          </li>
-          <li>
-            <strong>Mycosoft, LLC</strong> — a California limited liability company (CA Entity No.
-            202253910565) and operating subsidiary. This is the federal contracting entity, the
-            manufacturing entity, and the party that signs pilot, deployment, and reseller agreements.
-            All federal submissions are 100% self-performed by Mycosoft, LLC.
-          </li>
-        </ul>
         <p>
-          Federal credentials are held by Mycosoft, LLC: UEI{" "}
-          <span className="font-mono">YK3ARVKJ77S9</span>, CAGE{" "}
-          <span className="font-mono">9KR60</span>, with an active SAM.gov registration valid through
-          April 9, 2027.
+          Mycosoft&apos;s thesis is that technology should not dominate nature but understand it. The
+          missing layer in conventional sensing is continuous, in-situ biological telemetry —
+          especially below ground, in the air, and inside the fungal and microbial networks that
+          underpin every ecosystem. The company&apos;s shorthand for the approach is{" "}
+          <strong>Nature Compute</strong>: living networks measured, interfaced with, and used as
+          grounded signal sources for environmental intelligence.
         </p>
 
-        <h3 id="mission">Mission</h3>
         <p>
-          Build the substrate that lets biology, sensors, and AI cooperate at planetary scale —
-          starting with the most distributed and under-sampled signal sources on Earth: soil, air,
-          water, and the fungal networks woven through them. Every Mycosoft product earns its place
-          by feeding, modelling, or acting on that signal.
+          In practice that translates into devices that read soil, air, water, and bioelectric
+          activity; protocols that move that signal through a provenance-preserving telemetry layer;
+          a database layer that indexes and correlates it; and an AI layer that grounds reasoning in
+          continuous environmental context rather than only in text.
         </p>
 
-        <h3 id="how-we-talk">How we talk about what we do</h3>
-        <p>
-          We are deliberate about claims. Mycosoft ships measurable systems — sensors that record
-          environmental and bioelectric activity, dashboards that visualise telemetry, agents that
-          execute defined workflows. We do <em>not</em> claim that fungi are language-capable
-          computers, that Wi-Fi sensing gives planetary perception, or that interspecies translation
-          is a solved problem. Research that explores those frontiers is labelled <em>frontier</em>{" "}
-          throughout the documentation; commercial work is labelled <em>stable</em>.
-        </p>
-
-        <h2 id="stack">The stack at a glance</h2>
+        <h2 id="stack">The stack</h2>
 
         <p>
-          Mycosoft is built in five layers. Each layer is independently usable; customer value
-          compounds when they are combined.
+          The Mycosoft stack is built in five layers. Each layer is independently named on the public
+          site; customer value compounds when they are used together.
         </p>
 
         <h3 id="layer-devices">1. Devices — environmental and biological sensing</h3>
         <p>
-          Purpose-built field hardware. Each device is a sealed, solar-capable, mesh-networked
-          compute node running our firmware over ESP32-S3 class silicon. Production lineup:
+          Purpose-built field hardware. The current public device line:
         </p>
         <ul>
           <li>
-            <strong>Mushroom 1</strong> — the flagship. A solar-powered <em>quadruped walker</em>{" "}
-            with four articulated carbon-fibre legs, a 2-metre multi-depth soil probe, dual Bosch
-            BME688 environmental sensors, and a long-range 915 MHz mesh radio. Walks itself to
-            optimal terrain, reads soil and air, and joins the local network. Designed for forests,
-            farms, parks, and remote field sites.
+            <strong>
+              <Link href="/devices/mushroom-1">Mushroom 1</Link>
+            </strong>{" "}
+            — a ground-deployed environmental sensing platform for fungal, soil, atmospheric, and
+            multimodal field data. Publicly exposed specs include up to 2 m sensing depth, ~5 km
+            line-of-sight range, IP67, ESP32-S3 with 16 MB flash + 8 MB PSRAM, 32 GB local storage
+            with cloud sync, ~4.5 kg, 30 × 30 × 100 cm, and roughly six months of solar-rechargeable
+            battery life. The device page also names 4K vision, radar / LiDAR, BME690 gas sensing,
+            software-defined radio, and a ground-actuated FCI probe.
           </li>
           <li>
-            <strong>Hyphae 1</strong> — an on-ground distributed edge datacenter. Air, light, sound,
-            and gas sensors plus radar, lidar, and radio (including jamming and anti-jamming) in a
-            single shelter-grade enclosure. Aggregates and computes locally for clusters of
-            Mushroom 1, MycoNode, SporeBase, and Agaric units.
+            <strong>
+              <Link href="/devices/sporebase">SporeBase</Link>
+            </strong>{" "}
+            — a bioaerosol collection system that produces time-indexed physical samples while
+            preserving environmental context. Publicly exposed specs include 2,880 sample intervals
+            per cassette, 30-day cassettes, a 15-minute default cadence, IP65 design target, LoRa
+            mesh with optional Wi-Fi or cellular, MPPT solar + Li-ion battery, dual ESP32-S3
+            controllers, microSD storage (32–256 GB), and approximately 194 × 149 × 53 mm.
           </li>
           <li>
-            <strong>MycoBrain</strong> — the ESP32-S3 edge compute module that ships inside every
-            Mycosoft device. Dual BME688 + BSEC2, runs the firmware stack, processes all sensor
-            inputs locally before they leave the device.
+            <strong>
+              <Link href="/devices/hyphae-1">Hyphae 1</Link>
+            </strong>{" "}
+            — the exterior edge-compute and sensing-node family. Publicly named variants are
+            Compact, Standard, and Industrial. The public page describes MycoBrain + Jetson compute,
+            multi-modal sensing, Ethernet / Wi-Fi / LoRa / LTE / 5G options, and an IP66-class /
+            NEMA 4X-equivalent outdoor mechanical intent. Exact workload power and BOM are
+            configuration-specific.
           </li>
           <li>
-            <strong>MycoNode</strong> — a subsurface bioelectric probe with a 5-mile broadcast range.
-            Deployed by hand or dropped from a MycoDrone, it captures fungal and root-zone electrical
-            signal and forwards it through the mesh.
+            <strong>
+              <Link href="/devices/myconode">MycoNode</Link>
+            </strong>{" "}
+            — a subsurface bioelectric probe and mesh-networking node for fungal-data telemetry and
+            local sensing.
           </li>
           <li>
-            <strong>SporeBase v4</strong> — a bioaerosol collector. A stepper-driven sealed tape
-            cassette captures pollen, spores, fungal, bacterial, and viral particulates in
-            time-indexed 15- to 60-minute segments (up to 2,880 segments over 30 days). Dual ESP32-S3,
-            LoRa, fan-driven sampling, Bosch BME69x gas sensing, solar + battery.
+            <strong>
+              <Link href="/devices/alarm">ALARM</Link>
+            </strong>{" "}
+            — a biological detection and early-warning device with on-device TinyML inference.
           </li>
           <li>
-            <strong>Agaric</strong> — a flying sensor hub (drone) available in Mini, Standard, and
-            Heavy-Lift variants. Six-point coaxial propulsion, tangential flight control, MAVLink,
-            LoRa mesh, and satellite options for over-the-horizon work.
+            <strong>
+              <Link href="/devices/agaric">Agaric</Link>
+            </strong>{" "}
+            — the flying platform for aerial survey, mesh extension, over-the-horizon work, and
+            payload delivery of Mushroom 1, MycoNode, or SporeBase to remote terrain. Replaces the
+            earlier MycoDrone concept.
           </li>
           <li>
-            <strong>ALARM</strong> — an incident signaling device. Dual smoke detection (ionisation +
-            photoelectric), MOS VOC, PM1.0 / 2.5 / 10 particulates, NDIR CO₂ (400–5,000 ppm), BME688
-            climate, mold warning, ESP32-S3 + on-device TinyML for early-warning classification.
+            <strong>
+              <Link href="/devices/psathyrella">Psathyrella</Link>
+            </strong>{" "}
+            — a water buoy / surface platform for aquatic environmental intelligence.
           </li>
           <li>
-            <strong>MycoDrone</strong> — a flying carrier that deploys Mushroom 1, MycoNode, or
-            SporeBase to remote terrain.
+            <strong>
+              <Link href="/devices/mycobrain">MycoBrain</Link>
+            </strong>{" "}
+            — the edge-compute module that ships inside Mycosoft devices and runs the firmware
+            stack locally before signal leaves the device.
           </li>
         </ul>
         <p>
-          <strong>Draft:</strong> <em>Psathyrella</em> — a water buoy for undersea cable monitoring,
-          boat and submarine deterrence, cameras, and laser comms. Surface-deployed from USVs, manned
-          vessels, or shore. Solar + battery, four turbopropellers.
-        </p>
-        <p>
-          See <Link href="/devices">/devices</Link> for the full specifications page.
+          Full specifications for each device live at <Link href="/devices">/devices</Link>. The
+          device pages publish dimensions, sensor channels, power profiles, and connectivity
+          options.
         </p>
 
-        <h3 id="layer-firmware">2. Firmware and protocols</h3>
+        <h3 id="layer-protocols">2. Telemetry and provenance — Mycorrhizae Protocol, FCI</h3>
         <p>
-          Every Mycosoft device runs the same firmware stack and speaks two protocols designed for
-          biological and environmental telemetry:
+          Devices speak two public protocols that move signal through the stack while preserving
+          chain-of-custody:
         </p>
         <ul>
           <li>
-            <strong>MDP</strong> — Mycosoft Data Protocol. Device-level transport. COBS-framed with
-            CRC-16. Low-overhead, lossy-link tolerant, suitable for radio mesh and serial bus.
+            <strong>Mycorrhizae Protocol</strong> — the public device-telemetry and sensor-mesh
+            standard. Mushroom 1 and SporeBase explicitly route structured field data through it,
+            and SporeBase additionally uses it to encode chain-of-custody for time-indexed samples.
           </li>
           <li>
-            <strong>MMP</strong> — Mycosoft Mycorrhizae Protocol. Gateway-to-cloud mesh transport.
-            Handles store-and-forward, prioritisation, and platform attestation.
+            <strong>FCI — Fungal Computer Interface</strong> — the bridge between living mycelial
+            networks and digital systems. On Mushroom 1, FCI is a deployable, ground-actuated probe
+            into soil, roots, fungal networks, gas exchange, moisture gradients, and bioelectric
+            activity. FCI is also indexed in MINDEX and surfaced through NatureOS.
           </li>
         </ul>
-        <p>
-          On-device features include BME688 / BSEC2 environmental processing, bioelectric sampling,
-          OTA updates, signed attestation, and on-device safety controls.
-        </p>
 
-        <h3 id="layer-platform">3. Platform — NatureOS</h3>
+        <h3 id="layer-data">3. Data and indexing — MINDEX</h3>
         <p>
-          <strong>NatureOS</strong> is the cloud and edge platform that ingests device signal, stores
-          it, models it, and exposes it through dashboards and APIs. Named services you will see
-          across the docs:
+          <strong>MINDEX</strong> is the public name for the company&apos;s mycological database and
+          provenance layer. The About page describes it as a global fungal species intelligence
+          database; the documentation index frames it as a cryptographic mycological database with
+          schema, access tiers, and query patterns planned. On device pages it is also where
+          chain-of-custody records and long-term storage are surfaced, particularly for Mushroom 1
+          and SporeBase. Detailed schema documentation is currently marked coming soon.
         </p>
-        <ul>
-          <li>
-            <strong>MINDEX</strong> — the indexed data plane. Postgres-backed store of record for
-            telemetry, specimen records, chain-of-custody, and model outputs.
-          </li>
-          <li>
-            <strong>AI Studio</strong> — model training, evaluation, and deployment for internal and
-            partner ML work.
-          </li>
-          <li>
-            <strong>Earth Simulator</strong> — environmental world-model service for scenario
-            generation, simulation-backed training, and what-if analysis against live telemetry.
-          </li>
-          <li>
-            <strong>CREP</strong> — Common Relevant Environmental Picture. The fused, time-aligned
-            operational view of an area of interest — combining device telemetry, public data, and
-            model output into a single shared picture used by operators and partners.
-          </li>
-          <li>
-            <strong>OEI</strong> — Open Environmental Intelligence. Public-data ingestion (AIS,
-            ADS-B, satellite, weather, biodiversity).
-          </li>
-        </ul>
 
         <h3 id="layer-ai">4. AI — MYCA, AVANI, NLM</h3>
         <p>
-          The intelligence layer is paired: <strong>MYCA</strong> is the hand that acts, <strong>AVANI</strong>{" "}
-          is the palm that senses.
+          The AI layer is the part of the stack most visible in the public navigation. Three named
+          systems work together:
         </p>
         <ul>
           <li>
-            <strong>MYCA</strong> — the MYCOSOFT Environmental Super Intelligence. An edge-native
-            multi-agent system orchestrating <strong>over 1,000 specialised agents</strong> across{" "}
-            <strong>14 categories</strong>, governed by a three-tier permission model: <em>Read</em>{" "}
-            (auto-approved), <em>Write</em> (requires approval), and <em>Execute</em> (requires
-            explicit yes). Powered by NVIDIA Nemotron foundation models and PersonaPlex, designed for
-            Blackwell-generation edge GPUs. Self-trains from NLM, MDP, MMP, and open-source models.
-            Repo: <a href="https://github.com/MycosoftLabs/mycosoft-mas">github.com/MycosoftLabs/mycosoft-mas</a>.
+            <strong>
+              <Link href="/myca">MYCA</Link>
+            </strong>{" "}
+            — the company&apos;s primary operating intelligence. An edge-native, multi-agent system
+            running in distributed edge data centers embedded in dedicated hardware and nodes, not
+            only in centralised cloud. MYCA is described as the structured &ldquo;hand&rdquo; in the
+            stack, coordinating agents, tasks, APIs, and local reasoning. Public technical specs
+            name a 6-state consciousness model, a 6-layer memory architecture, and roughly 150+
+            agents, skills, and integrations across 14 categories.
           </li>
           <li>
-            <strong>AVANI</strong> — the Live Earth Substrate. A dedicated backend next to MYCA that
-            ingests and harmonises planetary-scale signals — climate, sensor networks, infrastructure
-            telemetry, remote sensing — and serves them to MYCA through privacy-respecting APIs so
-            agents always act with environmental and societal context.
+            <strong>
+              <Link href="/ai/avani">AVANI</Link>
+            </strong>{" "}
+            — the live Earth substrate for MYCA: the &ldquo;palm&rdquo; that ingests, harmonises,
+            and serves climate, sensor, infrastructure, and remote-sensing signals so MYCA acts with
+            real environmental context. AVANI&apos;s public architecture is a layered design (input,
+            processing, model, serving) with a constitution centred on planetary primacy, human
+            legibility, privacy and sovereignty, safety and resilience, and alignment with MYCA.
           </li>
           <li>
-            <strong>MycaPLEX</strong> — full-duplex voice-to-voice and voice-to-agent interface for
-            MYCA. A modified PersonaPlex stack that lets operators converse with agents naturally,
-            including on the field, in vehicles, and through hardware headsets.
-          </li>
-          <li>
-            <strong>NLM</strong> — Natural Language Model. Mycosoft&rsquo;s frontier research
-            programme on bioelectric and environmental signal interfaces. Labelled <em>frontier</em>;
-            not a shipping product.
+            <strong>NLM — Nature Learning Model</strong> — the reasoning backbone that learns from
+            environmental and biological signal rather than only from text. NLM is described on the
+            AI and device pages as the model layer behind MYCA-grounded reasoning.
           </li>
         </ul>
+
+        <h3 id="layer-platform">5. Platform and apps — NatureOS, MINDEX, AI Studio, simulation</h3>
         <p>
-          We are explicit about a separation that matters in the field: pipelines that affect
-          physical equipment, regulated workflows, or chain-of-custody records are{" "}
-          <em>deterministic</em> by default. Frontier models reason, draft, and explore — they are
-          never the sole decision-maker for a field action.
+          The operator-facing layer is presented under the NatureOS umbrella. Several of the
+          overview pages are currently gated behind sign-in; the public site names them, but the
+          full interfaces are accessible to authenticated users today.
         </p>
-
-        <h3 id="layer-apps">5. Apps — simulation and lab tools</h3>
-        <p>
-          Focused web apps that sit on top of NatureOS for scientists, students, and operators:{" "}
-          <em>earth-simulator</em>, <em>alchemy-lab</em>, <em>compound-sim</em>, <em>digital-twin</em>,{" "}
-          <em>genetic-circuit</em>, <em>growth-analytics</em>, <em>lifecycle-sim</em>,{" "}
-          <em>mushroom-sim</em>, <em>petri-dish-sim</em>, <em>physics-sim</em>, <em>retrosynthesis</em>,{" "}
-          <em>spore-tracker</em>, and <em>symbiosis</em>. Each app is a thin client over the NatureOS
-          APIs.
-        </p>
-
-        <h2 id="who-its-for">Who Mycosoft is for</h2>
-
-        <h3 id="customers">Customers and use cases</h3>
         <ul>
           <li>
-            <strong>Defence and government</strong> — non-kinetic environmental intelligence,
-            biosurveillance, common relevant environmental picture (CREP) generation,
-            chain-of-custody evidence pipelines, and autonomous field-deployment programmes. Mycosoft
-            focuses on non-kinetic electronic warfare capabilities — jamming and anti-jamming,
-            microwave, laser, radar — aligned with the U.S. military Black Dart programme. Mycosoft,
-            LLC is the federal contracting entity; all submissions are self-performed.
+            <strong>NatureOS</strong> — the cloud and edge platform for environmental intelligence.
+            Public copy describes it as a cloud OS, an Earth-intelligence workflow layer, and an
+            operator dashboard for fleets, telemetry, and alerts.
           </li>
           <li>
-            <strong>Research institutions</strong> — universities, national labs, and biotech / agtech
-            R&amp;D groups using the devices and NatureOS APIs for mycology, soil science, and
-            environmental monitoring.
+            <strong>AI Studio</strong> — &ldquo;MYCA agent orchestration and model training.&rdquo;
+            Currently sign-in gated.
           </li>
           <li>
-            <strong>Commercial operators</strong> — agriculture, food and beverage, indoor cultivation,
-            and industrial fermentation customers using the devices for process monitoring.
+            <strong>Earth Simulator / CREP</strong> — the Common Relevant Environmental Picture.
+            Earth Simulator is the runtime; CREP is the name for what it produces and how it is
+            used: a fused, time-aligned worldview combining device telemetry, public data, species,
+            sensors, missions, and live planetary context into a single shared operational picture
+            for operators and partners. Same surface, two names.
           </li>
           <li>
-            <strong>Educators and citizen scientists</strong> — schools and individual makers using
-            the devices and firmware to teach and explore.
+            <strong>Fungi Compute</strong> — biological-computing visualisation; mycelial neural
+            networks and bio-compute exploration.
           </li>
           <li>
-            <strong>Developers and integrators</strong> — partners building on the APIs, firmware,
-            and the MYCA multi-agent runtime.
+            <strong>Ancestry Database</strong> — fungal genealogy and genomics explorer.
+          </li>
+          <li>
+            <strong>Petri Dish Simulator</strong> — virtual culture-growth simulation and a
+            lab-bench experiment surface.
+          </li>
+          <li>
+            <strong>Compound Analyzer</strong> — chemical compound analysis (the documentation
+            index also separately names Alchemy Lab and Compound Sim).
+          </li>
+          <li>
+            <strong>Genomics Tools</strong> — genome browsers and visualisation.
           </li>
         </ul>
 
-        <h3 id="federal-programs">Federal program focus</h3>
         <p>
-          Mycosoft is actively pursuing DARPA and U.S. Army programmes first, with USAF engagement
-          around MycoDrone and U.S. Navy engagement on Tactical Operations (TAC-O) and undersea
-          monitoring. Notable submissions: Army <em>ITDX 2026</em> white paper
-          (W91RUSI-FCID260001) and a DARPA submission against HR001125S0011 covering the FUSARIUM
-          programme. DoD SBIR engagement is sequenced after these primary programmes.
+          The documentation index also publicly advertises additional studio tools — Alchemy Lab,
+          Compound Sim, Digital Twin, Genetic Circuit, Growth Analytics, Lifecycle Sim, Mushroom Sim,
+          Physics Sim, Retrosynthesis, Spore Tracker, and Symbiosis — most of which are marked{" "}
+          <em>Coming soon</em>. Their names and one-line purposes are public; their interfaces are
+          not yet generally available.
         </p>
 
-        <h3 id="capital">Capital and community</h3>
+        <h2 id="use-cases">Use cases</h2>
+
         <p>
-          Mycosoft maintains two capital tracks: traditional equity through Mycosoft, Inc., and a
-          tokenised community track through <strong>MYCO DAO</strong>. The DAO raised approximately
-          $500,000 in its first 48 hours by selling 15% of the MYCO token on Solana, funding
-          community-aligned research and tooling. Operating contracts and federal programmes continue
-          to be executed through Mycosoft, LLC.
+          The public use cases point first toward <strong>environmental sensing where biological
+          signals matter before surface indicators do</strong>: early anomaly detection,
+          infrastructure resilience, agricultural and ecological intelligence, climate-adaptive land
+          management, and contamination response. The argument is that continuous in-situ biological
+          telemetry is the missing layer in conventional environmental sensing.
         </p>
 
-        <h3 id="for-investors">If you&apos;re an investor</h3>
         <p>
-          The short version: Mycosoft is a vertically integrated stack — devices, firmware, platform,
-          AI, and apps — sold into defence, research, and commercial customers. Hardware revenue
-          funds the platform; platform contracts compound the device base. Federal contracting
-          credentials are active. For financing materials, structure, and cap-table details, the
-          investor packet is shared under NDA — contact{" "}
+          SporeBase expands the envelope into <strong>airborne biology and temporal sampling</strong>{" "}
+          — mycology research, allergy forecasting, agriculture, and air-quality monitoring — because
+          it produces a time-indexed physical sample record rather than only a momentary reading.
+          The stack is not only about inference from live telemetry; it is also about preserving
+          material samples and provenance for later lab work.
+        </p>
+
+        <p>
+          Mushroom 1 adds <strong>field ecological sensing and direct substrate interaction</strong>,
+          publicly tying multimodal environmental sensing to FCI and to MYCA-grounded reasoning.
+          Hyphae 1 broadens the envelope toward <strong>exterior edge compute at sites, campuses,
+          industrial estates, laboratories, and agriculture</strong>, where correlation and local
+          processing are needed outside the building rather than only in the cloud.
+        </p>
+
+        <p>
+          Taken together, the public basis is: field sensing, bioaerosol capture, exterior edge
+          compute, database and provenance, and AI reasoning — for ecology, research, air quality,
+          agriculture, site monitoring, and environmental operations.
+        </p>
+
+        <h2 id="philosophy">Philosophy</h2>
+
+        <p>
+          The site&apos;s governing philosophy is unusually explicit. About says technology should not
+          dominate nature but understand it. Mycosoft repeatedly frames the platform as hybrid
+          biological-digital computing rooted in biological respect, decentralised intelligence,
+          sustainability, and environmental stewardship.
+        </p>
+
+        <p>
+          The AI and AVANI pages add a second layer: <strong>human legibility, privacy and
+          sovereignty, uncertainty awareness, and multi-stakeholder governance</strong>. AVANI&apos;s
+          constitution says outputs should remain explainable and privacy-respecting and should
+          explicitly surface uncertainty under partial data. MYCA&apos;s philosophy section says the
+          system is built with the goal of treating all organisms as users, adopting a reality-first
+          principle in which biological networks are not only data sources but active experimental
+          partners.
+        </p>
+
+        <p>
+          That is why public copy across the site emphasises grounding, accountability, provenance,
+          and environmental context over generic AI-chatbot language.
+        </p>
+
+        <h2 id="how-to-engage">How to engage</h2>
+
+        <h3 id="for-investors">If you are an investor</h3>
+        <p>
+          The short version: Mycosoft is a vertically integrated environmental-intelligence stack —
+          devices, telemetry, provenance, AI, and platform — sold into research, commercial, and
+          institutional customers. For materials shared under NDA, contact{" "}
           <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a>.
         </p>
 
-        <h3 id="for-customers">If you&apos;re a customer</h3>
+        <h3 id="for-customers">If you are a customer or researcher</h3>
         <p>
-          Start with <Link href="/docs/quickstart">Quickstart</Link>. It takes you from
-          &ldquo;I&apos;ve heard of Mycosoft&rdquo; to your first data flowing in fifteen minutes —
-          which device or API to choose, how to request access, and where the data lands.
+          Start with <Link href="/docs/quickstart">Quickstart</Link>. It walks you from
+          &ldquo;I&apos;ve heard of Mycosoft&rdquo; to your first data flowing — which device or API
+          fits, how to request access, and where the data lands.
         </p>
 
-        <h3 id="for-developers">If you&apos;re a developer or partner</h3>
+        <h3 id="for-developers">If you are a developer or partner</h3>
         <p>
-          The agent runtime is open-source at{" "}
-          <a href="https://github.com/MycosoftLabs/mycosoft-mas">github.com/MycosoftLabs/mycosoft-mas</a>.
-          API and firmware references are linked from <Link href="/docs">/docs</Link>; protocol
-          specifications for MDP and MMP are part of the same documentation set.
+          The MYCA white paper, device datasheets, brochures, full specifications, CAD models, and
+          engineering illustrations are advertised on the documentation index. The API documentation
+          headings — REST, GraphQL, Webhooks, rate limits and quotas, authentication — are public
+          but currently marked <em>Coming soon</em>. Open-source repository, license, and contributing
+          headings exist as public sections and are being filled in.
         </p>
 
-        <h3 id="for-defense">If you&apos;re a defence or government contact</h3>
-        <p>
-          See <Link href="/docs/defense-government">Defence &amp; Government</Link> for SAM.gov
-          credentials, capability statement, programme alignment (DARPA, Army ITDX, USAF, Navy TAC-O,
-          Black Dart), and the deployment-sponsor model for regulated field work.
-        </p>
-
-        <h2 id="status">Status, openness, and how to engage</h2>
+        <h2 id="status">Status, openness, and how to read this site</h2>
 
         <h3 id="status-labels">Status labels you will see in these docs</h3>
         <ul>
           <li>
-            <strong>Stable</strong> — shipping today, supported, covered by the standard Terms of
-            Service.
+            <strong>Stable</strong> — shipping today, supported, covered by the standard{" "}
+            <Link href="/terms">Terms of Service</Link>.
           </li>
           <li>
             <strong>Draft</strong> — being built right now; documentation reflects current direction
@@ -353,35 +364,26 @@ export default function Page() {
           </li>
         </ul>
 
-        <h3 id="openness">Open source and source-available</h3>
+        <h3 id="gated-vs-public">What is public versus gated</h3>
         <p>
-          The MYCA multi-agent system (MAS) is open source. Firmware is source-available. Selected
-          platform components and SDKs ship under permissive licences; others are commercial. See{" "}
-          <Link href="/docs/open-source">Open Source</Link> for the full matrix.
+          The site publicly names a coherent stack, but several overview interfaces — NatureOS, Apps,
+          AI Studio — currently redirect to sign-in. The accurate present-tense basis is: the public
+          site names the platform, while much of the detailed documentation and some interfaces
+          remain gated, pending, or research-stage. Where this page describes a system that is
+          gated, the description is grounded in the public marketing pages for that system, not in
+          the gated interface itself.
         </p>
 
-        <h3 id="terms">Legal</h3>
-        <p>
-          Use of any Mycosoft website, device, platform, agent, or API is governed by the{" "}
-          <Link href="/terms">Mycosoft Terms of Service</Link>. The Terms are the canonical legal
-          document; this overview is informational.
-        </p>
-
-        <h3 id="contact">Contact</h3>
+        <h2 id="contact">Contact</h2>
         <ul>
           <li>
             General — <a href="mailto:contact@mycosoft.com">contact@mycosoft.com</a>
           </li>
           <li>
-            Federal / defence —{" "}
-            <Link href="/docs/defense-government">/docs/defense-government</Link>
-          </li>
-          <li>
             Engineering — <a href="https://github.com/MycosoftLabs">github.com/MycosoftLabs</a>
           </li>
           <li>
-            Research writing —{" "}
-            <a href="https://medium.com/@mycosoft.inc">medium.com/@mycosoft.inc</a>
+            Research writing — <a href="https://medium.com/@mycosoft.inc">medium.com/@mycosoft.inc</a>
           </li>
           <li>
             Public channels —{" "}
@@ -392,7 +394,7 @@ export default function Page() {
           </li>
         </ul>
 
-        <hr className="my-12" />
+        <hr />
 
         <p className="text-sm text-muted-foreground">
           Next: <Link href="/docs/quickstart">Quickstart →</Link> ·{" "}


### PR DESCRIPTION
## Summary

Rewrites `/docs/what-is-mycosoft` per the public-site audit, and reconciles two terminology corrections from this session.

### Audit framing applied
- Nature Compute thesis as the opening frame
- Gated-vs-public honesty section
- Removed federal contracting / DAO / Black Dart / DARPA / '1,000+ agents' / '100% self-performed' claims
- Kept all live devices (Mushroom 1, SporeBase, Hyphae 1, MycoNode, ALARM, Agaric, Psathyrella, MycoBrain)

### Terminology fixes
- **Agaric is now the flying platform.** MycoDrone concept is retired; Agaric covers aerial survey, mesh extension, over-the-horizon work, and payload delivery of Mushroom 1 / MycoNode / SporeBase.
- **Earth Simulator and CREP are the same surface.** Earth Simulator is the runtime; CREP (Common Relevant Environmental Picture) is what it produces. Reconciled across `what-is-mycosoft` and `glossary`.

### Touch zones
- Modified: `app/docs/what-is-mycosoft/page.tsx`, `app/docs/glossary/page.tsx`
- Untouched: `app/devices/**`, `app/natureos/**`, `app/fusarium/**`, `app/apps/**`, `components/footer.tsx`
- No EIN published anywhere.

### Verification
- Lint: clean
- All 8 live device links verified 200 on mycosoft.com

## Summary by Sourcery

Rewrite the public-facing "What is Mycosoft" documentation page to align with the audited public site narrative, emphasizing the Nature Compute thesis, current device lineup, data and AI stack, use cases, philosophy, and engagement paths, while clarifying what is publicly available versus gated or research-stage.

Enhancements:
- Tighten copy and metadata for the "What is Mycosoft" page, including improved description, status labelling, and public-vs-gated disclosures for platform components.

Documentation:
- Refresh the "What is Mycosoft" doc to reflect the Nature Compute framing, updated stack layers, current live devices, and clarified investor/customer/developer guidance, aligned with the marketing site.
- Clarify and consolidate the glossary entry for Earth Simulator and CREP as two names for the same environmental world-model surface.