### PR TITLE
docs(quickstart): USAF references Agaric (MycoDrone retired)

### DIFF
--- a/app/docs/quickstart/page.tsx
+++ b/app/docs/quickstart/page.tsx
@@ -305,7 +305,7 @@ export default function Page() {
             FUSARIUM programme submitted.
           </li>
           <li>
-            <strong>USAF</strong> — engagement around MycoDrone as a deployment platform for
+            <strong>USAF</strong> — engagement around Agaric as a deployment platform for
             Mushroom 1, MycoNode, and SporeBase.
           </li>
           <li>


### PR DESCRIPTION
One-line cleanup. The USAF engagement bullet in Path D still said 'MycoDrone as a deployment platform for Mushroom 1, MycoNode, and SporeBase'. MycoDrone is retired; Agaric is the flying platform. Updated to match the rest of the docs.

## Summary by Sourcery

Documentation:
- Correct the USAF engagement bullet in the quickstart guide to reference Agaric as the deployment platform.