### PR TITLE
feat(natureos/devices): live OpenClaw control + COM7-style command console

### DIFF
--- a/__tests__/devices-agent-resolver.test.ts
+++ b/__tests__/devices-agent-resolver.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "@jest/globals"
+import { agentUrlForHost } from "@/lib/devices/agent-resolver"
+
+describe("agentUrlForHost", () => {
+  it("returns the matching operator URL when host matches", () => {
+    process.env.MYCOBRAIN_OPERATOR_URLS =
+      "http://192.168.0.228:8787,http://192.168.0.123:8787"
+    expect(agentUrlForHost("192.168.0.228")).toBe("http://192.168.0.228:8787")
+    expect(agentUrlForHost("192.168.0.123")).toBe("http://192.168.0.123:8787")
+  })
+  it("returns null for unknown host", () => {
+    expect(agentUrlForHost("10.0.0.1")).toBeNull()
+  })
+})

--- a/app/api/devices/[deviceId]/openclaw/action/route.ts
+++ b/app/api/devices/[deviceId]/openclaw/action/route.ts
@@ -1,11 +1,10 @@
 /**
- * POST /api/devices/:deviceId/command
+ * POST /api/devices/:deviceId/openclaw/action
  *
- * COM7-bench-style live command surface. Proxies a single MDP COMMAND to the
- * device\'s :8787 agent. Useful for: output_control (LED, buzzer, MOSFET),
- * stream_sensors, read_sensors, estop / clear_estop, Side B transport directives.
- *
- * Auth: company-gated. Operator email is attached for audit.
+ * Proxies a claw action to the device\'s :8787 agent. Auth: company-gated.
+ * The operator\'s email is attached as `user_subject` for audit. The
+ * Supabase session cookie is converted into a Bearer token the agent can
+ * verify against Supabase JWKS.
  */
 
 import { NextRequest, NextResponse } from "next/server"
@@ -16,12 +15,10 @@ import { resolveAgentUrl } from "@/lib/devices/agent-resolver"
 
 export const dynamic = "force-dynamic"
 
-interface CommandBody {
-  target: "side_a" | "side_b"
-  cmd: string
+interface ActionBody {
+  action: string
   params?: Record<string, unknown>
-  ack_requested?: boolean
-  timeout_ms?: number
+  request_id?: string
 }
 
 export async function POST(
@@ -48,15 +45,15 @@ export async function POST(
   const { data: { session } } = await supabase.auth.getSession()
   const bearer = session?.access_token
 
-  let body: CommandBody
-  try { body = await req.json() }
-  catch { return NextResponse.json({ error: "bad_json" }, { status: 400 }) }
-
-  if (!body.target || !body.cmd) {
-    return NextResponse.json({ error: "missing_target_or_cmd" }, { status: 400 })
+  let body: ActionBody
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "bad_json" }, { status: 400 })
   }
-  if (body.target !== "side_a" && body.target !== "side_b") {
-    return NextResponse.json({ error: "bad_target" }, { status: 400 })
+
+  if (!body.action || typeof body.action !== "string") {
+    return NextResponse.json({ error: "missing_action" }, { status: 400 })
   }
 
   const agentUrl = await resolveAgentUrl(params.deviceId)
@@ -64,8 +61,12 @@ export async function POST(
     return NextResponse.json({ error: "no_agent_for_device" }, { status: 404 })
   }
 
+  const requestId =
+    body.request_id ||
+    `nat-${Math.random().toString(36).slice(2, 10)}-${Date.now()}`
+
   try {
-    const res = await fetch(`${agentUrl}/command`, {
+    const res = await fetch(`${agentUrl}/openclaw/action`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -73,23 +74,25 @@ export async function POST(
         ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
       },
       body: JSON.stringify({
-        target: body.target,
-        cmd: body.cmd,
+        action: body.action,
         params: body.params || {},
-        ack_requested: body.ack_requested !== false,
-        timeout_ms: body.timeout_ms || 2000,
+        request_id: requestId,
         user_subject: user.email,
       }),
-      signal: AbortSignal.timeout((body.timeout_ms || 2000) + 3000),
+      signal: AbortSignal.timeout(8000),
       cache: "no-store",
     })
-    const text = await res.text()
+    const responseBody = await res.text()
     let parsed: unknown
-    try { parsed = JSON.parse(text) } catch { parsed = { raw: text } }
+    try {
+      parsed = JSON.parse(responseBody)
+    } catch {
+      parsed = { raw: responseBody }
+    }
     return NextResponse.json(parsed, { status: res.status })
   } catch (err) {
     return NextResponse.json(
-      { ok: false, error: (err as Error).message },
+      { ok: false, error: (err as Error).message, request_id: requestId },
       { status: 502 }
     )
   }

--- a/app/api/devices/[deviceId]/openclaw/status/route.ts
+++ b/app/api/devices/[deviceId]/openclaw/status/route.ts
@@ -1,0 +1,57 @@
+/**
+ * GET /api/devices/:deviceId/openclaw/status
+ *
+ * Proxies to <agent_url>/openclaw/status on the device\'s :8787 agent.
+ * Auth: company-gated (Supabase session with @mycosoft.org/.com email).
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+import { isCompanyEmail } from "@/lib/access/types"
+import { resolveAgentUrl } from "@/lib/devices/agent-resolver"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { deviceId: string } }
+) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return NextResponse.json({ error: "config_missing" }, { status: 500 })
+  }
+
+  const cookieStore = cookies()
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() { return cookieStore.getAll() },
+      setAll() { /* noop for read-only handler */ },
+    },
+  })
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user || !isCompanyEmail(user.email)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 })
+  }
+
+  const agentUrl = await resolveAgentUrl(params.deviceId)
+  if (!agentUrl) {
+    return NextResponse.json({ available: false, reason: "no_agent" })
+  }
+
+  try {
+    const res = await fetch(`${agentUrl}/openclaw/status`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+      cache: "no-store",
+    })
+    const body = await res.json()
+    return NextResponse.json(body, { status: res.status })
+  } catch (err) {
+    return NextResponse.json(
+      { available: true, ready: false, error: (err as Error).message },
+      { status: 502 }
+    )
+  }
+}

--- a/app/natureos/devices/[deviceId]/page.tsx
+++ b/app/natureos/devices/[deviceId]/page.tsx
@@ -28,6 +28,8 @@ import Link from "next/link"
 import { useParams } from "next/navigation"
 import { useEffect, useState } from "react"
 import { getRoleConfigForDevice } from "@/lib/device-configs"
+import { OpenClawPanel } from "@/components/devices/openclaw-panel"
+import { LiveCommandConsole } from "@/components/devices/live-command-console"
 
 interface DeviceInfo {
   deviceId: string
@@ -345,14 +347,11 @@ export default function DeviceDetailPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <DeviceTelemetryCard
-              deviceId={device.deviceId}
-              deviceName={displayName}
-              role={device.device_role}
-              status={device.status}
-              pollIntervalMs={5000}
-            />
-          </CardContent>
+            <DeviceTelemetryCard deviceId={device?.deviceId ?? deviceId} />
+        {/* LIVE OPENCLAW + COMMAND CONSOLE (PR #9, May 2026) */}
+        <OpenClawPanel deviceId={device?.deviceId ?? deviceId} />
+        <LiveCommandConsole deviceId={device?.deviceId ?? deviceId} />
+        </CardContent>
         </Card>
 
         {/* Command Panel - only for online devices */}

--- a/components/devices/live-command-console.tsx
+++ b/components/devices/live-command-console.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Loader2, Terminal, Lightbulb, Volume2, Power } from "lucide-react"
+
+interface CommandResult {
+  ok?: boolean
+  seq?: number
+  ack?: { received_at?: string; success?: boolean; message?: string }
+  telemetry?: unknown
+  error?: string
+}
+
+interface Entry {
+  ts: string
+  target: string
+  cmd: string
+  params: Record<string, unknown>
+  result: CommandResult
+  ms: number
+}
+
+interface Props {
+  deviceId: string
+}
+
+const QUICK_ACTIONS: Array<{
+  label: string
+  icon: React.ReactNode
+  target: "side_a" | "side_b"
+  cmd: string
+  params: Record<string, unknown>
+}> = [
+  {
+    label: "Read sensors",
+    icon: <Terminal className="h-4 w-4" />,
+    target: "side_a",
+    cmd: "read_sensors",
+    params: {},
+  },
+  {
+    label: "LED red",
+    icon: <Lightbulb className="h-4 w-4" />,
+    target: "side_a",
+    cmd: "output_control",
+    params: { id: "neopixel", value: 1, r: 255, g: 0, b: 0 },
+  },
+  {
+    label: "LED green",
+    icon: <Lightbulb className="h-4 w-4" />,
+    target: "side_a",
+    cmd: "output_control",
+    params: { id: "neopixel", value: 1, r: 0, g: 255, b: 0 },
+  },
+  {
+    label: "LED off",
+    icon: <Lightbulb className="h-4 w-4" />,
+    target: "side_a",
+    cmd: "output_control",
+    params: { id: "neopixel", value: 0 },
+  },
+  {
+    label: "Buzzer ding",
+    icon: <Volume2 className="h-4 w-4" />,
+    target: "side_a",
+    cmd: "output_control",
+    params: { id: "buzzer", value: 1, freq: 1200, duration_ms: 200 },
+  },
+  {
+    label: "Estop",
+    icon: <Power className="h-4 w-4" />,
+    target: "side_a",
+    cmd: "estop",
+    params: {},
+  },
+  {
+    label: "Clear estop",
+    icon: <Power className="h-4 w-4" />,
+    target: "side_a",
+    cmd: "clear_estop",
+    params: {},
+  },
+  {
+    label: "Transport status",
+    icon: <Terminal className="h-4 w-4" />,
+    target: "side_b",
+    cmd: "transport_status",
+    params: {},
+  },
+]
+
+export function LiveCommandConsole({ deviceId }: Props) {
+  const [history, setHistory] = useState<Entry[]>([])
+  const [pending, setPending] = useState<string | null>(null)
+  const [target, setTarget] = useState<"side_a" | "side_b">("side_a")
+  const [cmd, setCmd] = useState<string>("read_sensors")
+  const [paramsText, setParamsText] = useState<string>("{}")
+
+  async function send(
+    t: "side_a" | "side_b",
+    c: string,
+    p: Record<string, unknown>,
+    label?: string,
+  ) {
+    if (pending) return
+    const key = label || `${t}:${c}`
+    setPending(key)
+    const startedAt = Date.now()
+    try {
+      const res = await fetch(
+        `/api/devices/${encodeURIComponent(deviceId)}/command`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            target: t,
+            cmd: c,
+            params: p,
+            ack_requested: true,
+          }),
+        }
+      )
+      const result = (await res.json()) as CommandResult
+      setHistory((prev) =>
+        [
+          {
+            ts: new Date().toISOString(),
+            target: t,
+            cmd: c,
+            params: p,
+            result,
+            ms: Date.now() - startedAt,
+          },
+          ...prev,
+        ].slice(0, 30)
+      )
+    } catch (err) {
+      setHistory((prev) =>
+        [
+          {
+            ts: new Date().toISOString(),
+            target: t,
+            cmd: c,
+            params: p,
+            result: { ok: false, error: (err as Error).message },
+            ms: Date.now() - startedAt,
+          },
+          ...prev,
+        ].slice(0, 30)
+      )
+    } finally {
+      setPending(null)
+    }
+  }
+
+  function sendCustom() {
+    let parsed: Record<string, unknown> = {}
+    try {
+      parsed = JSON.parse(paramsText || "{}")
+    } catch (err) {
+      alert(`Bad JSON in params: ${(err as Error).message}`)
+      return
+    }
+    send(target, cmd, parsed, "custom")
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Terminal className="h-4 w-4" /> Live Command Console
+        </CardTitle>
+        <CardDescription className="text-xs">
+          Direct MDP command surface — same vocabulary as the COM7 bench session, now over `:8787/command`.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Quick actions */}
+        <div className="flex flex-wrap gap-2">
+          {QUICK_ACTIONS.map((q) => (
+            <Button
+              key={q.label}
+              size="sm"
+              variant="outline"
+              onClick={() => send(q.target, q.cmd, q.params, q.label)}
+              disabled={!!pending}
+            >
+              {pending === q.label ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              ) : (
+                <span className="mr-1">{q.icon}</span>
+              )}
+              {q.label}
+            </Button>
+          ))}
+        </div>
+
+        {/* Custom command form */}
+        <div className="grid gap-2 md:grid-cols-[auto_1fr_2fr_auto] md:items-end">
+          <div>
+            <Label className="text-xs">target</Label>
+            <select
+              value={target}
+              onChange={(e) => setTarget(e.target.value as "side_a" | "side_b")}
+              className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+              disabled={!!pending}
+            >
+              <option value="side_a">side_a</option>
+              <option value="side_b">side_b</option>
+            </select>
+          </div>
+          <div>
+            <Label className="text-xs">cmd</Label>
+            <Input
+              value={cmd}
+              onChange={(e) => setCmd(e.target.value)}
+              disabled={!!pending}
+              className="h-9"
+            />
+          </div>
+          <div>
+            <Label className="text-xs">params (JSON)</Label>
+            <Input
+              value={paramsText}
+              onChange={(e) => setParamsText(e.target.value)}
+              disabled={!!pending}
+              className="h-9 font-mono"
+            />
+          </div>
+          <Button size="sm" onClick={sendCustom} disabled={!!pending}>
+            {pending === "custom" ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : null}
+            Send
+          </Button>
+        </div>
+
+        {/* History */}
+        {history.length > 0 && (
+          <div>
+            <div className="text-xs text-muted-foreground mb-1">History</div>
+            <div className="space-y-1 max-h-64 overflow-auto font-mono text-xs">
+              {history.map((h, i) => (
+                <div key={i} className="border-l-2 pl-2 py-1" style={{
+                  borderColor: h.result.ok ? "rgb(34,197,94)" : "rgb(239,68,68)"
+                }}>
+                  <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                    <span>{new Date(h.ts).toLocaleTimeString()}</span>
+                    <span>{h.target} / {h.cmd}</span>
+                    <span>{h.ms}ms</span>
+                    <span className={h.result.ok ? "text-green-500" : "text-destructive"}>
+                      {h.result.ok ? "✓" : "✗"}
+                    </span>
+                  </div>
+                  {h.result.error && (
+                    <div className="text-destructive">{h.result.error}</div>
+                  )}
+                  {h.result.ack && (
+                    <div>ack: {h.result.ack.message || (h.result.ack.success ? "ok" : "fail")}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/devices/openclaw-panel.tsx
+++ b/components/devices/openclaw-panel.tsx
@@ -1,0 +1,274 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Slider } from "@/components/ui/slider"
+import {
+  Loader2,
+  Hand,
+  Power,
+  Settings,
+  AlertOctagon,
+  RotateCw,
+} from "lucide-react"
+
+interface OpenClawStatus {
+  available: boolean
+  ready?: boolean
+  position?: number
+  is_closed?: boolean
+  force_adc?: number
+  mode?: number | string
+  calibrated?: boolean
+  estop_latched?: boolean
+  error?: string
+}
+
+interface ActionResult {
+  ok: boolean
+  request_id?: string
+  audit_id?: number
+  started_at?: string
+  completed_at?: string
+  result?: unknown
+  error?: string
+}
+
+interface Props {
+  deviceId: string
+}
+
+export function OpenClawPanel({ deviceId }: Props) {
+  const [status, setStatus] = useState<OpenClawStatus | null>(null)
+  const [position, setPosition] = useState<number>(90)
+  const [pending, setPending] = useState<string | null>(null)
+  const [lastResult, setLastResult] = useState<ActionResult | null>(null)
+  const [actions, setActions] = useState<Array<{ action: string; ts: string; ok: boolean; ms: number }>>([])
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/devices/${encodeURIComponent(deviceId)}/openclaw/status`,
+        { cache: "no-store" }
+      )
+      const body = (await res.json()) as OpenClawStatus
+      setStatus(body)
+      if (typeof body.position === "number") setPosition(body.position)
+    } catch (err) {
+      setStatus({ available: false, error: (err as Error).message })
+    }
+  }, [deviceId])
+
+  useEffect(() => {
+    refresh()
+    const id = setInterval(refresh, 5000)
+    return () => clearInterval(id)
+  }, [refresh])
+
+  async function fireAction(action: string, params: Record<string, unknown> = {}) {
+    if (pending) return
+    setPending(action)
+    const startedAt = Date.now()
+    try {
+      const res = await fetch(
+        `/api/devices/${encodeURIComponent(deviceId)}/openclaw/action`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action, params }),
+        }
+      )
+      const body = (await res.json()) as ActionResult
+      setLastResult(body)
+      setActions((prev) =>
+        [
+          {
+            action,
+            ts: new Date().toISOString(),
+            ok: !!body.ok,
+            ms: Date.now() - startedAt,
+          },
+          ...prev,
+        ].slice(0, 8)
+      )
+      // Re-fetch status after action for fast feedback
+      setTimeout(refresh, 300)
+    } catch (err) {
+      setLastResult({ ok: false, error: (err as Error).message })
+    } finally {
+      setPending(null)
+    }
+  }
+
+  if (!status) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <Loader2 className="h-4 w-4 animate-spin" /> Probing OpenClaw…
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!status.available) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">OpenClaw</CardTitle>
+          <CardDescription>
+            Not available on this device {status.error ? `(${status.error})` : ""}
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  const estop = status.estop_latched === true
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Hand className="h-4 w-4" /> OpenClaw
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            {estop && (
+              <Badge variant="destructive" className="text-[10px]">
+                ESTOP latched
+              </Badge>
+            )}
+            <Badge variant={status.ready ? "default" : "secondary"} className="text-[10px]">
+              {status.ready ? "READY" : "not ready"}
+            </Badge>
+          </div>
+        </div>
+        <CardDescription className="text-xs">
+          Live control over `:8787/openclaw/action` → MDP claw commands `0x0030`–`0x003F`
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Position read-out */}
+        <div className="grid grid-cols-3 gap-3 text-xs">
+          <div>
+            <div className="text-muted-foreground">Position</div>
+            <div className="text-2xl font-mono">
+              {typeof status.position === "number" ? `${status.position}°` : "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-muted-foreground">Gripper</div>
+            <div className="text-2xl font-mono">
+              {status.is_closed === true ? "Closed" : status.is_closed === false ? "Open" : "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-muted-foreground">Force ADC</div>
+            <div className="text-2xl font-mono">
+              {typeof status.force_adc === "number" ? status.force_adc : "—"}
+            </div>
+          </div>
+        </div>
+
+        {/* Quick-action buttons */}
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            onClick={() => fireAction("grip")}
+            disabled={!!pending || estop}
+          >
+            {pending === "grip" ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Hand className="h-4 w-4 mr-1" />}
+            Grip
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => fireAction("release")}
+            disabled={!!pending || estop}
+          >
+            {pending === "release" ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Power className="h-4 w-4 mr-1" />}
+            Release
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => fireAction("calibrate")}
+            disabled={!!pending || estop}
+          >
+            <Settings className="h-4 w-4 mr-1" /> Calibrate
+          </Button>
+          {!estop ? (
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => fireAction("estop")}
+              disabled={!!pending}
+            >
+              <AlertOctagon className="h-4 w-4 mr-1" /> ESTOP
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              onClick={() => fireAction("clear_estop")}
+              disabled={!!pending}
+            >
+              <RotateCw className="h-4 w-4 mr-1" /> Clear ESTOP
+            </Button>
+          )}
+        </div>
+
+        {/* Position slider */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">Position: {position}°</span>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => fireAction("position", { angle: position })}
+              disabled={!!pending || estop}
+            >
+              {pending === "position" ? <Loader2 className="h-4 w-4 animate-spin" /> : "Apply"}
+            </Button>
+          </div>
+          <Slider
+            value={[position]}
+            onValueChange={(v) => setPosition(v[0] ?? 90)}
+            min={0}
+            max={180}
+            step={1}
+            disabled={!!pending || estop}
+          />
+        </div>
+
+        {/* Recent actions */}
+        {actions.length > 0 && (
+          <div>
+            <div className="text-xs text-muted-foreground mb-1">Recent actions</div>
+            <div className="space-y-1 max-h-32 overflow-auto">
+              {actions.map((a, i) => (
+                <div key={i} className="text-xs font-mono flex items-center gap-2">
+                  <span className="text-muted-foreground">
+                    {new Date(a.ts).toLocaleTimeString()}
+                  </span>
+                  <span>{a.action}</span>
+                  <span className="text-muted-foreground">{a.ms}ms</span>
+                  <span className={a.ok ? "text-green-500" : "text-destructive"}>
+                    {a.ok ? "✓" : "✗"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {lastResult && !lastResult.ok && lastResult.error && (
+          <div className="text-xs text-destructive">
+            Last error: {lastResult.error}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/access/routes.ts
+++ b/lib/access/routes.ts
@@ -35,15 +35,6 @@ export const PUBLIC_ROUTES: RouteAccess[] = [
   { path: '/natureos/crep', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'CREP Dashboard' },
   { path: '/natureos/fusarium', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'FUSARIUM' },
   { path: '/natureos/earth-simulator', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Earth Simulator (NatureOS)' },
-  { path: '/natureos/devices', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Device Network' },
-  { path: '/natureos/devices/registry', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Device Registry' },
-  { path: '/natureos/devices/telemetry', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Device Telemetry' },
-  { path: '/natureos/devices/alerts', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Device Alerts' },
-  { path: '/natureos/devices/map', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Device Map' },
-  { path: '/natureos/devices/fleet', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Device Fleet' },
-  { path: '/natureos/devices/insights', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Device Insights' },
-  { path: '/natureos/devices/network', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'Device Network Map' },
-  { path: '/natureos/devices/onsite-ai', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'On-Site AI' },
   { path: '/natureos/settings', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'System Settings' },
   { path: '/natureos/api', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'API Explorer' },
   { path: '/dashboard/crep', gate: AccessGate.PUBLIC, config: { gate: AccessGate.PUBLIC, minimumRole: UserRole.ANONYMOUS }, description: 'CREP Dashboard (public)' },
@@ -153,6 +144,16 @@ export const COMPANY_ROUTES: RouteAccess[] = [
   { path: '/natureos/storage', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Storage' },
   { path: '/natureos/containers', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Containers' },
   { path: '/natureos/monitoring', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Monitoring' },
+  { path: '/natureos/devices', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Device Network' },
+  { path: '/natureos/devices/registry', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Device Registry' },
+  { path: '/natureos/devices/telemetry', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Device Telemetry' },
+  { path: '/natureos/devices/alerts', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Device Alerts' },
+  { path: '/natureos/devices/map', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Device Map' },
+  { path: '/natureos/devices/fleet', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Device Fleet' },
+  { path: '/natureos/devices/insights', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Device Insights' },
+  { path: '/natureos/devices/network', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'Device Network Map' },
+  { path: '/natureos/devices/onsite-ai', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'On-Site AI' },
+
 ]
 
 // Premium routes - require subscription

--- a/lib/devices/agent-resolver.ts
+++ b/lib/devices/agent-resolver.ts
@@ -1,16 +1,24 @@
 /**
  * Per-device agent URL resolver.
  *
- * Looks up where a deviceId's mycobrain-agent lives, by:
- *   1. Direct env override: MYCOBRAIN_OPERATOR_URLS (host list, port :8787 assumed)
- *      with the device's host matching one of them via /api/devices/network registry
- *   2. Fallback to legacy MYCOBRAIN_SERVICE_URL (:8003) for devices we don\'t yet
- *      have a unified agent for
+ * Looks up where a deviceId's mycobrain-agent lives, in priority order:
  *
- * The website does NOT need to know about every device statically — the MAS
- * device registry at /api/devices/network is the source of truth, and includes
- * each device\'s `host` (LAN IP). Combined with MYCOBRAIN_OPERATOR_URLS, we
- * route to the right :8787.
+ *   1. MAS device registry (`${MAS_API_URL}/api/devices`)
+ *      Devices that have heartbeat-registered with MAS publish their
+ *      `host` and (post unified-agent) `agent_url`.
+ *
+ *   2. Local /api/mycobrain operator probes
+ *      The website probes MYCOBRAIN_OPERATOR_URLS directly via
+ *      /api/mycobrain. Any device that came back with
+ *      `source: "operator-http"` AND a host/port can be matched here.
+ *      This is the path that finds devices not yet in MAS (e.g. the
+ *      live Pi at 192.168.0.123 today).
+ *
+ *   3. MYCOBRAIN_OPERATOR_URLS host match (last resort)
+ *      If the deviceId's suffix encodes the host (e.g. "...-192-168-0-123"),
+ *      try to map it directly.
+ *
+ * Returns the agent's base URL (no trailing slash) or null.
  */
 
 const OPERATOR_HOSTS = (
@@ -28,16 +36,23 @@ interface RegistryDevice {
   host?: string
   port?: number
   openclaw_url?: string | null
+  agent_url?: string
+}
+
+interface OperatorDevice {
+  device_id: string
+  source?: string
+  network_host?: string
+  network_port?: number | string
 }
 
 let registryCache: { ts: number; devices: RegistryDevice[] } | null = null
-const REGISTRY_TTL_MS = 30_000
+let operatorCache: { ts: number; devices: OperatorDevice[] } | null = null
+const TTL_MS = 30_000
 
 async function fetchRegistry(): Promise<RegistryDevice[]> {
   const now = Date.now()
-  if (registryCache && now - registryCache.ts < REGISTRY_TTL_MS) {
-    return registryCache.devices
-  }
+  if (registryCache && now - registryCache.ts < TTL_MS) return registryCache.devices
   try {
     const res = await fetch(`${MAS_API_URL}/api/devices`, {
       headers: { Accept: "application/json" },
@@ -54,34 +69,82 @@ async function fetchRegistry(): Promise<RegistryDevice[]> {
   }
 }
 
-/**
- * Resolve the agent URL (port 8787) for a given device, or null if the device
- * isn\'t reachable via the unified agent path.
- */
-export async function resolveAgentUrl(deviceId: string): Promise<string | null> {
-  const registry = await fetchRegistry()
-  const device = registry.find((d) => d.device_id === deviceId)
-  if (!device) return null
-
-  // Prefer the agent URL the device self-reported, if it has one matching :8787
-  // (post unified-agent rollout, every agent registers with `agent_url`).
-  const reportedUrl = (device as { agent_url?: string }).agent_url
-  if (typeof reportedUrl === "string" && /:8787\/?$/.test(reportedUrl)) {
-    return reportedUrl.replace(/\/+$/, "")
+async function fetchOperatorDevices(): Promise<OperatorDevice[]> {
+  const now = Date.now()
+  if (operatorCache && now - operatorCache.ts < TTL_MS) return operatorCache.devices
+  // Use the site's own /api/mycobrain endpoint which already probes
+  // MYCOBRAIN_OPERATOR_URLS at :8787 and returns normalized devices.
+  // We call it absolutely via the request origin when available, else via
+  // a same-origin relative path; in route handlers we fall back to env.
+  const base =
+    process.env.WEBSITE_INTERNAL_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "http://localhost:3000"
+  try {
+    const res = await fetch(`${base.replace(/\/+$/, "")}/api/mycobrain`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(8000),
+      cache: "no-store",
+    })
+    if (!res.ok) return []
+    const data = await res.json()
+    const devices: OperatorDevice[] = data.devices || []
+    operatorCache = { ts: now, devices }
+    return devices
+  } catch {
+    return []
   }
+}
 
-  // Else match by host against MYCOBRAIN_OPERATOR_URLS
-  if (device.host) {
-    const match = OPERATOR_HOSTS.find((u) => new URL(u).hostname === device.host)
-    if (match) return match
-  }
-  return null
+function hostFromDeviceIdSuffix(deviceId: string): string | null {
+  // e.g. mycobrain-sidea-10b41d-amb-192-168-0-123 -> 192.168.0.123
+  const m = deviceId.match(/(\d{1,3})-(\d{1,3})-(\d{1,3})-(\d{1,3})$/)
+  if (!m) return null
+  return `${m[1]}.${m[2]}.${m[3]}.${m[4]}`
 }
 
 /**
- * Same idea but synchronous — for callers that already have a `host` string
- * (e.g. from a parent request that already fetched the registry).
+ * Resolve the agent URL (port 8787) for a given device, or null if the device
+ * isn't reachable via the unified agent path.
  */
+export async function resolveAgentUrl(deviceId: string): Promise<string | null> {
+  // 1. MAS registry
+  const registry = await fetchRegistry()
+  const masMatch = registry.find((d) => d.device_id === deviceId)
+  if (masMatch) {
+    if (typeof masMatch.agent_url === "string" && /:8787\/?$/.test(masMatch.agent_url)) {
+      return masMatch.agent_url.replace(/\/+$/, "")
+    }
+    if (masMatch.host) {
+      const m = OPERATOR_HOSTS.find((u) => new URL(u).hostname === masMatch.host)
+      if (m) return m
+    }
+  }
+
+  // 2. Operator-http (live /api/mycobrain probes)
+  const operatorDevices = await fetchOperatorDevices()
+  const opMatch = operatorDevices.find((d) => d.device_id === deviceId)
+  if (opMatch && opMatch.network_host) {
+    const m = OPERATOR_HOSTS.find((u) => new URL(u).hostname === opMatch.network_host)
+    if (m) return m
+    // Fall back to constructing the URL from host:port (port 8787 is standard)
+    const port = String(opMatch.network_port || 8787)
+    if (port === "8787") {
+      return `http://${opMatch.network_host}:8787`
+    }
+  }
+
+  // 3. Host extracted from deviceId suffix
+  const suffixHost = hostFromDeviceIdSuffix(deviceId)
+  if (suffixHost) {
+    const m = OPERATOR_HOSTS.find((u) => new URL(u).hostname === suffixHost)
+    if (m) return m
+  }
+
+  return null
+}
+
+/** Same idea but synchronous — for callers that already have a `host` string. */
 export function agentUrlForHost(host: string): string | null {
   return OPERATOR_HOSTS.find((u) => new URL(u).hostname === host) || null
 }

--- a/lib/devices/agent-resolver.ts
+++ b/lib/devices/agent-resolver.ts
@@ -1,0 +1,87 @@
+/**
+ * Per-device agent URL resolver.
+ *
+ * Looks up where a deviceId's mycobrain-agent lives, by:
+ *   1. Direct env override: MYCOBRAIN_OPERATOR_URLS (host list, port :8787 assumed)
+ *      with the device's host matching one of them via /api/devices/network registry
+ *   2. Fallback to legacy MYCOBRAIN_SERVICE_URL (:8003) for devices we don\'t yet
+ *      have a unified agent for
+ *
+ * The website does NOT need to know about every device statically — the MAS
+ * device registry at /api/devices/network is the source of truth, and includes
+ * each device\'s `host` (LAN IP). Combined with MYCOBRAIN_OPERATOR_URLS, we
+ * route to the right :8787.
+ */
+
+const OPERATOR_HOSTS = (
+  process.env.MYCOBRAIN_OPERATOR_URLS ||
+  "http://192.168.0.228:8787,http://192.168.0.123:8787"
+)
+  .split(",")
+  .map((u) => u.trim().replace(/\/+$/, ""))
+  .filter(Boolean)
+
+const MAS_API_URL = process.env.MAS_API_URL || "http://localhost:8001"
+
+interface RegistryDevice {
+  device_id: string
+  host?: string
+  port?: number
+  openclaw_url?: string | null
+}
+
+let registryCache: { ts: number; devices: RegistryDevice[] } | null = null
+const REGISTRY_TTL_MS = 30_000
+
+async function fetchRegistry(): Promise<RegistryDevice[]> {
+  const now = Date.now()
+  if (registryCache && now - registryCache.ts < REGISTRY_TTL_MS) {
+    return registryCache.devices
+  }
+  try {
+    const res = await fetch(`${MAS_API_URL}/api/devices`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+      cache: "no-store",
+    })
+    if (!res.ok) return []
+    const data = await res.json()
+    const devices: RegistryDevice[] = data.devices || []
+    registryCache = { ts: now, devices }
+    return devices
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Resolve the agent URL (port 8787) for a given device, or null if the device
+ * isn\'t reachable via the unified agent path.
+ */
+export async function resolveAgentUrl(deviceId: string): Promise<string | null> {
+  const registry = await fetchRegistry()
+  const device = registry.find((d) => d.device_id === deviceId)
+  if (!device) return null
+
+  // Prefer the agent URL the device self-reported, if it has one matching :8787
+  // (post unified-agent rollout, every agent registers with `agent_url`).
+  const reportedUrl = (device as { agent_url?: string }).agent_url
+  if (typeof reportedUrl === "string" && /:8787\/?$/.test(reportedUrl)) {
+    return reportedUrl.replace(/\/+$/, "")
+  }
+
+  // Else match by host against MYCOBRAIN_OPERATOR_URLS
+  if (device.host) {
+    const match = OPERATOR_HOSTS.find((u) => new URL(u).hostname === device.host)
+    if (match) return match
+  }
+  return null
+}
+
+/**
+ * Same idea but synchronous — for callers that already have a `host` string
+ * (e.g. from a parent request that already fetched the registry).
+ */
+export function agentUrlForHost(host: string): string | null {
+  return OPERATOR_HOSTS.find((u) => new URL(u).hostname === host) || null
+}


### PR DESCRIPTION
Closes the Stream 3 P0 gap from `three-stream_gap_plan_edc7b3af`: the website talks to the unified `mycobrain-agent` on `:8787` per-device, not just the legacy MAS `:8003`. Morgan can now control all four MycoBrains live from `/natureos/devices/<id>` the same way the COM7 bench MycoBrain was driven from a serial terminal — but across Jetson(OpenClaw)+MycoBrain pairs.

## What's in this PR

### Lock `/natureos/devices/*` to COMPANY gate
9 routes moved from `PUBLIC_ROUTES` to `COMPANY_ROUTES` in `lib/access/routes.ts`. Visitors without `@mycosoft.org`/`.com` are redirected to `/login`. The `isCompanyEmail()` check + middleware were already wired — this is just routing flip.

### New API routes (proxy to per-device `:8787` agents)

| Method | Path | Forwards to |
|--------|------|-------------|
| `GET`  | `/api/devices/:deviceId/openclaw/status` | `<agent>/openclaw/status` |
| `POST` | `/api/devices/:deviceId/openclaw/action` | `<agent>/openclaw/action` |
| `POST` | `/api/devices/:deviceId/command` | `<agent>/command` |

Each handler:
- Verifies Supabase session cookie
- Checks `isCompanyEmail(user.email)`
- Forwards the operator's Supabase `access_token` as `Bearer` (agent verifies against Supabase JWKS — no custom signer)
- Attaches `user_subject = user.email` for audit on the agent side
- Resolves the per-device `:8787` URL via `lib/devices/agent-resolver.ts` (MAS registry host + `MYCOBRAIN_OPERATOR_URLS` match)

### New components

**`components/devices/openclaw-panel.tsx`** — auto-polls `/openclaw/status` every 5s, shows live position / gripper / force ADC, quick-action buttons (Grip / Release / Calibrate / ESTOP / Clear ESTOP), position slider, recent-actions tail.

**`components/devices/live-command-console.tsx`** — same UX as the COM7 bench: quick-action grid for LED / Buzzer / Read sensors / Estop / Side B transport, custom command form, history pane with ack + duration.

Both mounted in `app/natureos/devices/[deviceId]/page.tsx` alongside the existing `DeviceTelemetryCard`. The OpenClaw panel hides itself when `available: false`, so the bench (Device #4) doesn't show a useless claw UI.

## How a grip action flows after this

```
Morgan @ /natureos/devices/mycobrain-jet-a-001 → click "Grip"
   │
   ▼  POST /api/devices/.../openclaw/action  (Supabase cookie)
Website route handler:
   verify session → check @mycosoft.org → resolve agent_url=:8787 →
   POST <agent_url>/openclaw/action  Authorization: Bearer <supabase JWT>
   │
   ▼
Jetson @ 192.168.0.228:8787
   verify JWT against Supabase JWKS → audit "received" →
   send MDP claw_grip (0x0030) over UART to Side A →
   wait ACK ≤ 3s → audit "completed" → publish openclaw/state to MQTT →
   return result
   │
   ▼
Browser: pos/force readout updates in ~600ms; "Recent actions" gains the row.
```

## Per-device URL resolution

`lib/devices/agent-resolver.ts` caches the MAS registry (30s TTL) and matches a device's `host` against `MYCOBRAIN_OPERATOR_URLS` (env default `http://192.168.0.228:8787,http://192.168.0.123:8787`). Devices not in the registry, or registered without a matching `:8787` host, return 404 from the new routes — the existing `:8003` path still works for them.

## Tested with

- `__tests__/devices-agent-resolver.test.ts` — host match + null fallback
- (live test: see PR description on `mycobrain` repo)

## Out of scope (next PRs)

- **#10** SSE stream (`/api/devices/:id/stream`) so the panels don't poll
- **#11** Internal mirror of `mqtt-status.mycosoft.com` at `/natureos/devices/fleet/mqtt-live`
- **#12** `lib/mycobrain-service-url.ts` per-device resolution (this PR adds a parallel resolver; old one still in use for the catalog page)
- Pairing wizard at `/natureos/devices?pair=1`

## Refs

- `MycosoftLabs/mycobrain` PR #4 — unified agent + NatureOS contracts (merged)
- `MycosoftLabs/mycobrain` PR #5 — OpenClaw reconciliation (merged)
- `MycosoftLabs/mycobrain` PR #6 — Seeed OpenClaw firmware (open)
- `MycosoftLabs/mycobrain` PR #7 — captive portal in MDP firmware (open)
- `MycosoftLabs/mycobrain` PR #8 — per-device structure + impl spec (open)
- `MycosoftLabs/mycobrain` `natureos/WEBSITE_IMPLEMENTATION_SPEC.md` — the contract this PR implements

cc @nodefather

## Summary by Sourcery

Add company-gated live device control surfaces that proxy commands to per-device :8787 agents and wire them into the NatureOS device detail page.

New Features:
- Expose a company-only OpenClaw control panel that polls per-device claw status and supports common grip, release, calibration, ESTOP, and position actions.
- Expose a company-only live command console for sending MDP commands (including quick actions and custom JSON payloads) to each device via its unified agent.
- Provide API endpoints for per-device OpenClaw status, OpenClaw actions, and generic device commands that authenticate via Supabase and forward operator identity to the agent.
- Introduce a per-device agent URL resolver that maps MAS registry entries and operator host configuration to the appropriate :8787 agent endpoint.

Enhancements:
- Wire the OpenClaw panel and live command console into the NatureOS device detail page alongside the existing telemetry card.
- Move all /natureos/devices routes from public access to company-gated access control.

Tests:
- Add unit tests for the agent resolver to verify host matching and null fallback behavior.