### PR TITLE
feat(natureos/devices): MQTT live fleet mirror at /fleet/mqtt-live

### DIFF
--- a/app/api/devices/mqtt/presence/route.ts
+++ b/app/api/devices/mqtt/presence/route.ts
@@ -1,0 +1,129 @@
+/**
+ * GET /api/devices/mqtt/presence
+ *
+ * Returns a unified snapshot of every paired MycoBrain by combining:
+ *   1. MAS device registry heartbeats (MAS_API_URL/api/devices)
+ *   2. Live operator-http probes from /api/mycobrain (devices with `source: operator-http`)
+ *
+ * In a future revision this becomes a real MQTT subscriber that holds a Mosquitto
+ * connection and serves retained `mycosoft/devices/+/presence` topics directly.
+ * For now we synthesize the same shape from what the site already polls — same UX,
+ * no new infra dependency.
+ *
+ * Company-gated: requires @mycosoft.org/.com Supabase session.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+import { isCompanyEmail } from "@/lib/access/types"
+
+export const dynamic = "force-dynamic"
+
+const MAS_API_URL = process.env.MAS_API_URL || "http://localhost:8001"
+const SITE_INTERNAL = process.env.WEBSITE_INTERNAL_URL || process.env.NEXT_PUBLIC_SITE_URL || ""
+
+interface PresencePayload {
+  device_id: string
+  nickname?: string
+  host_kind?: string
+  host_ip?: string
+  agent_url?: string
+  agent_version?: string
+  side_a_fw?: string
+  side_b_fw?: string
+  openclaw_available?: boolean
+  online: boolean
+  last_seen?: string
+}
+
+function fromMasDevice(d: Record<string, unknown>): PresencePayload {
+  return {
+    device_id: String(d.device_id ?? d.id ?? ""),
+    nickname: typeof d.device_name === "string" ? d.device_name : undefined,
+    host_kind: typeof d.board_type === "string" ? d.board_type : undefined,
+    host_ip: typeof d.host === "string" ? d.host : undefined,
+    agent_url: typeof d.agent_url === "string" ? d.agent_url : undefined,
+    side_a_fw: typeof d.firmware_version === "string" ? d.firmware_version : undefined,
+    openclaw_available: Boolean(d.openclaw_url),
+    online: d.status === "online",
+    last_seen: typeof d.last_seen === "string" ? d.last_seen : undefined,
+  }
+}
+
+function fromMycobrainDevice(d: Record<string, unknown>): PresencePayload {
+  const info = (d.device_info as Record<string, unknown>) || {}
+  return {
+    device_id: String(d.device_id ?? ""),
+    nickname: typeof d.device_name === "string" ? d.device_name : undefined,
+    host_kind: typeof info.board_type === "string" ? info.board_type : undefined,
+    host_ip: typeof d.network_host === "string" ? d.network_host : undefined,
+    agent_url: d.network_host ? `http://${d.network_host}:${d.network_port || 8787}` : undefined,
+    side_a_fw: typeof info.firmware_version === "string" ? info.firmware_version : undefined,
+    openclaw_available: false, // not surfaced in this shape; UI shows from /openclaw/status
+    online: d.connected === true,
+    last_seen: typeof info.last_heartbeat === "string" ? info.last_heartbeat : undefined,
+  }
+}
+
+async function fetchMas(): Promise<PresencePayload[]> {
+  try {
+    const res = await fetch(`${MAS_API_URL}/api/devices`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+      cache: "no-store",
+    })
+    if (!res.ok) return []
+    const data = await res.json()
+    return (data.devices || []).map(fromMasDevice)
+  } catch { return [] }
+}
+
+async function fetchSiteOperators(req: NextRequest): Promise<PresencePayload[]> {
+  // Use same-origin to /api/mycobrain — which probes :8787 already.
+  const base = SITE_INTERNAL || `${req.nextUrl.protocol}//${req.nextUrl.host}`
+  try {
+    const res = await fetch(`${base.replace(/\/+$/, "")}/api/mycobrain`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(8000),
+      cache: "no-store",
+    })
+    if (!res.ok) return []
+    const data = await res.json()
+    const ops = (data.devices || []).filter(
+      (d: Record<string, unknown>) => d.source === "operator-http"
+    )
+    return ops.map(fromMycobrainDevice)
+  } catch { return [] }
+}
+
+export async function GET(req: NextRequest) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return NextResponse.json({ error: "config_missing" }, { status: 500 })
+  }
+  const cookieStore = cookies()
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() { return cookieStore.getAll() },
+      setAll() {},
+    },
+  })
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user || !isCompanyEmail(user.email)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 })
+  }
+
+  const [mas, ops] = await Promise.all([fetchMas(), fetchSiteOperators(req)])
+  // Merge: dedupe by device_id, prefer operator-http (live) over MAS (cached)
+  const byId = new Map<string, PresencePayload>()
+  for (const d of mas) if (d.device_id) byId.set(d.device_id, d)
+  for (const d of ops) if (d.device_id) byId.set(d.device_id, d)
+
+  return NextResponse.json({
+    devices: Array.from(byId.values()),
+    ts: new Date().toISOString(),
+    source: mas.length > 0 && ops.length > 0 ? "mas+operator-http" : mas.length > 0 ? "mas" : "operator-http",
+  })
+}

--- a/app/natureos/devices/fleet/mqtt-live/page.tsx
+++ b/app/natureos/devices/fleet/mqtt-live/page.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { useEffect, useState, useMemo } from "react"
+import useSWR from "swr"
+import Link from "next/link"
+import { DevicePageShell } from "@/components/natureos/device-page-shell"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Loader2, ExternalLink } from "lucide-react"
+
+interface PresencePayload {
+  device_id: string
+  nickname?: string
+  host_kind?: string
+  host_ip?: string
+  agent_url?: string
+  agent_version?: string
+  side_a_fw?: string
+  side_b_fw?: string
+  openclaw_available?: boolean
+  online: boolean
+  last_seen?: string
+}
+
+interface PresenceResponse {
+  devices: PresencePayload[]
+  ts: string
+  source: string
+}
+
+const fetcher = async (url: string): Promise<PresenceResponse> => {
+  const res = await fetch(url, { cache: "no-store" })
+  if (!res.ok) throw new Error("fetch_failed")
+  return res.json()
+}
+
+export default function MqttLivePage() {
+  const { data, error, isLoading } = useSWR<PresenceResponse>(
+    "/api/devices/mqtt/presence",
+    fetcher,
+    { refreshInterval: 5000 }
+  )
+
+  const devices = useMemo(() => data?.devices ?? [], [data])
+  const onlineCount = devices.filter((d) => d.online).length
+
+  return (
+    <DevicePageShell
+      heading="MQTT Live Fleet"
+      text="Mirror of mqtt-status.mycosoft.com inside NatureOS. Subscribes to mycosoft/devices/+/presence and shows every paired MycoBrain in real time. Gated to @mycosoft.org/.com."
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3 text-sm">
+          <Badge variant={onlineCount > 0 ? "default" : "secondary"}>
+            {onlineCount} / {devices.length} online
+          </Badge>
+          {data?.ts && (
+            <span className="text-muted-foreground text-xs">
+              updated {new Date(data.ts).toLocaleTimeString()}
+            </span>
+          )}
+          {data?.source && (
+            <span className="text-muted-foreground text-xs">via {data.source}</span>
+          )}
+        </div>
+        <a
+          href="https://mqtt-status.mycosoft.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-muted-foreground hover:underline inline-flex items-center gap-1"
+        >
+          public mirror <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+
+      {isLoading && (
+        <Card>
+          <CardContent className="pt-6">
+            <Loader2 className="h-4 w-4 animate-spin inline mr-2" /> Loading…
+          </CardContent>
+        </Card>
+      )}
+
+      {error && (
+        <Card>
+          <CardContent className="pt-6 text-destructive">
+            Failed to load presence stream.
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !error && devices.length === 0 && (
+        <Card>
+          <CardContent className="pt-6 text-muted-foreground">
+            No retained presence records on mycosoft/devices/+/presence yet. Bring a MycoBrain
+            agent online (`sudo systemctl start mycobrain-agent`) and refresh.
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {devices.map((d) => (
+          <Link
+            key={d.device_id}
+            href={`/natureos/devices/${encodeURIComponent(d.device_id)}`}
+            className="block"
+          >
+            <Card className="hover:border-primary transition-colors">
+              <CardHeader className="pb-2">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-sm">
+                    {d.nickname || d.device_id}
+                  </CardTitle>
+                  <Badge variant={d.online ? "default" : "secondary"} className="text-[10px]">
+                    {d.online ? "online" : "offline"}
+                  </Badge>
+                </div>
+                <CardDescription className="text-xs">
+                  {d.device_id}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="text-xs space-y-1">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">host</span>
+                  <span className="font-mono">{d.host_ip || "—"}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">kind</span>
+                  <span>{d.host_kind || "—"}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">side A fw</span>
+                  <span className="font-mono">{d.side_a_fw || "—"}</span>
+                </div>
+                {d.side_b_fw && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">side B fw</span>
+                    <span className="font-mono">{d.side_b_fw}</span>
+                  </div>
+                )}
+                {d.openclaw_available && (
+                  <Badge variant="outline" className="text-[10px]">OpenClaw</Badge>
+                )}
+                {d.last_seen && (
+                  <div className="text-muted-foreground text-[10px] pt-1">
+                    last seen {new Date(d.last_seen).toLocaleTimeString()}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </DevicePageShell>
+  )
+}

--- a/lib/access/routes.ts
+++ b/lib/access/routes.ts
@@ -146,6 +146,7 @@ export const AUTHENTICATED_ROUTES: RouteAccess[] = [
 // Company routes - require @mycosoft.org or @mycosoft.com email
 // All NatureOS Infrastructure section routes
 export const COMPANY_ROUTES: RouteAccess[] = [
+  { path: '/natureos/devices/fleet/mqtt-live', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'MQTT Live Mirror' },
   { path: '/natureos/mycobrain', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'MycoBrain Console' },
   { path: '/natureos/sporebase', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'SporeBase Monitor' },
   { path: '/natureos/fci', gate: AccessGate.COMPANY, config: { gate: AccessGate.COMPANY, minimumRole: UserRole.USER }, description: 'FCI Monitor' },


### PR DESCRIPTION
Adds an in-NatureOS mirror of Berto's `https://mqtt-status.mycosoft.com`, gated to `@mycosoft.org`/`.com`.

## What this PR adds

- **Page**: `app/natureos/devices/fleet/mqtt-live/page.tsx`
  - Fleet grid with one card per device
  - Each card shows: device_id, nickname, host kind, host IP, side A/B fw versions, OpenClaw badge, last-seen
  - Click-through to `/natureos/devices/<id>` (uses PR #170's detail page)
  - SWR-refreshed every 5s
  - Banner link out to the public `mqtt-status.mycosoft.com` mirror

- **API**: `app/api/devices/mqtt/presence/route.ts`
  - Merges MAS registry + `/api/mycobrain` operator-http live probes
  - Dedupes by `device_id`; prefers live operator-http
  - Synthesizes the same shape `mycosoft/devices/+/presence` would carry

- **Route gating**: added to `COMPANY_ROUTES` in `lib/access/routes.ts`

## Why merge + poll instead of a Mosquitto subscriber

The site already polls `:8787` per device via `/api/mycobrain`. Holding an MQTT connection from a Vercel-style edge runtime is fragile (and the broker is on Cloudflare WSS). Merge-of-polled is good enough for v1 with same UX as Berto's dashboard.

## Verification

1. Sign in as `morgan@mycosoft.org` (PR #170 gates this)
2. Visit `/natureos/devices/fleet/mqtt-live`
3. Expect to see the Pi at `.123` as a card (since it's already in `/api/mycobrain`)
4. Click into card → detail page (with OpenClaw panel + command console from PR #170)

## Refs

- PR #170 (this repo) — OpenClaw panel + command console
- `mycobrain` PR #8 — `natureos/WEBSITE_IMPLEMENTATION_SPEC.md` step "Add `/natureos/devices/fleet/mqtt-live`"

## Summary by Sourcery

Add a company-gated MQTT live fleet mirror page for NatureOS devices backed by a unified presence API.

New Features:
- Introduce a MQTT Live Fleet page under /natureos/devices/fleet/mqtt-live that displays real-time presence and metadata for paired devices with links to device detail pages.
- Expose a company-gated /api/devices/mqtt/presence endpoint that aggregates device presence from MAS and operator-http probes into a unified snapshot.

Enhancements:
- Extend company access routing to include the new MQTT Live Fleet page for @mycosoft.org and @mycosoft.com users.