### PR TITLE
[codex] Fix live auth gateway headers

### DIFF
--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -38,6 +38,15 @@ http {
   keepalive_requests 1000;
   types_hash_max_size 2048;
 
+  # Supabase SSR auth can emit multiple chunked Set-Cookie headers on login,
+  # and authenticated requests send those cookies back through this proxy.
+  # Keep enough header room so successful sign-ins do not become nginx 502s.
+  client_header_buffer_size 16k;
+  large_client_header_buffers 8 32k;
+  proxy_buffer_size 32k;
+  proxy_buffers 8 32k;
+  proxy_busy_buffers_size 64k;
+
   # Proxy buffering for RSC / streamed responses
   proxy_buffering off;          # Next.js RSC streams — don't buffer
   proxy_http_version 1.1;

--- a/docker-compose.production.blue-green.yml
+++ b/docker-compose.production.blue-green.yml
@@ -68,6 +68,8 @@ services:
       - NODE_ENV=production
       - PORT=3000
       - HOSTNAME=0.0.0.0
+      # Supabase auth uses chunked cookies; keep authenticated request headers accepted.
+      - NODE_OPTIONS=${NODE_OPTIONS:---max-http-header-size=32768}
       - DEPLOY_SLOT=blue
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=redis://redis:6379
@@ -134,6 +136,8 @@ services:
       - NODE_ENV=production
       - PORT=3000
       - HOSTNAME=0.0.0.0
+      # Supabase auth uses chunked cookies; keep authenticated request headers accepted.
+      - NODE_OPTIONS=${NODE_OPTIONS:---max-http-header-size=32768}
       - DEPLOY_SLOT=green
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=redis://redis:6379

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -74,6 +74,8 @@ services:
       # Next.js standalone binds to HOSTNAME — force 0.0.0.0 so healthcheck
       # (curl localhost:3000) works regardless of container/VM hostname.
       - HOSTNAME=0.0.0.0
+      # Supabase auth uses chunked cookies; keep authenticated request headers accepted.
+      - NODE_OPTIONS=${NODE_OPTIONS:---max-http-header-size=32768}
       # Data layer (in-stack)
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=redis://redis:6379

--- a/scripts/blue-green-deploy.sh
+++ b/scripts/blue-green-deploy.sh
@@ -10,7 +10,7 @@
 #   3. Pull new image from GHCR into the idle slot's image env var
 #   4. Start idle slot container
 #   5. Wait for idle /api/health to pass 3× in a row (max 180s)
-#   6. Render nginx conf.d pointing at idle slot + `nginx -s reload` inside proxy
+#   6. Sync nginx.conf, render conf.d pointing at idle slot + `nginx -s reload` inside proxy
 #   7. Flip /opt/mycosoft/state/active-slot to the new slot
 #   8. Purge Cloudflare cache (purge_everything)
 #   9. Public verification: mycosoft.com must serve the new slot (check header)
@@ -93,6 +93,18 @@ cd "$DEPLOY_DIR"
 
 # ───── Helpers ──────────────────────────────────────────────────────────────
 compose() { docker compose "${COMPOSE_FILES[@]}" "$@"; }
+
+install_nginx_base_conf() {
+  local src="$DEPLOY_DIR/deploy/nginx/nginx.conf"
+  local dst="$NGINX_DIR/nginx.conf"
+  [[ -f "$src" ]] || { err "Missing nginx base config: $src"; return 1; }
+  if [[ ! -f "$dst" ]] || ! cmp -s "$src" "$dst"; then
+    cp "$src" "$dst"
+    ok "Installed nginx base config ($dst)"
+  else
+    log "nginx base config already current"
+  fi
+}
 
 render_nginx_conf_for() {
   local target="$1" # "blue" or "green"
@@ -217,6 +229,7 @@ if [[ "$MODE" == "rollback" ]]; then
     fi
     wait_healthy "$IDLE" || { err "Rollback failed — idle slot didn't come back"; exit 6; }
   fi
+  install_nginx_base_conf
   render_nginx_conf_for "$IDLE"
   reload_proxy
   echo "$IDLE" > "$ACTIVE_FILE"
@@ -277,6 +290,7 @@ if ! wait_healthy "$IDLE"; then
 fi
 
 # 4. Render nginx conf.d pointing at idle slot + graceful reload
+install_nginx_base_conf
 render_nginx_conf_for "$IDLE"
 if ! reload_proxy; then
   err "nginx reload failed — REVERTING conf"


### PR DESCRIPTION
## What changed

- Enlarged nginx request/response header buffers for Supabase SSR auth cookies.
- Added `NODE_OPTIONS=--max-http-header-size=32768` to the production website containers.
- Updated the blue/green deploy script so nginx base config changes are synced before proxy reloads.

## Why

Successful Supabase login can emit chunked auth cookies and authenticated requests return those cookies through Cloudflare/nginx/Next. Without coordinated header limits, the login path can present as a gateway failure even though Supabase and the app are otherwise healthy.

## Validation

- `git diff --check`
- `bash -n scripts/blue-green-deploy.sh`
- `bash -n scripts/blue-green-bootstrap.sh`
- `docker compose -f docker-compose.production.yml -f docker-compose.production.blue-green.yml config --quiet`
- Live production already verified with `/healthz`, `/api/health`, fake-login POST, and large-cookie auth-path probes.

## Summary by Sourcery

Align header size limits across nginx and Node.js to prevent Supabase auth cookies from causing gateway errors and ensure blue/green deploys sync the base nginx config before reloads.

Bug Fixes:
- Prevent nginx 502/gateway failures on Supabase logins and authenticated requests by increasing nginx and Node.js HTTP header size limits.

Deployment:
- Ensure blue/green deployments install/sync the base nginx.conf before rendering vhost configs and reloading the proxy.
- Set NODE_OPTIONS with a larger default max HTTP header size for production website containers in both single and blue/green docker-compose setups.