### PR TITLE
security: CVE-2026-31431 (Copy Fail) mitigation bundle

### DIFF
--- a/.github/workflows/cve-2026-31431-runner-precheck.yml
+++ b/.github/workflows/cve-2026-31431-runner-precheck.yml
@@ -1,0 +1,23 @@
+name: cve-2026-31431-runner-precheck
+
+on:
+  workflow_call: {}
+  workflow_dispatch: {}
+
+jobs:
+  kernel-precheck:
+    runs-on: self-hosted
+    steps:
+      - name: Refuse to run on unpatched runners
+        shell: bash
+        run: |
+          set -euo pipefail
+          if lsmod | awk '{print $1}' | grep -qx algif_aead; then
+            echo "::error::algif_aead loaded on runner -- CVE-2026-31431 exposure. Aborting."
+            exit 1
+          fi
+          if ! grep -rqE '^install\\s+algif_aead\\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+            echo "::error::CVE-2026-31431 mitigation not applied to runner."
+            exit 1
+          fi
+          echo "runner-precheck ok"

--- a/docs/security/cve-2026-31431-report.md
+++ b/docs/security/cve-2026-31431-report.md
@@ -1,0 +1,121 @@
+# CVE-2026-31431 ("Copy Fail") -- mitigation & adjacent-issue report
+
+**Status:** mitigation artifacts staged in this PR. Host-level rollout via
+`ops/ansible/cve-2026-31431.yml` is still pending operator action.
+
+**Repo scope:** `mycosoftlabs/website`
+
+## 1. Vulnerability summary
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-31431 |
+| Nickname | Copy Fail |
+| Class | Linux kernel local privilege escalation -> container escape |
+| Root cause | 2017 in-place optimisation in `algif_aead` crypto module |
+| Primitive | 4-byte write into page cache via `AF_ALG` + `splice()` chain |
+| Affected | All mainstream Linux distros, kernels 4.14 (2017) -> current pre-fix |
+| Disclosed | 2026-04-29 (Theori) |
+| Upstream fix | mainline commit `a664bf3d603d` -- VERIFY on kernel.org / distro tracker |
+| Public PoC | 732-byte Python script |
+
+A page-cache write does not touch the on-disk file, so any setuid binary
+(`/usr/bin/su`, `sudo`, `mount`, etc.) becomes a root trampoline until the
+cache page is evicted. Page cache is host-wide -- containers do not isolate it.
+
+## 2. What this PR adds
+
+| Path | Purpose |
+|---|---|
+| `scripts/security/cve-2026-31431-mitigate.sh` | Host mitigation (modprobe block + module unload) |
+| `scripts/security/cve-2026-31431-detect.sh` | Exit-code based detection probe |
+| `ops/ansible/cve-2026-31431.yml` | Fleet rollout via Ansible |
+| `ops/k8s/cve-2026-31431-kyverno-policy.yaml` | Cluster admission policy |
+| `ops/k8s/seccomp/block-af-alg.json` | Seccomp profile blocking `socket(AF_ALG)` |
+| `ops/k8s/cve-2026-31431-falco-rules.yaml` | Runtime detection rules |
+| `.github/workflows/cve-2026-31431-runner-precheck.yml` | Reusable Actions precheck |
+| `scripts/ci/runner-precheck.sh` | Self-hosted runner job-started hook |
+
+## 3. Rollout checklist (operator action required)
+
+- [ ] Confirm upstream commit `a664bf3d603d` against your distro security tracker; pin the kernel package version accordingly.
+- [ ] Run `ansible-playbook ops/ansible/cve-2026-31431.yml -i <inventory>` against:
+  - [ ] developer laptops / workstations
+  - [ ] bastion / jump hosts
+  - [ ] build servers and CI runners
+  - [ ] all Kubernetes nodes (control plane + workers)
+  - [ ] VM hosts (KVM / Proxmox)
+- [ ] Reboot each host after the playbook (page-cache flush).
+- [ ] Distribute `ops/k8s/seccomp/block-af-alg.json` to `/var/lib/kubelet/seccomp/` on every node, then apply the Kyverno policy.
+- [ ] Load the Falco rules into your Falco DaemonSet / sidecar.
+- [ ] Install `scripts/ci/runner-precheck.sh` as `ACTIONS_RUNNER_HOOK_JOB_STARTED` on every self-hosted runner.
+- [ ] Run `scripts/security/cve-2026-31431-detect.sh` from monitoring; alert on non-zero exit.
+
+## 4. Adjacent-issue audit (this repo)
+
+GitHub code search across `mycosoftlabs/*` for the relevant primitives:
+
+| Pattern | Hits in this repo | Notes |
+|---|---|---|
+| `AF_ALG`, `algif`, `algif_aead` | 0 | No application code touches the vulnerable interface. |
+| `splice`, `vmsplice` in `*.c/py/go/rs` | 0 | No userland splice() callers found. |
+| `privileged: true` in `*.yaml` | 0 | No privileged-container manifests surfaced. |
+| `hostNetwork` / `hostPID` / `hostIPC` | 0 | No host-namespace pods surfaced. |
+| `SYS_MODULE`, `CAP_SYS_ADMIN`, `allowPrivilegeEscalation` | 0 | No capability-elevating manifests surfaced. |
+| `USER root` in `Dockerfile` | 0 | No explicit root-Dockerfile pattern surfaced. |
+
+No direct application-code exposure detected. The risk is entirely at the
+host / kernel layer and is addressed by the bundle above.
+
+## 5. Related / class-similar CVEs to keep on the radar
+
+- **CVE-2022-0847 (Dirty Pipe)** -- pipe-buffer page-cache write; same
+  "write into page cache without touching disk" class. Patched long ago;
+  verify your minimum kernel is past 5.16.11 / 5.15.25 / 5.10.102.
+- **CVE-2022-2602 (io_uring + unix GC)** -- different vector, same
+  page-cache / fd-lifetime class.
+- **CVE-2023-32233 (Netfilter nf_tables UAF)** -- another LPE that
+  benefits from the same setuid-trampoline post-exploitation pattern.
+- **CVE-2024-1086 (nf_tables double-free)** -- ditto.
+- **Historical `algif_*` bugs** (`algif_skcipher`, `algif_hash`):
+  CVE-2017-13215 et al. Disabling the entire `algif_*` family (this PR
+  does that) closes the door on the whole module family, not just
+  `algif_aead`.
+
+## 6. Hardening recommendations beyond this patch
+
+1. Make the `algif_*` block permanent fleet policy even after kernel
+   upgrade -- almost no workload here needs userspace crypto via
+   `AF_ALG`.
+2. Adopt a default-deny seccomp policy at the cluster level; the
+   `block-af-alg.json` profile is a minimal starting point.
+3. Add a CI gate that runs `cve-2026-31431-detect.sh` against any
+   image / runner before scheduling work on it.
+4. Subscribe the SOC dashboard to the Falco rule output so AF_ALG
+   socket creation generates an immediate page.
+
+## 7. Verification commands
+
+```bash
+# host-side
+sudo bash scripts/security/cve-2026-31431-mitigate.sh
+bash scripts/security/cve-2026-31431-detect.sh && echo MITIGATED
+
+# kubernetes
+kubectl apply -f ops/k8s/cve-2026-31431-kyverno-policy.yaml
+kubectl get clusterpolicy cve-2026-31431-require-af-alg-seccomp
+
+# ci runner
+sudo install -m 0755 scripts/ci/runner-precheck.sh \
+  /home/runner/.actions/hooks/ACTIONS_RUNNER_HOOK_JOB_STARTED
+```
+
+## 8. Open questions / caveats
+
+- The upstream commit hash `a664bf3d603d` is taken from the public
+  disclosure post and was NOT independently verified against kernel.org
+  in this PR. Confirm before treating it as canonical.
+- The Kyverno policy assumes a Kyverno-managed cluster. Translate to OPA
+  / Gatekeeper or PSA labels if your cluster uses something else.
+- The Falco rules use `evt.arg.domain=AF_ALG`; older Falco builds may
+  need the numeric constant `38` instead.

--- a/ops/ansible/cve-2026-31431.yml
+++ b/ops/ansible/cve-2026-31431.yml
@@ -1,0 +1,63 @@
+---
+# Apply CVE-2026-31431 (Copy Fail) mitigation across the Linux fleet.
+# Idempotent. Re-running is safe.
+
+- name: Mitigate CVE-2026-31431 (Copy Fail)
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    modprobe_conf: /etc/modprobe.d/disable-algif.conf
+    algif_modules:
+      - algif_aead
+      - algif_hash
+      - algif_skcipher
+      - algif_rng
+
+  tasks:
+    - name: Persist modprobe block for algif_*
+      ansible.builtin.copy:
+        dest: "{{ modprobe_conf }}"
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          # Managed by ansible (CVE-2026-31431 mitigation).
+          {% for m in algif_modules %}
+          install {{ m }} /bin/false
+          {% endfor %}
+      notify: rebuild initramfs
+
+    - name: Unload algif_* modules if loaded
+      community.general.modprobe:
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ algif_modules }}"
+      failed_when: false
+
+    - name: Capture lsmod
+      ansible.builtin.shell: lsmod | awk '{print $1}'
+      register: lsmod_out
+      changed_when: false
+
+    - name: Fail if an algif module is still loaded
+      ansible.builtin.fail:
+        msg: "algif module still loaded: {{ item }}"
+      when: item in lsmod_out.stdout_lines
+      loop: "{{ algif_modules }}"
+
+    - name: Record mitigation marker
+      ansible.builtin.copy:
+        dest: /var/lib/cve-2026-31431.applied
+        content: "{{ ansible_date_time.iso8601 }}\n"
+        mode: "0644"
+
+  handlers:
+    - name: rebuild initramfs
+      ansible.builtin.shell: |
+        if command -v update-initramfs >/dev/null 2>&1; then
+          update-initramfs -u
+        elif command -v dracut >/dev/null 2>&1; then
+          dracut --force
+        fi

--- a/ops/k8s/cve-2026-31431-falco-rules.yaml
+++ b/ops/k8s/cve-2026-31431-falco-rules.yaml
@@ -1,0 +1,25 @@
+---
+# Falco rules for CVE-2026-31431 ("Copy Fail") detection.
+- macro: af_alg_socket
+  condition: (evt.type=socket and evt.arg.domain=AF_ALG)
+
+- rule: AF_ALG socket created
+  desc: >
+    Any process creating an AF_ALG socket. CVE-2026-31431 exploitation
+    requires this primitive. Almost nothing legitimate needs it.
+  condition: af_alg_socket and not proc.name in (cryptsetup, systemd-cryptsetup)
+  output: >
+    AF_ALG socket created
+    (user=%user.name pid=%proc.pid proc=%proc.name cmdline=%proc.cmdline
+     container=%container.id image=%container.image.repository)
+  priority: CRITICAL
+  tags: [cve-2026-31431, kernel, exploit]
+
+- rule: splice from AF_ALG fd
+  desc: splice() from an AF_ALG file descriptor (Copy Fail page-cache write primitive)
+  condition: evt.type=splice and (fd.type=alg or fd.l4proto=alg)
+  output: >
+    splice() from AF_ALG fd (CVE-2026-31431 primitive)
+    (user=%user.name pid=%proc.pid proc=%proc.name cmdline=%proc.cmdline)
+  priority: CRITICAL
+  tags: [cve-2026-31431, kernel, exploit]

--- a/ops/k8s/cve-2026-31431-kyverno-policy.yaml
+++ b/ops/k8s/cve-2026-31431-kyverno-policy.yaml
@@ -1,0 +1,48 @@
+---
+# Kyverno ClusterPolicy: require pods to land on a seccomp profile that
+# blocks socket(AF_ALG, ...). Pair with ops/k8s/seccomp/block-af-alg.json
+# distributed to every node under /var/lib/kubelet/seccomp/block-af-alg.json.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cve-2026-31431-require-af-alg-seccomp
+  annotations:
+    policies.kyverno.io/title: Block AF_ALG (CVE-2026-31431)
+    policies.kyverno.io/category: Kernel Hardening
+    policies.kyverno.io/severity: critical
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-block-af-alg-seccomp
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+      exclude:
+        any:
+          - resources:
+              namespaces: ["kube-system"]
+      validate:
+        message: >-
+          Pods must reference seccomp profile block-af-alg.json
+          (CVE-2026-31431). Set spec.securityContext.seccompProfile to
+          Localhost / block-af-alg.json or use the namespace default.
+        pattern:
+          spec:
+            securityContext:
+              seccompProfile:
+                type: Localhost
+                localhostProfile: "block-af-alg.json"
+    - name: forbid-host-namespaces
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+      validate:
+        message: hostNetwork/hostPID/hostIPC widen CVE-2026-31431 blast radius.
+        pattern:
+          spec:
+            =(hostNetwork): "false"
+            =(hostPID): "false"
+            =(hostIPC): "false"

--- a/ops/k8s/seccomp/block-af-alg.json
+++ b/ops/k8s/seccomp/block-af-alg.json
@@ -1,0 +1,14 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "syscalls": [
+    {
+      "names": ["socket", "socketpair"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 1,
+      "args": [
+        { "index": 0, "value": 38, "op": "SCMP_CMP_EQ" }
+      ],
+      "comment": "Deny AF_ALG (38) to mitigate CVE-2026-31431"
+    }
+  ]
+}

--- a/scripts/ci/runner-precheck.sh
+++ b/scripts/ci/runner-precheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Install as ACTIONS_RUNNER_HOOK_JOB_STARTED on self-hosted runners.
+set -euo pipefail
+
+if lsmod | awk '{print $1}' | grep -qx algif_aead; then
+    echo "[abort] algif_aead loaded -- runner unpatched (CVE-2026-31431)"
+    exit 1
+fi
+
+if ! grep -rqE '^install\s+algif_aead\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+    echo "[abort] CVE-2026-31431 mitigation not present"
+    exit 1
+fi
+
+exit 0

--- a/scripts/security/cve-2026-31431-detect.sh
+++ b/scripts/security/cve-2026-31431-detect.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Detect exposure to CVE-2026-31431 ("Copy Fail").
+# Exit codes:
+#   0 = mitigated
+#   1 = exposed
+#   2 = indeterminate
+
+set -uo pipefail
+
+status=0
+note() { printf '%s\n' "$*" >&2; }
+
+KERNEL=$(uname -r)
+note "kernel: ${KERNEL}"
+
+if grep -rqE '^install\s+algif_aead\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+    note "[ok] modprobe block present"
+else
+    note "[!] no modprobe block for algif_aead"
+    status=1
+fi
+
+if lsmod 2>/dev/null | awk '{print $1}' | grep -qx algif_aead; then
+    note "[!] algif_aead is loaded"
+    status=1
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import socket, sys
+try:
+    s = socket.socket(38, socket.SOCK_SEQPACKET, 0)  # AF_ALG = 38
+    s.close()
+    print("[!] AF_ALG socket creation succeeded from unprivileged context")
+    sys.exit(3)
+except OSError as e:
+    print(f"[ok] AF_ALG blocked: {e}")
+    sys.exit(0)
+PY
+    rc=$?
+    if [[ ${rc} -eq 3 ]]; then status=1; fi
+fi
+
+exit ${status}

--- a/scripts/security/cve-2026-31431-mitigate.sh
+++ b/scripts/security/cve-2026-31431-mitigate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# CVE-2026-31431 ("Copy Fail") host-level mitigation.
+#
+# Disables the algif_* kernel modules and persists the block via modprobe.
+# Reference: https://copy.fail/
+# Upstream fix: mainline commit a664bf3d603d -- VERIFY against your distro's
+# security advisory before treating the hash as authoritative.
+#
+# Run as root. Reboot recommended afterwards so page-cache pressure flushes
+# any potentially-tainted cached pages.
+
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "must run as root" >&2
+    exit 1
+fi
+
+CONF=/etc/modprobe.d/disable-algif.conf
+
+echo "[*] writing ${CONF}"
+cat >"${CONF}" <<'EOF'
+# Managed file. CVE-2026-31431 mitigation. Do not remove without a patched kernel.
+install algif_aead    /bin/false
+install algif_hash    /bin/false
+install algif_skcipher /bin/false
+install algif_rng     /bin/false
+EOF
+chmod 0644 "${CONF}"
+
+echo "[*] unloading algif_* modules"
+for mod in algif_aead algif_hash algif_skcipher algif_rng; do
+    if lsmod | awk '{print $1}' | grep -qx "${mod}"; then
+        rmmod "${mod}" 2>/dev/null || echo "[!] could not unload ${mod} (in use?)"
+    fi
+done
+
+echo "[*] rebuilding initramfs (best effort)"
+if command -v update-initramfs >/dev/null 2>&1; then
+    update-initramfs -u || true
+elif command -v dracut >/dev/null 2>&1; then
+    dracut --force || true
+fi
+
+echo "[+] mitigation applied. reboot recommended to flush page cache."


### PR DESCRIPTION
## Summary

Stages mitigation artifacts for **CVE-2026-31431 ("Copy Fail")** — a Linux kernel LPE / container-escape in `algif_aead` that lets any local user write 4 bytes into the page cache (e.g. into the in-memory copy of `/usr/bin/su`) and become root. Affects every mainstream Linux distro on unpatched kernels since 2017. Public disclosure: 2026-04-29.

This PR does **not** patch hosts — it ships the tooling. Host rollout is operator-driven via the Ansible playbook.

## What's included

- `scripts/security/cve-2026-31431-mitigate.sh` — host mitigation (modprobe block + `rmmod algif_*`)
- `scripts/security/cve-2026-31431-detect.sh` — detection probe (exit-code based)
- `ops/ansible/cve-2026-31431.yml` — fleet rollout
- `ops/k8s/cve-2026-31431-kyverno-policy.yaml` + `ops/k8s/seccomp/block-af-alg.json` — admission policy and seccomp profile to block `socket(AF_ALG)`
- `ops/k8s/cve-2026-31431-falco-rules.yaml` — runtime detection
- `.github/workflows/cve-2026-31431-runner-precheck.yml` + `scripts/ci/runner-precheck.sh` — refuse jobs on unpatched self-hosted runners
- `docs/security/cve-2026-31431-report.md` — full report incl. adjacent-issue audit and related CVEs

## Adjacent-issue audit (this repo)

GitHub code search returned **0 hits** for `AF_ALG`, `algif`, `algif_aead`, `splice`/`vmsplice`, `privileged: true`, `hostNetwork/PID/IPC`, `SYS_MODULE`/`CAP_SYS_ADMIN`, and `USER root` in Dockerfiles. No direct application-code exposure.

## Caveats

- The upstream commit `a664bf3d603d` cited in the disclosure was **not independently verified** here; confirm against kernel.org / your distro's security tracker before treating it as the canonical fix.
- Kyverno-specific — translate to OPA / Gatekeeper / PSA labels if your cluster uses a different admission controller.

## Test plan

- [ ] Run `bash scripts/security/cve-2026-31431-mitigate.sh` (root) on a staging box; reboot; verify `scripts/security/cve-2026-31431-detect.sh` exits 0.
- [ ] Dry-run `ansible-playbook ops/ansible/cve-2026-31431.yml --check -i <inventory>`.
- [ ] `kubectl apply --dry-run=server -f ops/k8s/cve-2026-31431-kyverno-policy.yaml` on staging cluster.
- [ ] Load Falco rules in a staging Falco DaemonSet; verify a deliberate `socket(AF_ALG)` triggers the rule.
- [ ] Install `runner-precheck.sh` on a single self-hosted runner; verify a deliberately unpatched runner refuses jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXuz2NPKgVn226KaV58czU)_

## Summary by Sourcery

Stage a mitigation toolkit for CVE-2026-31431 ("Copy Fail") across hosts, Kubernetes clusters, and CI runners, including documentation, detection, and enforcement artifacts.

New Features:
- Add host-side mitigation and detection scripts to disable vulnerable algif_* kernel modules and verify CVE-2026-31431 exposure status.
- Introduce an Ansible playbook to roll out the CVE-2026-31431 mitigation consistently across the Linux fleet.
- Add Kyverno policy and a seccomp profile to enforce blocking AF_ALG usage for Kubernetes pods and restrict host-namespace exposure.
- Define Falco runtime detection rules to alert on AF_ALG socket creation and related splice() primitives indicative of exploitation.
- Introduce a reusable GitHub Actions workflow and runner hook script to refuse jobs on unmitigated self-hosted runners.
- Add a detailed security report documenting CVE-2026-31431 impact, adjacent-issue audit, rollout steps, and hardening guidance.

CI:
- Add a precheck workflow for self-hosted GitHub Actions runners that fails jobs when CVE-2026-31431 mitigation is not present on the runner.

Deployment:
- Add Kubernetes security artifacts (Kyverno policy, seccomp profile, Falco rules) to enforce and monitor CVE-2026-31431 mitigations at cluster level.

Documentation:
- Add a comprehensive security report for CVE-2026-31431 covering vulnerability details, repo exposure audit, rollout checklist, related CVEs, and verification guidance.