### PR TITLE
fix(migrations): idempotency guards + worldview_v1 RPC bug — launch prep

### DIFF
--- a/supabase/migrations/20260117210000_storage_policies.sql
+++ b/supabase/migrations/20260117210000_storage_policies.sql
@@ -9,32 +9,36 @@ ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
 -- ============================================
 
 -- Allow public read access to avatars
+DROP POLICY IF EXISTS "Public read access for avatars" ON storage.objects;
 CREATE POLICY "Public read access for avatars"
 ON storage.objects FOR SELECT
 USING (bucket_id = 'avatars');
 
 -- Allow authenticated users to upload avatars
+DROP POLICY IF EXISTS "Authenticated upload avatars" ON storage.objects;
 CREATE POLICY "Authenticated upload avatars"
 ON storage.objects FOR INSERT
 WITH CHECK (
-  bucket_id = 'avatars' 
+  bucket_id = 'avatars'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow users to update their own avatars
+DROP POLICY IF EXISTS "Users can update own avatars" ON storage.objects;
 CREATE POLICY "Users can update own avatars"
 ON storage.objects FOR UPDATE
 USING (
-  bucket_id = 'avatars' 
+  bucket_id = 'avatars'
   AND auth.role() = 'authenticated'
   AND (storage.foldername(name))[1] = auth.uid()::text
 );
 
 -- Allow users to delete their own avatars
+DROP POLICY IF EXISTS "Users can delete own avatars" ON storage.objects;
 CREATE POLICY "Users can delete own avatars"
 ON storage.objects FOR DELETE
 USING (
-  bucket_id = 'avatars' 
+  bucket_id = 'avatars'
   AND auth.role() = 'authenticated'
   AND (storage.foldername(name))[1] = auth.uid()::text
 );
@@ -44,31 +48,35 @@ USING (
 -- ============================================
 
 -- Allow public read access to species images
+DROP POLICY IF EXISTS "Public read access for species-images" ON storage.objects;
 CREATE POLICY "Public read access for species-images"
 ON storage.objects FOR SELECT
 USING (bucket_id = 'species-images');
 
 -- Allow authenticated users to upload species images
+DROP POLICY IF EXISTS "Authenticated upload species-images" ON storage.objects;
 CREATE POLICY "Authenticated upload species-images"
 ON storage.objects FOR INSERT
 WITH CHECK (
-  bucket_id = 'species-images' 
+  bucket_id = 'species-images'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to update species images
+DROP POLICY IF EXISTS "Authenticated update species-images" ON storage.objects;
 CREATE POLICY "Authenticated update species-images"
 ON storage.objects FOR UPDATE
 USING (
-  bucket_id = 'species-images' 
+  bucket_id = 'species-images'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to delete species images
+DROP POLICY IF EXISTS "Authenticated delete species-images" ON storage.objects;
 CREATE POLICY "Authenticated delete species-images"
 ON storage.objects FOR DELETE
 USING (
-  bucket_id = 'species-images' 
+  bucket_id = 'species-images'
   AND auth.role() = 'authenticated'
 );
 
@@ -77,34 +85,38 @@ USING (
 -- ============================================
 
 -- Allow authenticated users to read firmware
+DROP POLICY IF EXISTS "Authenticated read firmware" ON storage.objects;
 CREATE POLICY "Authenticated read firmware"
 ON storage.objects FOR SELECT
 USING (
-  bucket_id = 'firmware' 
+  bucket_id = 'firmware'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to upload firmware
+DROP POLICY IF EXISTS "Authenticated upload firmware" ON storage.objects;
 CREATE POLICY "Authenticated upload firmware"
 ON storage.objects FOR INSERT
 WITH CHECK (
-  bucket_id = 'firmware' 
+  bucket_id = 'firmware'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to update firmware
+DROP POLICY IF EXISTS "Authenticated update firmware" ON storage.objects;
 CREATE POLICY "Authenticated update firmware"
 ON storage.objects FOR UPDATE
 USING (
-  bucket_id = 'firmware' 
+  bucket_id = 'firmware'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to delete firmware
+DROP POLICY IF EXISTS "Authenticated delete firmware" ON storage.objects;
 CREATE POLICY "Authenticated delete firmware"
 ON storage.objects FOR DELETE
 USING (
-  bucket_id = 'firmware' 
+  bucket_id = 'firmware'
   AND auth.role() = 'authenticated'
 );
 
@@ -113,35 +125,39 @@ USING (
 -- ============================================
 
 -- Allow authenticated users to read documents
+DROP POLICY IF EXISTS "Authenticated read documents" ON storage.objects;
 CREATE POLICY "Authenticated read documents"
 ON storage.objects FOR SELECT
 USING (
-  bucket_id = 'documents' 
+  bucket_id = 'documents'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to upload documents
+DROP POLICY IF EXISTS "Authenticated upload documents" ON storage.objects;
 CREATE POLICY "Authenticated upload documents"
 ON storage.objects FOR INSERT
 WITH CHECK (
-  bucket_id = 'documents' 
+  bucket_id = 'documents'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to update their own documents
+DROP POLICY IF EXISTS "Users can update own documents" ON storage.objects;
 CREATE POLICY "Users can update own documents"
 ON storage.objects FOR UPDATE
 USING (
-  bucket_id = 'documents' 
+  bucket_id = 'documents'
   AND auth.role() = 'authenticated'
   AND (storage.foldername(name))[1] = auth.uid()::text
 );
 
 -- Allow authenticated users to delete their own documents
+DROP POLICY IF EXISTS "Users can delete own documents" ON storage.objects;
 CREATE POLICY "Users can delete own documents"
 ON storage.objects FOR DELETE
 USING (
-  bucket_id = 'documents' 
+  bucket_id = 'documents'
   AND auth.role() = 'authenticated'
   AND (storage.foldername(name))[1] = auth.uid()::text
 );
@@ -151,33 +167,37 @@ USING (
 -- ============================================
 
 -- Allow authenticated users to read telemetry exports
+DROP POLICY IF EXISTS "Authenticated read telemetry-exports" ON storage.objects;
 CREATE POLICY "Authenticated read telemetry-exports"
 ON storage.objects FOR SELECT
 USING (
-  bucket_id = 'telemetry-exports' 
+  bucket_id = 'telemetry-exports'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to upload telemetry exports
+DROP POLICY IF EXISTS "Authenticated upload telemetry-exports" ON storage.objects;
 CREATE POLICY "Authenticated upload telemetry-exports"
 ON storage.objects FOR INSERT
 WITH CHECK (
-  bucket_id = 'telemetry-exports' 
+  bucket_id = 'telemetry-exports'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to update telemetry exports
+DROP POLICY IF EXISTS "Authenticated update telemetry-exports" ON storage.objects;
 CREATE POLICY "Authenticated update telemetry-exports"
 ON storage.objects FOR UPDATE
 USING (
-  bucket_id = 'telemetry-exports' 
+  bucket_id = 'telemetry-exports'
   AND auth.role() = 'authenticated'
 );
 
 -- Allow authenticated users to delete telemetry exports
+DROP POLICY IF EXISTS "Authenticated delete telemetry-exports" ON storage.objects;
 CREATE POLICY "Authenticated delete telemetry-exports"
 ON storage.objects FOR DELETE
 USING (
-  bucket_id = 'telemetry-exports' 
+  bucket_id = 'telemetry-exports'
   AND auth.role() = 'authenticated'
 );

--- a/supabase/migrations/20260126000000_user_app_state.sql
+++ b/supabase/migrations/20260126000000_user_app_state.sql
@@ -24,21 +24,25 @@ CREATE INDEX IF NOT EXISTS idx_user_app_state_tool_states ON public.user_app_sta
 ALTER TABLE public.user_app_state ENABLE ROW LEVEL SECURITY;
 
 -- Policy: Users can only view their own app state
+DROP POLICY IF EXISTS "Users can view own app state" ON public.user_app_state;
 CREATE POLICY "Users can view own app state" ON public.user_app_state
   FOR SELECT
   USING (auth.uid() = user_id);
 
 -- Policy: Users can insert their own app state
+DROP POLICY IF EXISTS "Users can insert own app state" ON public.user_app_state;
 CREATE POLICY "Users can insert own app state" ON public.user_app_state
   FOR INSERT
   WITH CHECK (auth.uid() = user_id);
 
 -- Policy: Users can update their own app state
+DROP POLICY IF EXISTS "Users can update own app state" ON public.user_app_state;
 CREATE POLICY "Users can update own app state" ON public.user_app_state
   FOR UPDATE
   USING (auth.uid() = user_id);
 
 -- Policy: Users can delete their own app state
+DROP POLICY IF EXISTS "Users can delete own app state" ON public.user_app_state;
 CREATE POLICY "Users can delete own app state" ON public.user_app_state
   FOR DELETE
   USING (auth.uid() = user_id);

--- a/supabase/migrations/20260212000000_create_support_tickets.sql
+++ b/supabase/migrations/20260212000000_create_support_tickets.sql
@@ -34,16 +34,19 @@ CREATE INDEX IF NOT EXISTS idx_support_tickets_issue_type ON public.support_tick
 ALTER TABLE public.support_tickets ENABLE ROW LEVEL SECURITY;
 
 -- Create policy: Users can view their own tickets
+DROP POLICY IF EXISTS "Users can view own tickets" ON public.support_tickets;
 CREATE POLICY "Users can view own tickets" ON public.support_tickets
   FOR SELECT
   USING (email = current_setting('request.jwt.claims', true)::json->>'email');
 
 -- Create policy: Service role can do anything
+DROP POLICY IF EXISTS "Service role has full access" ON public.support_tickets;
 CREATE POLICY "Service role has full access" ON public.support_tickets
   FOR ALL
   USING (current_setting('request.jwt.claims', true)::json->>'role' = 'service_role');
 
 -- Create policy: Authenticated users can insert tickets
+DROP POLICY IF EXISTS "Anyone can create tickets" ON public.support_tickets;
 CREATE POLICY "Anyone can create tickets" ON public.support_tickets
   FOR INSERT
   WITH CHECK (true);
@@ -58,6 +61,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Create trigger
+DROP TRIGGER IF EXISTS update_support_tickets_updated_at ON public.support_tickets;
 CREATE TRIGGER update_support_tickets_updated_at
   BEFORE UPDATE ON public.support_tickets
   FOR EACH ROW

--- a/supabase/migrations/20260224000000_active_sessions.sql
+++ b/supabase/migrations/20260224000000_active_sessions.sql
@@ -39,16 +39,20 @@ CREATE INDEX IF NOT EXISTS idx_active_sessions_last_activity ON public.active_se
 ALTER TABLE public.active_sessions ENABLE ROW LEVEL SECURITY;
 
 -- Users can manage their own sessions
+DROP POLICY IF EXISTS "Users can insert own sessions" ON public.active_sessions;
 CREATE POLICY "Users can insert own sessions" ON public.active_sessions
   FOR INSERT WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can update own sessions" ON public.active_sessions;
 CREATE POLICY "Users can update own sessions" ON public.active_sessions
   FOR UPDATE USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can delete own sessions" ON public.active_sessions;
 CREATE POLICY "Users can delete own sessions" ON public.active_sessions
   FOR DELETE USING (auth.uid() = user_id);
 
 -- Users can view own; staff can view all
+DROP POLICY IF EXISTS "Users or staff can view sessions" ON public.active_sessions;
 CREATE POLICY "Users or staff can view sessions" ON public.active_sessions
   FOR SELECT USING (auth.uid() = user_id OR public.is_staff());
 
@@ -76,10 +80,12 @@ CREATE INDEX IF NOT EXISTS idx_heartbeat_recent ON public.user_heartbeat(heartbe
 ALTER TABLE public.user_heartbeat ENABLE ROW LEVEL SECURITY;
 
 -- Users can insert their own heartbeats
+DROP POLICY IF EXISTS "Users can insert own heartbeat" ON public.user_heartbeat;
 CREATE POLICY "Users can insert own heartbeat" ON public.user_heartbeat
   FOR INSERT WITH CHECK (auth.uid() = user_id);
 
 -- Users can view own; staff can view all
+DROP POLICY IF EXISTS "Users or staff can view heartbeat" ON public.user_heartbeat;
 CREATE POLICY "Users or staff can view heartbeat" ON public.user_heartbeat
   FOR SELECT USING (auth.uid() = user_id OR public.is_staff());
 
@@ -110,12 +116,14 @@ CREATE INDEX IF NOT EXISTS idx_api_usage_endpoint ON public.api_usage_log(endpoi
 ALTER TABLE public.api_usage_log ENABLE ROW LEVEL SECURITY;
 
 -- Authenticated users can insert (their own or anonymous)
+DROP POLICY IF EXISTS "Authenticated can insert api usage" ON public.api_usage_log;
 CREATE POLICY "Authenticated can insert api usage" ON public.api_usage_log
   FOR INSERT WITH CHECK (
     user_id IS NULL OR auth.uid() = user_id
   );
 
 -- Users can view own; staff can view all
+DROP POLICY IF EXISTS "Users or staff can view api usage" ON public.api_usage_log;
 CREATE POLICY "Users or staff can view api usage" ON public.api_usage_log
   FOR SELECT USING (user_id = auth.uid() OR public.is_staff());
 

--- a/supabase/migrations/20260307120000_supabase_operational_backbone.sql
+++ b/supabase/migrations/20260307120000_supabase_operational_backbone.sql
@@ -347,51 +347,67 @@ ALTER TABLE public.external_record_links ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.sheet_sync_status ENABLE ROW LEVEL SECURITY;
 
 -- Service role bypasses RLS. Policies allow backend/authenticated access for operational tables.
+DROP POLICY IF EXISTS "Operational access apps_services" ON public.apps_services;
 CREATE POLICY "Operational access apps_services" ON public.apps_services
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access customer_vendors" ON public.customer_vendors;
 CREATE POLICY "Operational access customer_vendors" ON public.customer_vendors
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access commitments" ON public.commitments;
 CREATE POLICY "Operational access commitments" ON public.commitments
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access liabilities" ON public.liabilities;
 CREATE POLICY "Operational access liabilities" ON public.liabilities
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access recruitment_roles" ON public.recruitment_roles;
 CREATE POLICY "Operational access recruitment_roles" ON public.recruitment_roles
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access recruitment_candidates" ON public.recruitment_candidates;
 CREATE POLICY "Operational access recruitment_candidates" ON public.recruitment_candidates
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access production_runs" ON public.production_runs;
 CREATE POLICY "Operational access production_runs" ON public.production_runs
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access singlogs" ON public.singlogs;
 CREATE POLICY "Operational access singlogs" ON public.singlogs
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access external_accounts" ON public.external_accounts;
 CREATE POLICY "Operational access external_accounts" ON public.external_accounts
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access integration_connections" ON public.integration_connections;
 CREATE POLICY "Operational access integration_connections" ON public.integration_connections
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access agent_skills_registry" ON public.agent_skills_registry;
 CREATE POLICY "Operational access agent_skills_registry" ON public.agent_skills_registry
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access mcp_connections_registry" ON public.mcp_connections_registry;
 CREATE POLICY "Operational access mcp_connections_registry" ON public.mcp_connections_registry
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access llm_usage_ledger" ON public.llm_usage_ledger;
 CREATE POLICY "Operational access llm_usage_ledger" ON public.llm_usage_ledger
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access sync_runs" ON public.sync_runs;
 CREATE POLICY "Operational access sync_runs" ON public.sync_runs
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access external_record_links" ON public.external_record_links;
 CREATE POLICY "Operational access external_record_links" ON public.external_record_links
   FOR ALL USING (true) WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Operational access sheet_sync_status" ON public.sheet_sync_status;
 CREATE POLICY "Operational access sheet_sync_status" ON public.sheet_sync_status
   FOR ALL USING (true) WITH CHECK (true);
 

--- a/supabase/migrations/20260316_agent_payment_pipeline.sql
+++ b/supabase/migrations/20260316_agent_payment_pipeline.sql
@@ -158,10 +158,12 @@ END $$;
 -- Agent API keys: users can read their own
 ALTER TABLE public.agent_api_keys ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can read own API keys" ON public.agent_api_keys;
 CREATE POLICY "Users can read own API keys"
   ON public.agent_api_keys FOR SELECT
   USING (profile_id IN (SELECT id FROM public.profiles WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Service role full access on api_keys" ON public.agent_api_keys;
 CREATE POLICY "Service role full access on api_keys"
   ON public.agent_api_keys FOR ALL
   USING (auth.role() = 'service_role');
@@ -169,10 +171,12 @@ CREATE POLICY "Service role full access on api_keys"
 -- Agent sessions: users can read their own
 ALTER TABLE public.agent_sessions ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can read own sessions" ON public.agent_sessions;
 CREATE POLICY "Users can read own sessions"
   ON public.agent_sessions FOR SELECT
   USING (profile_id IN (SELECT id FROM public.profiles WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Service role full access on sessions" ON public.agent_sessions;
 CREATE POLICY "Service role full access on sessions"
   ON public.agent_sessions FOR ALL
   USING (auth.role() = 'service_role');

--- a/supabase/migrations/20260317_agent_platform_v3.sql
+++ b/supabase/migrations/20260317_agent_platform_v3.sql
@@ -26,10 +26,12 @@ CREATE INDEX IF NOT EXISTS idx_usage_log_created ON public.agent_usage_log(creat
 
 ALTER TABLE public.agent_usage_log ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can read own usage logs" ON public.agent_usage_log;
 CREATE POLICY "Users can read own usage logs"
   ON public.agent_usage_log FOR SELECT
   USING (profile_id IN (SELECT id FROM public.profiles WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Service role full access on usage_log" ON public.agent_usage_log;
 CREATE POLICY "Service role full access on usage_log"
   ON public.agent_usage_log FOR ALL
   USING (auth.role() = 'service_role');
@@ -54,10 +56,12 @@ CREATE INDEX IF NOT EXISTS idx_events_created ON public.agent_events(created_at)
 
 ALTER TABLE public.agent_events ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can read own events" ON public.agent_events;
 CREATE POLICY "Users can read own events"
   ON public.agent_events FOR SELECT
   USING (profile_id IN (SELECT id FROM public.profiles WHERE id = auth.uid()));
 
+DROP POLICY IF EXISTS "Service role full access on events" ON public.agent_events;
 CREATE POLICY "Service role full access on events"
   ON public.agent_events FOR ALL
   USING (auth.role() = 'service_role');
@@ -78,6 +82,7 @@ CREATE INDEX IF NOT EXISTS idx_temp_keys_session ON public.agent_temp_keys(sessi
 
 ALTER TABLE public.agent_temp_keys ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Service role full access on temp_keys" ON public.agent_temp_keys;
 CREATE POLICY "Service role full access on temp_keys"
   ON public.agent_temp_keys FOR ALL
   USING (auth.role() = 'service_role');

--- a/supabase/migrations/20260324120000_unified_capabilities.sql
+++ b/supabase/migrations/20260324120000_unified_capabilities.sql
@@ -170,17 +170,29 @@ ALTER TABLE public.mdp_data_streams ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.mdp_payloads ENABLE ROW LEVEL SECURITY;
 
 -- Allow unrestricted operational backend access for Service Roles
+DROP POLICY IF EXISTS "Operational access all" ON public.avani_avatars;
 CREATE POLICY "Operational access all" ON public.avani_avatars FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.nlm_training_runs;
 CREATE POLICY "Operational access all" ON public.nlm_training_runs FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.nlm_checkpoints;
 CREATE POLICY "Operational access all" ON public.nlm_checkpoints FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.mindex_proxy_cache;
 CREATE POLICY "Operational access all" ON public.mindex_proxy_cache FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.crep_compute_nodes;
 CREATE POLICY "Operational access all" ON public.crep_compute_nodes FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.crep_workloads;
 CREATE POLICY "Operational access all" ON public.crep_workloads FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.global_search_indices;
 CREATE POLICY "Operational access all" ON public.global_search_indices FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.search_query_history;
 CREATE POLICY "Operational access all" ON public.search_query_history FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.mmp_mesh_nodes;
 CREATE POLICY "Operational access all" ON public.mmp_mesh_nodes FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.mmp_routing_tables;
 CREATE POLICY "Operational access all" ON public.mmp_routing_tables FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.mdp_data_streams;
 CREATE POLICY "Operational access all" ON public.mdp_data_streams FOR ALL USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "Operational access all" ON public.mdp_payloads;
 CREATE POLICY "Operational access all" ON public.mdp_payloads FOR ALL USING (true) WITH CHECK (true);
 
 GRANT ALL ON public.avani_avatars TO service_role;

--- a/supabase/migrations/20260423_worldview_v1.sql
+++ b/supabase/migrations/20260423_worldview_v1.sql
@@ -154,12 +154,12 @@ BEGIN
         RETURN;
     END IF;
 
-    -- Balance. We read profile-level balance if the agent_payment_pipeline
-    -- migration set it on agent_profiles; otherwise fall back to the
-    -- per-key balance if any.
+    -- Balance lives on public.profiles.balance_cents (added by
+    -- 20260316_agent_payment_pipeline.sql). profile_id here is the
+    -- profiles.id of the key owner.
     SELECT balance_cents INTO v_profile_bal
-    FROM public.agent_profiles
-    WHERE profile_id = p_profile_id;
+    FROM public.profiles
+    WHERE id = p_profile_id;
 
     v_balance := COALESCE(v_profile_bal, 0);
 
@@ -176,9 +176,9 @@ BEGIN
     END IF;
 
     -- Debit + log
-    UPDATE public.agent_profiles
+    UPDATE public.profiles
     SET balance_cents = balance_cents - p_cost_cents
-    WHERE profile_id = p_profile_id;
+    WHERE id = p_profile_id;
 
     UPDATE public.agent_api_keys
     SET last_used_at = v_now,

--- a/supabase/migrations/20260513_nlm_notifications.sql
+++ b/supabase/migrations/20260513_nlm_notifications.sql
@@ -24,6 +24,22 @@ create table if not exists public.nlm_training_runs (
   updated_at timestamptz not null default now()
 );
 
+-- Reconcile with earlier 20260324120000_unified_capabilities.sql which created
+-- nlm_training_runs with a different schema (run_name/model_architecture/
+-- hyperparameters/current_epoch/current_loss + a status CHECK constraint that
+-- doesn't include 'queued'). If that ran first, CREATE IF NOT EXISTS above
+-- silently skips and we'd be missing these columns plus blocked by the CHECK.
+alter table public.nlm_training_runs
+  add column if not exists model_id   uuid references public.nlm_models(id) on delete cascade,
+  add column if not exists owner_id   uuid references auth.users(id) on delete cascade,
+  add column if not exists config     jsonb not null default '{}'::jsonb,
+  add column if not exists metrics    jsonb not null default '{}'::jsonb,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.nlm_training_runs
+  drop constraint if exists nlm_training_runs_status_check;
+
 create table if not exists public.nlm_checkpoints (
   id uuid primary key default gen_random_uuid(),
   model_id uuid references public.nlm_models(id) on delete cascade,
@@ -33,6 +49,15 @@ create table if not exists public.nlm_checkpoints (
   metadata jsonb not null default '{}'::jsonb,
   created_at timestamptz not null default now()
 );
+
+-- Reconcile with earlier 20260324120000_unified_capabilities.sql which created
+-- nlm_checkpoints with epoch/s3_url/validation_score/is_best instead of
+-- model_id/owner_id/path/metadata.
+alter table public.nlm_checkpoints
+  add column if not exists model_id  uuid references public.nlm_models(id) on delete cascade,
+  add column if not exists owner_id  uuid references auth.users(id) on delete cascade,
+  add column if not exists path      text,
+  add column if not exists metadata  jsonb not null default '{}'::jsonb;
 
 create table if not exists public.nlm_variants (
   id text primary key,
@@ -66,6 +91,15 @@ create table if not exists public.notifications (
   metadata jsonb not null default '{}'::jsonb,
   created_at timestamptz not null default now()
 );
+
+-- Prod notifications predates this migration with only:
+-- (id, user_id, type, title, message, read, action_url, created_at, updated_at).
+-- Backfill the four columns this file expects so code can rely on them.
+alter table public.notifications
+  add column if not exists source         text not null default 'MYCA',
+  add column if not exists action_label   text,
+  add column if not exists correlation_id text,
+  add column if not exists metadata       jsonb not null default '{}'::jsonb;
 
 create table if not exists public.mindex_etl_requests (
   id uuid primary key default gen_random_uuid(),

--- a/supabase/migrations/create_contact_submissions.sql
+++ b/supabase/migrations/create_contact_submissions.sql
@@ -27,16 +27,19 @@ CREATE INDEX IF NOT EXISTS idx_contact_submissions_submitted_at ON contact_submi
 ALTER TABLE contact_submissions ENABLE ROW LEVEL SECURITY;
 
 -- Create policy for inserting (public can submit)
+DROP POLICY IF EXISTS "Allow public insert" ON contact_submissions;
 CREATE POLICY "Allow public insert" ON contact_submissions
   FOR INSERT
   WITH CHECK (true);
 
 -- Create policy for selecting (only authenticated users can view)
+DROP POLICY IF EXISTS "Allow authenticated read" ON contact_submissions;
 CREATE POLICY "Allow authenticated read" ON contact_submissions
   FOR SELECT
   USING (auth.role() = 'authenticated');
 
 -- Create policy for updating (only authenticated users can update)
+DROP POLICY IF EXISTS "Allow authenticated update" ON contact_submissions;
 CREATE POLICY "Allow authenticated update" ON contact_submissions
   FOR UPDATE
   USING (auth.role() = 'authenticated');
@@ -50,6 +53,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS contact_submissions_updated_at ON contact_submissions;
 CREATE TRIGGER contact_submissions_updated_at
   BEFORE UPDATE ON contact_submissions
   FOR EACH ROW


### PR DESCRIPTION
## Why

Prerequisite for the Worldview v1 launch PR. Audit against prod Supabase (`Mycosoft.com Production`) found:

1. **Runtime bug in `20260423_worldview_v1.sql`.** The `worldview_meter_and_limit` RPC reads/writes `public.agent_profiles`, but **no migration anywhere creates that table.** `CREATE FUNCTION` doesn't validate table references, so `db push` would succeed; first paid request then 500s with `relation "public.agent_profiles" does not exist`. Canonical pattern in every other agent RPC (`validate_api_key`, `increment_api_usage`, `get_agent_usage_summary`) is `public.profiles` keyed by `id`, and prod's `public.profiles` already has the `balance_cents` column. Fix matches that pattern.

2. **`db push --include-all` would abort** on the first existing-policy conflict. 23 prod policies already exist that un-guarded `CREATE POLICY` statements would try to recreate (12 on `storage.objects`, 6 on `active_sessions`/`user_heartbeat`, 4 on `user_app_state`, 1 on `agent_api_keys`).

3. **Silent schema drift on `public.notifications`.** Prod table predates `20260513_nlm_notifications.sql` with `(id, user_id, type, title, message, read, action_url, created_at, updated_at)` — missing `source`, `action_label`, `correlation_id`, `metadata`. `CREATE TABLE IF NOT EXISTS` would skip silently and code expecting the new columns would break.

4. **`nlm_training_runs` / `nlm_checkpoints` schema overlap** between `20260324120000_unified_capabilities.sql` (run_name/model_architecture/hyperparameters/current_epoch/current_loss + a `status CHECK` that excludes `queued`) and `20260513_nlm_notifications.sql` (model_id/owner_id/config/metrics). The earlier migration wins; the later silently skips.

## What's in this PR

| File | Change |
|---|---|
| `20260423_worldview_v1.sql` | `public.agent_profiles` → `public.profiles` (id key) in `worldview_meter_and_limit` body |
| `20260117210000_storage_policies.sql` | `DROP POLICY IF EXISTS` × 20 across all bucket policies |
| `20260126000000_user_app_state.sql` | `DROP POLICY IF EXISTS` × 4 |
| `20260212000000_create_support_tickets.sql` | `DROP POLICY IF EXISTS` × 3, `DROP TRIGGER IF EXISTS` × 1 |
| `20260224000000_active_sessions.sql` | `DROP POLICY IF EXISTS` × 8 (active_sessions / user_heartbeat / api_usage_log) |
| `20260307120000_supabase_operational_backbone.sql` | `DROP POLICY IF EXISTS` × 16 |
| `20260316_agent_payment_pipeline.sql` | `DROP POLICY IF EXISTS` × 4 |
| `20260317_agent_platform_v3.sql` | `DROP POLICY IF EXISTS` × 5 |
| `20260324120000_unified_capabilities.sql` | `DROP POLICY IF EXISTS` × 12 |
| `20260513_nlm_notifications.sql` | `ALTER TABLE ADD COLUMN IF NOT EXISTS` for notifications (4) + nlm_training_runs (6) + nlm_checkpoints (4); `DROP CONSTRAINT IF EXISTS nlm_training_runs_status_check` to clear the CHECK that excludes 'queued' |
| `create_contact_submissions.sql` | `DROP POLICY IF EXISTS` × 3, `DROP TRIGGER IF EXISTS` × 1 |

Untouched (already idempotent): `20260307130000_hardware_network_devices.sql`, `20260321_extend_temp_key_expiry.sql`, `20260423_device_visibility.sql`, `20260502_natureos_crep_waypoints.sql`, `20260503_natureos_crep_waypoints_attrs.sql`, `20260513090000_search_context_earth_filters.sql`.

## Prod-state evidence (verified before edits)

- 12 of 20 `storage.objects` policies already on prod (avatars/species-images/documents)
- `active_sessions` (4 policies) and `user_heartbeat` (2 policies) all present
- `user_app_state` (4 policies) all present
- `agent_api_keys` "Users can read own API keys" present (partial-apply of agent_payment_pipeline)
- `agent_api_keys.scopes` column already added (partial-apply of worldview_v1)
- `profiles.balance_cents` column already added (partial-apply of agent_payment_pipeline)
- `agent_usage_events`, `worldview_meter_and_limit`, `worldview_rate_weight_last_minute` **missing** (the bits this PR's downstream `db push` will add)
- `pgvector` 0.8.0, `pgcrypto` 1.3, `uuid-ossp` 1.1 — all extensions present for `VECTOR(1536)` etc.
- `economy_wallets` UPDATE in agent_payment_pipeline is a no-op — current prod rows already match the hardcoded BTC/ETH/SOL addresses byte-for-byte
- Destructive-op scan across all 17 files: one intentional `DROP INDEX IF EXISTS` in `20260503_natureos_crep_waypoints_attrs.sql`, nothing else

## What does *not* change

- No behavior change for any existing policy or RPC body except `worldview_meter_and_limit`. The PR adds guards, not rewrites.
- Permissive `USING (true) WITH CHECK (true)` policies in `supabase_operational_backbone.sql` and `unified_capabilities.sql` are flagged by Supabase security advisors but **left as-is** — that's a policy design decision, not a bug.
- Public-listable buckets (`avatars`, `species-images`) — same story, left as-is.

## Drift not addressed here

The Supabase `schema_migrations` tracker stops at `20260415073102`. Every repo migration after that date is unrecorded. This PR makes those re-runnable but doesn't claim ownership of the tracker drift problem (likely Vercel deploy-hook removal). Tracked in `go_no_go_decision.md` for the launch evidence packet.

## Apply path

After this merges:
1. Morgan runs `supabase db push --include-all` from Windows against the Production project.
2. I re-verify prod (same SELECT that flagged the bugs) — expect all worldview objects present.
3. Worldview launch branch lands.

## Test plan

- [ ] Local SQL syntax parse (already clean — see commit message)
- [ ] Apply against a Supabase branch / staging project before prod
- [ ] Confirm `worldview_meter_and_limit` callable on prod after apply
- [ ] Confirm 23 pre-existing policies still present (no accidental data path change)

https://claude.ai/code/session_01FEJ9i4idLFVXtMcrxym49K

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEJ9i4idLFVXtMcrxym49K)_

## Summary by Sourcery

Make Supabase SQL migrations idempotent for existing production state and fix the worldview metering RPC to use the correct profiles table for balances.

Bug Fixes:
- Update the worldview_meter_and_limit RPC to read and write balance_cents on public.profiles instead of the non-existent public.agent_profiles table, matching existing agent billing patterns.
- Align nlm_training_runs and nlm_checkpoints schemas with earlier unified_capabilities definitions and relax a restrictive status check constraint so queued runs are allowed.
- Backfill missing notifications columns (source, action_label, correlation_id, metadata) on existing public.notifications tables so application code can rely on them.

Enhancements:
- Add DROP POLICY IF EXISTS guards before (re)creating row-level security policies across storage, user app state, support tickets, active sessions, heartbeat, API usage, agent usage/events/temp_keys, agent API keys/sessions, unified capabilities, and operational backbone tables to make migrations re-runnable.
- Add DROP TRIGGER IF EXISTS guards before creating triggers on support_tickets and contact_submissions to avoid apply-time conflicts.
- Use ALTER TABLE ... ADD COLUMN IF NOT EXISTS for nlm_training_runs, nlm_checkpoints, and notifications to safely reconcile schema drift without destructive changes.