### PR TITLE
fix(mycobrain-service-url): per-device resolution alongside legacy :8003

### DIFF
--- a/__tests__/mycobrain-service-url.test.ts
+++ b/__tests__/mycobrain-service-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from "@jest/globals"
+import { resolveMycoBrainServiceUrl } from "@/lib/mycobrain-service-url"
+
+describe("resolveMycoBrainServiceUrl (back-compat)", () => {
+  beforeEach(() => {
+    delete process.env.MYCOBRAIN_SERVICE_URL
+    delete process.env.MYCOBRAIN_API_URL
+    delete process.env.ALLOW_LOOPBACK_MYCOBRAIN
+  })
+
+  it("returns the default LAN URL when nothing is configured", () => {
+    expect(resolveMycoBrainServiceUrl()).toBe("http://192.168.0.196:8003")
+  })
+
+  it("honors MYCOBRAIN_SERVICE_URL", () => {
+    process.env.MYCOBRAIN_SERVICE_URL = "http://172.16.0.50:8003"
+    expect(resolveMycoBrainServiceUrl()).toBe("http://172.16.0.50:8003")
+  })
+
+  it("rejects loopback unless ALLOW_LOOPBACK_MYCOBRAIN=1", () => {
+    process.env.MYCOBRAIN_SERVICE_URL = "http://localhost:8003"
+    expect(resolveMycoBrainServiceUrl()).toBe("http://192.168.0.196:8003")
+    process.env.ALLOW_LOOPBACK_MYCOBRAIN = "1"
+    expect(resolveMycoBrainServiceUrl()).toBe("http://localhost:8003")
+  })
+
+  it("strips trailing slashes", () => {
+    process.env.MYCOBRAIN_SERVICE_URL = "http://172.16.0.50:8003/"
+    expect(resolveMycoBrainServiceUrl()).toBe("http://172.16.0.50:8003")
+  })
+})

--- a/lib/mycobrain-service-url.ts
+++ b/lib/mycobrain-service-url.ts
@@ -1,3 +1,26 @@
+/**
+ * MycoBrain service URL resolution.
+ *
+ * History: this module used to return a single URL (the legacy MAS service at
+ * :8003 by default), which made it impossible to address individual unified
+ * agents on :8787. PR #12 (May 2026) refactors it to also resolve per-device
+ * via lib/devices/agent-resolver.ts.
+ *
+ * Three layers:
+ *   - resolveMycoBrainServiceUrl()         — legacy: returns the global :8003 URL
+ *                                            (callers that don\'t know about
+ *                                            individual devices still get
+ *                                            the correct global service)
+ *   - resolveMycoBrainServiceUrlFor(id)    — per-device: tries the unified
+ *                                            agent first (:8787), falls back
+ *                                            to the global :8003
+ *   - resolveMycoBrainGlobalAndAgent(id)   — returns both URLs so callers
+ *                                            that talk to both layers don\'t
+ *                                            need two lookups
+ */
+
+import { resolveAgentUrl } from "./devices/agent-resolver"
+
 const MYCOBRAIN_VM_LAN = "http://192.168.0.196:8003"
 
 function isLoopbackUrl(value: string): boolean {
@@ -9,6 +32,12 @@ function isLoopbackUrl(value: string): boolean {
   }
 }
 
+/**
+ * Returns the legacy :8003 MAS-fronted MycoBrain service URL.
+ * Behavior unchanged from the pre-May 2026 implementation, so every existing
+ * caller keeps working. New code that needs per-device addressing should call
+ * resolveMycoBrainServiceUrlFor(deviceId) instead.
+ */
 export function resolveMycoBrainServiceUrl(): string {
   const configured =
     process.env.MYCOBRAIN_SERVICE_URL?.trim() ||
@@ -18,6 +47,32 @@ export function resolveMycoBrainServiceUrl(): string {
   if (configured.startsWith("/") || (isLoopbackUrl(configured) && process.env.ALLOW_LOOPBACK_MYCOBRAIN !== "1")) {
     return MYCOBRAIN_VM_LAN
   }
-
   return configured.replace(/\/+$/, "")
+}
+
+/**
+ * Per-device resolution. Tries the unified agent on :8787 first (via the
+ * MAS registry + operator-http path in agent-resolver). Falls back to the
+ * legacy :8003 URL.
+ *
+ * Use this in route handlers that target a specific deviceId.
+ */
+export async function resolveMycoBrainServiceUrlFor(deviceId: string): Promise<string> {
+  const agent = await resolveAgentUrl(deviceId)
+  if (agent) return agent
+  return resolveMycoBrainServiceUrl()
+}
+
+/**
+ * Returns both the per-device agent URL (if any) and the legacy global URL,
+ * so callers that talk to both layers (e.g. dual-write health checks) don\'t
+ * need two awaits.
+ */
+export async function resolveMycoBrainGlobalAndAgent(
+  deviceId: string
+): Promise<{ agent: string | null; global: string }> {
+  return {
+    agent: await resolveAgentUrl(deviceId),
+    global: resolveMycoBrainServiceUrl(),
+  }
 }


### PR DESCRIPTION
Closes Stream 3 P1 from the gap plan: `lib/mycobrain-service-url.ts` env drift fix.

## What changes

- `resolveMycoBrainServiceUrl()` — **unchanged** (back-compat; every existing caller stays correct)
- `resolveMycoBrainServiceUrlFor(deviceId)` — new; tries `:8787` via `agent-resolver.ts`, falls back to `:8003`
- `resolveMycoBrainGlobalAndAgent(deviceId)` — convenience returning both URLs

## Tests

`__tests__/mycobrain-service-url.test.ts` covers the back-compat surface (default, env override, loopback gate, trailing-slash strip).

## Why a separate PR

Keeps the file's behavior change atomic + easy to revert. PR #170 added the new per-device routes via direct calls to `agent-resolver.ts`. This PR generalizes the legacy module so future migrations are mechanical (just swap `resolveMycoBrainServiceUrl()` → `resolveMycoBrainServiceUrlFor(deviceId)` where context allows).

## Summary by Sourcery

Introduce per-device MycoBrain service URL resolution while preserving the existing global URL behavior.

New Features:
- Add per-device MycoBrain URL resolver that prefers unified agent endpoints and falls back to the legacy global service.
- Expose a helper that returns both per-device agent and global MycoBrain URLs for callers needing dual access.

Enhancements:
- Document the MycoBrain service URL resolution layers and their historical context in the module.

Tests:
- Add tests covering legacy MycoBrain URL resolution behavior, including env overrides, loopback gating, and trailing-slash handling.