### PR TITLE
Earth Simulator (CREP): MYCA view cleanup, label LOD, live cameras, North America intel

### DIFF
--- a/components/crep/eagle-eye/VideoWallWidget.tsx
+++ b/components/crep/eagle-eye/VideoWallWidget.tsx
@@ -132,9 +132,20 @@ function HlsPlayer({ url, onFallback }: { url: string; onFallback?: () => void }
     // state, no overlay until / unless fatal error.
     const kickPlay = () => video.play().catch(() => { /* autoplay blocked — user clicks play */ })
 
+    // Live playlists (duration === Infinity) jump to the edge so the modal
+    // shows the present moment, not replayed buffer. VOD plays from the start.
+    const seekNativeToLiveEdge = () => {
+      try {
+        if (video.duration === Infinity && video.seekable.length) {
+          video.currentTime = video.seekable.end(video.seekable.length - 1)
+        }
+      } catch { /* ignore */ }
+    }
+
     if (video.canPlayType("application/vnd.apple.mpegurl")) {
       // Native HLS (Safari / iOS / Edge on macOS)
       video.src = playbackUrl
+      video.addEventListener("loadedmetadata", seekNativeToLiveEdge, { once: true })
       kickPlay()
     } else {
       import("hls.js").then((Hls) => {
@@ -142,24 +153,43 @@ function HlsPlayer({ url, onFallback }: { url: string; onFallback?: () => void }
         if (!H.isSupported()) {
           // Firefox with plugin / older browsers — try direct src.
           video.src = playbackUrl
+          video.addEventListener("loadedmetadata", seekNativeToLiveEdge, { once: true })
           kickPlay()
           return
         }
-        const hls = new H({ maxBufferLength: 10, manifestLoadingTimeOut: 12_000, levelLoadingTimeOut: 12_000, fragLoadingTimeOut: 12_000 })
+        // Live-tuned: follow the live edge, keep no back-buffer. Recovery
+        // re-syncs to "now" instead of looping the buffered clip.
+        const hls = new H({
+          lowLatencyMode: true,
+          liveSyncDurationCount: 3,
+          liveMaxLatencyDurationCount: 10,
+          backBufferLength: 0,
+          maxBufferLength: 10,
+          manifestLoadingTimeOut: 12_000,
+          levelLoadingTimeOut: 12_000,
+          fragLoadingTimeOut: 12_000,
+        })
+        const seekToLiveEdge = () => {
+          try {
+            if (hls.liveSyncPosition != null && Number.isFinite(hls.liveSyncPosition)) {
+              video.currentTime = hls.liveSyncPosition
+            }
+          } catch { /* ignore */ }
+        }
         hls.loadSource(playbackUrl)
         hls.attachMedia(video)
-        hls.on(H.Events.MANIFEST_PARSED, kickPlay)
+        hls.on(H.Events.MANIFEST_PARSED, () => { seekToLiveEdge(); kickPlay() })
         let recoveryAttempts = 0
         hls.on(H.Events.ERROR, (_evt: any, data: any) => {
           if (!data?.fatal) return
           if (data?.type === H.ErrorTypes.NETWORK_ERROR && recoveryAttempts < 1) {
             recoveryAttempts++
-            try { hls.startLoad() } catch { /* ignore */ }
+            try { hls.startLoad(); seekToLiveEdge() } catch { /* ignore */ }
             return
           }
           if (data?.type === H.ErrorTypes.MEDIA_ERROR && recoveryAttempts < 1) {
             recoveryAttempts++
-            try { hls.recoverMediaError() } catch { /* ignore */ }
+            try { hls.recoverMediaError(); seekToLiveEdge() } catch { /* ignore */ }
             return
           }
           if (retryNonce < 5) {

--- a/components/crep/eagle-eye/eagle-live-stream.tsx
+++ b/components/crep/eagle-eye/eagle-live-stream.tsx
@@ -176,28 +176,73 @@ export function HlsLivePlayer({
     let cleanup = () => {}
     const kickPlay = () => video.play().catch(() => {})
 
+    // Live edge for native HLS (Safari/iOS): duration === Infinity marks a
+    // live playlist — jump to the edge so we show the present, not buffered
+    // history. VOD playlists (finite duration) are left to play normally.
+    const seekNativeToLiveEdge = () => {
+      try {
+        if (video.duration === Infinity && video.seekable.length) {
+          video.currentTime = video.seekable.end(video.seekable.length - 1)
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+
     if (video.canPlayType("application/vnd.apple.mpegurl")) {
       video.src = playbackUrl
+      video.addEventListener("loadedmetadata", seekNativeToLiveEdge, { once: true })
       kickPlay()
     } else {
       import("hls.js").then((Hls) => {
         const H = (Hls as any).default || Hls
         if (!H.isSupported()) {
           video.src = playbackUrl
+          video.addEventListener("loadedmetadata", seekNativeToLiveEdge, { once: true })
           kickPlay()
           return
         }
+        // Live-tuned config: follow the live edge and keep no back-buffer, so a
+        // stalled feed resumes at "now" instead of replaying the same seconds.
         const hls = new H({
+          lowLatencyMode: true,
+          liveSyncDurationCount: 3,
+          liveMaxLatencyDurationCount: 10,
+          backBufferLength: 0,
           maxBufferLength: 8,
           manifestLoadingTimeOut: 10_000,
           levelLoadingTimeOut: 10_000,
           fragLoadingTimeOut: 10_000,
         })
+        const seekToLiveEdge = () => {
+          try {
+            if (hls.liveSyncPosition != null && Number.isFinite(hls.liveSyncPosition)) {
+              video.currentTime = hls.liveSyncPosition
+            }
+          } catch {
+            /* ignore */
+          }
+        }
         hls.loadSource(playbackUrl)
         hls.attachMedia(video)
-        hls.on(H.Events.MANIFEST_PARSED, kickPlay)
-        hls.on(H.Events.ERROR, (_evt: unknown, data: { fatal?: boolean }) => {
-          if (data?.fatal && retryNonce < 3) setRetryNonce((n) => n + 1)
+        hls.on(H.Events.MANIFEST_PARSED, () => {
+          seekToLiveEdge()
+          kickPlay()
+        })
+        hls.on(H.Events.ERROR, (_evt: unknown, data: { fatal?: boolean; type?: string }) => {
+          if (!data?.fatal) return
+          // Prefer in-place recovery (resumes at live edge) over a hard reload
+          // that would replay the buffered clip from the start.
+          if (data.type === H.ErrorTypes.MEDIA_ERROR) {
+            try {
+              hls.recoverMediaError()
+              seekToLiveEdge()
+              return
+            } catch {
+              /* fall through to reload */
+            }
+          }
+          if (retryNonce < 3) setRetryNonce((n) => n + 1)
         })
         cleanup = () => {
           try {

--- a/components/crep/panels/MycaViewportPanel.tsx
+++ b/components/crep/panels/MycaViewportPanel.tsx
@@ -18,7 +18,6 @@ import {
   Thermometer,
   Wind,
 } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import EagleEyeThumbnailGrid, { openEagleCamera } from "@/components/crep/eagle-eye/EagleEyeThumbnailGrid"
 import ViewportSensorGrid from "@/components/crep/eagle-eye/ViewportSensorGrid"
@@ -29,11 +28,22 @@ import {
   type EagleViewportSource,
 } from "@/lib/crep/eagle-viewport-sources"
 import {
-  esriWorldImageryTileUrl,
   isSignificantViewportChange,
   makeViewportRevisionKey,
   type MapBoundsLike,
 } from "@/lib/crep/viewport-revision"
+
+const DISMISSED_MENTIONS_KEY = "crep:myca:dismissed-mentions"
+
+function loadDismissedMentions(): Set<string> {
+  if (typeof window === "undefined") return new Set()
+  try {
+    const raw = window.sessionStorage.getItem(DISMISSED_MENTIONS_KEY)
+    return new Set(raw ? (JSON.parse(raw) as string[]) : [])
+  } catch {
+    return new Set()
+  }
+}
 
 interface GlobalEventLike {
   id: string
@@ -327,11 +337,6 @@ function MycaViewportPanel({
       .map(([name]) => name)
   }, [visibleFungalObservations])
 
-  const satelliteHeroUrl = useMemo(() => {
-    if (!viewportCenter) return null
-    return esriWorldImageryTileUrl(viewportCenter.lat, viewportCenter.lng, Math.max(8, Math.min(14, mapZoom)))
-  }, [viewportCenter, mapZoom])
-
   const fetchAiSummary = useCallback(async () => {
     if (!mapBounds || !revisionKey || !assetsReady) return
     if (lastAiRevision.current === revisionKey) return
@@ -436,43 +441,6 @@ function MycaViewportPanel({
   const current = environment?.weather?.current
   const units = environment?.weather?.units
   const forecastDaily = environment?.weather?.forecastDaily
-  const eventCarousel = useMemo(() => latestViewportEvents.slice(0, 15), [latestViewportEvents])
-  const [carouselIndex, setCarouselIndex] = useState(0)
-  const [carouselVisible, setCarouselVisible] = useState(true)
-  const prevFirstEventIdRef = useRef<string | null>(null)
-
-  // New event at the front → show it immediately (live feed behavior).
-  useEffect(() => {
-    const firstId = eventCarousel[0]?.id ?? null
-    if (!firstId) {
-      setCarouselIndex(0)
-      prevFirstEventIdRef.current = null
-      return
-    }
-    if (firstId !== prevFirstEventIdRef.current) {
-      prevFirstEventIdRef.current = firstId
-      setCarouselIndex(0)
-    }
-  }, [eventCarousel])
-
-  const activeEvent = eventCarousel[carouselIndex] ?? null
-
-  // Fade when the visible slide changes.
-  useEffect(() => {
-    if (!activeEvent) return
-    setCarouselVisible(false)
-    const t = window.setTimeout(() => setCarouselVisible(true), 40)
-    return () => window.clearTimeout(t)
-  }, [activeEvent?.id, carouselIndex])
-
-  // Auto-advance — no manual scroll; rotates through viewport events.
-  useEffect(() => {
-    if (eventCarousel.length <= 1) return
-    const timer = window.setInterval(() => {
-      setCarouselIndex((i) => (i + 1) % eventCarousel.length)
-    }, 5000)
-    return () => window.clearInterval(timer)
-  }, [eventCarousel.length, eventCarousel[0]?.id])
 
   const analysisMentions = useMemo((): AnalysisMention[] => {
     const mentions: AnalysisMention[] = []
@@ -585,8 +553,34 @@ function MycaViewportPanel({
     satelliteCount,
   ])
 
+  // Clicked "worth mentioning" chips are remembered for the session so the
+  // same item is not surfaced again (per-session dedupe, sessionStorage-backed).
+  const [dismissedMentions, setDismissedMentions] = useState<Set<string>>(loadDismissedMentions)
+
+  const dismissMention = useCallback((id: string) => {
+    setDismissedMentions((prev) => {
+      if (prev.has(id)) return prev
+      const next = new Set(prev)
+      next.add(id)
+      try {
+        window.sessionStorage.setItem(DISMISSED_MENTIONS_KEY, JSON.stringify([...next]))
+      } catch {
+        /* sessionStorage unavailable — keep in-memory only */
+      }
+      return next
+    })
+  }, [])
+
+  // Stable list (no auto-rotation): rotating/fading chips were stealing taps,
+  // so every chip is now a fixed, single-tap fly-to target.
+  const shownMentions = useMemo(
+    () => analysisMentions.filter((m) => !dismissedMentions.has(m.id)).slice(0, 10),
+    [analysisMentions, dismissedMentions],
+  )
+
   const handleMentionClick = useCallback(
     (mention: AnalysisMention) => {
+      dismissMention(mention.id)
       if (mention.kind === "camera" && mention.camera) {
         openEagleCamera(mention.camera, onFlyTo)
         return
@@ -600,130 +594,13 @@ function MycaViewportPanel({
           new CustomEvent("crep:analysis:select-event", { detail: { eventId } }),
         )
       }
-
-      if (mention.kind === "camera" && mention.camera) {
-        openEagleCamera(mention.camera, onFlyTo)
-      }
     },
-    [onFlyTo],
+    [onFlyTo, dismissMention],
   )
-
-  const mentionSlotCount = 2
-  const [mentionIndex, setMentionIndex] = useState(0)
-  const [mentionFade, setMentionFade] = useState(true)
-
-  useEffect(() => {
-    setMentionIndex(0)
-  }, [revisionKey, analysisMentions.length])
-
-  const visibleMentions = useMemo(() => {
-    if (analysisMentions.length === 0) return []
-    if (analysisMentions.length <= mentionSlotCount) return analysisMentions
-    return Array.from({ length: mentionSlotCount }, (_, i) =>
-      analysisMentions[(mentionIndex + i) % analysisMentions.length],
-    )
-  }, [analysisMentions, mentionIndex, mentionSlotCount])
-
-  useEffect(() => {
-    if (analysisMentions.length <= mentionSlotCount) return
-    const timer = window.setInterval(() => {
-      setMentionFade(false)
-      window.setTimeout(() => {
-        setMentionIndex((i) => (i + mentionSlotCount) % analysisMentions.length)
-        setMentionFade(true)
-      }, 140)
-    }, 3200)
-    return () => window.clearInterval(timer)
-  }, [analysisMentions.length, mentionSlotCount])
 
   return (
     <ScrollArea className="h-full">
       <div className="flex min-h-full flex-col gap-2 p-2">
-        {/* Satellite / imagery hero */}
-        <div className="relative overflow-hidden rounded-lg border border-purple-500/30 bg-black/40">
-          {satelliteHeroUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={satelliteHeroUrl}
-              alt=""
-              className="h-24 w-full object-cover opacity-90"
-            />
-          ) : (
-            <div className="flex h-24 items-center justify-center bg-gradient-to-br from-slate-900 to-purple-950/40">
-              <Satellite className="h-6 w-6 text-purple-400/60" />
-            </div>
-          )}
-          <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 to-transparent px-2 py-1.5">
-            <div className="flex items-center justify-between">
-              <span className="text-[9px] font-semibold text-purple-200">Viewport imagery</span>
-              {viewportCenter && (
-                <span className="font-mono text-[7px] text-gray-400">
-                  {viewportCenter.lat.toFixed(2)}°, {viewportCenter.lng.toFixed(2)}° · z{mapZoom.toFixed(1)}
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Live events carousel — auto-rotates; jumps to newest on ingest */}
-        <div className="rounded-lg border border-orange-500/25 bg-orange-950/10 p-1.5">
-          <div className="mb-1 flex items-center justify-between">
-            <div className="flex items-center gap-1">
-              <Radio className="h-3 w-3 text-orange-400" />
-              <span className="text-[9px] font-bold text-orange-200">Latest events</span>
-            </div>
-            <Badge variant="outline" className="border-orange-500/40 px-1 py-0 text-[7px] text-orange-300">
-              {latestViewportEvents.length}
-            </Badge>
-          </div>
-          {eventCarousel.length === 0 ? (
-            <span className="text-[8px] text-gray-500">No events in this viewport.</span>
-          ) : (
-            <div className="space-y-1">
-              <button
-                type="button"
-                onClick={() => {
-                  if (activeEvent?.lng != null && activeEvent?.lat != null) {
-                    onFlyTo?.(activeEvent.lng, activeEvent.lat, 10)
-                  }
-                }}
-                className={cn(
-                  "w-full rounded border border-orange-500/25 bg-black/35 px-2 py-1.5 text-left transition-opacity duration-300 hover:border-orange-400/50",
-                  carouselVisible ? "opacity-100" : "opacity-0",
-                )}
-              >
-                <div className="truncate text-[9px] font-medium text-white">{activeEvent?.title}</div>
-                <div className="mt-0.5 flex items-center justify-between gap-2">
-                  <span className="truncate text-[7px] text-gray-500">
-                    {activeEvent?.type || activeEvent?.source || "event"}
-                  </span>
-                  {activeEvent?.severity && (
-                    <span className="shrink-0 text-[7px] uppercase text-orange-300/90">{activeEvent.severity}</span>
-                  )}
-                </div>
-              </button>
-              {eventCarousel.length > 1 && (
-                <div className="flex items-center justify-center gap-1 pt-0.5">
-                  {eventCarousel.map((event, index) => (
-                    <button
-                      key={event.id}
-                      type="button"
-                      aria-label={`Show event ${index + 1}: ${event.title}`}
-                      onClick={() => setCarouselIndex(index)}
-                      className={cn(
-                        "h-1.5 rounded-full transition-all",
-                        index === carouselIndex
-                          ? "w-3 bg-orange-400"
-                          : "w-1.5 bg-orange-500/30 hover:bg-orange-400/60",
-                      )}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
         {/* Environment + species */}
         <div className="rounded-lg border border-emerald-500/25 bg-emerald-950/10 p-1.5">
           <div className="mb-1.5 flex items-center justify-between">
@@ -843,43 +720,33 @@ function MycaViewportPanel({
             )}
           </div>
 
-          {analysisMentions.length > 0 && (
+          {shownMentions.length > 0 && (
             <div className="mt-1.5 shrink-0">
-              <div className="mb-0.5 flex items-center justify-between gap-1">
-                <span className="text-[6px] font-semibold uppercase tracking-wider text-purple-300/65">
+              <div className="mb-1 flex items-center justify-between gap-1">
+                <span className="text-[7px] font-semibold uppercase tracking-wider text-purple-300/70">
                   Worth mentioning
                 </span>
-                {analysisMentions.length > mentionSlotCount && (
-                  <span className="text-[6px] tabular-nums text-purple-400/45">
-                    {Math.floor(mentionIndex / mentionSlotCount) + 1}/
-                    {Math.ceil(analysisMentions.length / mentionSlotCount)}
-                  </span>
-                )}
+                <span className="text-[7px] text-purple-400/45">tap to fly</span>
               </div>
-              <div
-                className={cn(
-                  "flex min-h-[18px] items-center gap-1 transition-opacity duration-150",
-                  mentionFade ? "opacity-100" : "opacity-30",
-                )}
-              >
-                {visibleMentions.map((mention, slotIdx) => {
+              <div className="flex flex-wrap gap-1">
+                {shownMentions.map((mention) => {
                   const Icon = mentionIcon(mention.kind)
-                  const clickable = mention.lng != null && mention.lat != null
+                  const clickable = (mention.lng != null && mention.lat != null) || mention.kind === "camera"
                   return (
                     <button
-                      key={`${mention.id}-slot-${slotIdx}`}
+                      key={mention.id}
                       type="button"
                       disabled={!clickable}
                       onClick={() => handleMentionClick(mention)}
                       title={mention.detail ? `${mention.label} · ${mention.detail}` : mention.label}
                       className={cn(
-                        "inline-flex h-[18px] max-w-[48%] flex-1 items-center gap-0.5 rounded border px-1 text-left transition-colors",
+                        "inline-flex min-h-[26px] max-w-full items-center gap-1 rounded border px-1.5 py-1 text-left transition-colors touch-manipulation",
                         mentionTone(mention.kind),
                         !clickable && "cursor-default opacity-45",
                       )}
                     >
-                      <Icon className="h-2 w-2 shrink-0 opacity-90" />
-                      <span className="truncate text-[6px] font-medium leading-none">{mention.label}</span>
+                      <Icon className="h-2.5 w-2.5 shrink-0 opacity-90" />
+                      <span className="truncate text-[8px] font-medium leading-tight">{mention.label}</span>
                     </button>
                   )
                 })}

--- a/lib/crep/civic-fallback.ts
+++ b/lib/crep/civic-fallback.ts
@@ -118,12 +118,160 @@ const STATE_NAME_TO_CODE: Record<string, string> = {
   wisconsin: "WI", wyoming: "WY", "district of columbia": "DC",
 }
 
-const STATE_EXECUTIVES: Record<string, { name: string; party?: string }> = {
-  CA: { name: "Gavin Newsom", party: "Democratic" },
-  TX: { name: "Greg Abbott", party: "Republican" },
-  NY: { name: "Kathy Hochul", party: "Democratic" },
-  FL: { name: "Ron DeSantis", party: "Republican" },
-  AZ: { name: "Katie Hobbs", party: "Democratic" },
+interface ExecutiveSeed {
+  name: string
+  party?: string
+  url?: string
+}
+
+/** Heads of state / government for North American nations (country-level LOD). */
+const NATIONAL_EXECUTIVES: Record<string, CivicFallbackOfficial[]> = {
+  US: [
+    {
+      id: "nat:us:potus",
+      name: "Donald J. Trump",
+      office: "President of the United States",
+      party: "Republican",
+      jurisdiction_name: "United States",
+      urls: ["https://www.whitehouse.gov/"],
+      phones: ["+1-202-456-1111"],
+      address: "1600 Pennsylvania Avenue NW, Washington, DC 20500",
+      term_start: "2025-01-20",
+      term_end: null,
+    },
+    {
+      id: "nat:us:vpotus",
+      name: "JD Vance",
+      office: "Vice President of the United States",
+      party: "Republican",
+      jurisdiction_name: "United States",
+      urls: ["https://www.whitehouse.gov/administration/"],
+      phones: ["+1-202-456-1111"],
+      term_start: "2025-01-20",
+      term_end: null,
+    },
+  ],
+  CA: [
+    {
+      id: "nat:ca:pm",
+      name: "Mark Carney",
+      office: "Prime Minister of Canada",
+      party: "Liberal",
+      jurisdiction_name: "Canada",
+      urls: ["https://www.pm.gc.ca/en"],
+      phones: ["+1-613-992-4211"],
+      address: "Office of the Prime Minister, 80 Wellington Street, Ottawa, ON K1A 0A2",
+      term_start: "2025-03-14",
+      term_end: null,
+    },
+  ],
+  MX: [
+    {
+      id: "nat:mx:potus",
+      name: "Claudia Sheinbaum",
+      office: "President of Mexico",
+      party: "Morena",
+      jurisdiction_name: "Mexico",
+      urls: ["https://www.gob.mx/presidencia"],
+      address: "Palacio Nacional, Plaza de la Constitución S/N, Centro, 06066 Ciudad de México",
+      term_start: "2024-10-01",
+      term_end: null,
+    },
+  ],
+}
+
+const COUNTRY_NAME_TO_CODE: Record<string, string> = {
+  "united states": "US",
+  "united states of america": "US",
+  usa: "US",
+  "u.s.a.": "US",
+  "u.s.": "US",
+  us: "US",
+  america: "US",
+  canada: "CA",
+  ca: "CA",
+  mexico: "MX",
+  méxico: "MX",
+  "estados unidos mexicanos": "MX",
+  mx: "MX",
+}
+
+/** Current U.S. governors (all 50 states). Live MINDEX civic data overrides this. */
+const STATE_EXECUTIVES: Record<string, ExecutiveSeed> = {
+  AL: { name: "Kay Ivey", party: "Republican", url: "https://governor.alabama.gov/" },
+  AK: { name: "Mike Dunleavy", party: "Republican", url: "https://gov.alaska.gov/" },
+  AZ: { name: "Katie Hobbs", party: "Democratic", url: "https://azgovernor.gov/" },
+  AR: { name: "Sarah Huckabee Sanders", party: "Republican", url: "https://governor.arkansas.gov/" },
+  CA: { name: "Gavin Newsom", party: "Democratic", url: "https://www.gov.ca.gov/" },
+  CO: { name: "Jared Polis", party: "Democratic", url: "https://governor.colorado.gov/" },
+  CT: { name: "Ned Lamont", party: "Democratic", url: "https://portal.ct.gov/governor" },
+  DE: { name: "Matt Meyer", party: "Democratic", url: "https://governor.delaware.gov/" },
+  FL: { name: "Ron DeSantis", party: "Republican", url: "https://www.flgov.com/" },
+  GA: { name: "Brian Kemp", party: "Republican", url: "https://gov.georgia.gov/" },
+  HI: { name: "Josh Green", party: "Democratic", url: "https://governor.hawaii.gov/" },
+  ID: { name: "Brad Little", party: "Republican", url: "https://gov.idaho.gov/" },
+  IL: { name: "JB Pritzker", party: "Democratic", url: "https://gov.illinois.gov/" },
+  IN: { name: "Mike Braun", party: "Republican", url: "https://www.in.gov/gov/" },
+  IA: { name: "Kim Reynolds", party: "Republican", url: "https://governor.iowa.gov/" },
+  KS: { name: "Laura Kelly", party: "Democratic", url: "https://governor.kansas.gov/" },
+  KY: { name: "Andy Beshear", party: "Democratic", url: "https://governor.ky.gov/" },
+  LA: { name: "Jeff Landry", party: "Republican", url: "https://gov.louisiana.gov/" },
+  ME: { name: "Janet Mills", party: "Democratic", url: "https://www.maine.gov/governor/mills/" },
+  MD: { name: "Wes Moore", party: "Democratic", url: "https://governor.maryland.gov/" },
+  MA: { name: "Maura Healey", party: "Democratic", url: "https://www.mass.gov/orgs/office-of-governor-maura-healey-and-lt-governor-kim-driscoll" },
+  MI: { name: "Gretchen Whitmer", party: "Democratic", url: "https://www.michigan.gov/whitmer" },
+  MN: { name: "Tim Walz", party: "Democratic-Farmer-Labor", url: "https://mn.gov/governor/" },
+  MS: { name: "Tate Reeves", party: "Republican", url: "https://governorreeves.ms.gov/" },
+  MO: { name: "Mike Kehoe", party: "Republican", url: "https://governor.mo.gov/" },
+  MT: { name: "Greg Gianforte", party: "Republican", url: "https://governor.mt.gov/" },
+  NE: { name: "Jim Pillen", party: "Republican", url: "https://governor.nebraska.gov/" },
+  NV: { name: "Joe Lombardo", party: "Republican", url: "https://gov.nv.gov/" },
+  NH: { name: "Kelly Ayotte", party: "Republican", url: "https://www.governor.nh.gov/" },
+  NJ: { name: "Phil Murphy", party: "Democratic", url: "https://www.nj.gov/governor/" },
+  NM: { name: "Michelle Lujan Grisham", party: "Democratic", url: "https://www.governor.state.nm.us/" },
+  NY: { name: "Kathy Hochul", party: "Democratic", url: "https://www.governor.ny.gov/" },
+  NC: { name: "Josh Stein", party: "Democratic", url: "https://governor.nc.gov/" },
+  ND: { name: "Kelly Armstrong", party: "Republican", url: "https://www.governor.nd.gov/" },
+  OH: { name: "Mike DeWine", party: "Republican", url: "https://governor.ohio.gov/" },
+  OK: { name: "Kevin Stitt", party: "Republican", url: "https://oklahoma.gov/governor.html" },
+  OR: { name: "Tina Kotek", party: "Democratic", url: "https://www.oregon.gov/gov/" },
+  PA: { name: "Josh Shapiro", party: "Democratic", url: "https://www.pa.gov/governor/" },
+  RI: { name: "Dan McKee", party: "Democratic", url: "https://governor.ri.gov/" },
+  SC: { name: "Henry McMaster", party: "Republican", url: "https://governor.sc.gov/" },
+  SD: { name: "Larry Rhoden", party: "Republican", url: "https://governor.sd.gov/" },
+  TN: { name: "Bill Lee", party: "Republican", url: "https://www.tn.gov/governor.html" },
+  TX: { name: "Greg Abbott", party: "Republican", url: "https://gov.texas.gov/" },
+  UT: { name: "Spencer Cox", party: "Republican", url: "https://governor.utah.gov/" },
+  VT: { name: "Phil Scott", party: "Republican", url: "https://governor.vermont.gov/" },
+  VA: { name: "Glenn Youngkin", party: "Republican", url: "https://www.governor.virginia.gov/" },
+  WA: { name: "Bob Ferguson", party: "Democratic", url: "https://governor.wa.gov/" },
+  WV: { name: "Patrick Morrisey", party: "Republican", url: "https://governor.wv.gov/" },
+  WI: { name: "Tony Evers", party: "Democratic", url: "https://evers.wi.gov/" },
+  WY: { name: "Mark Gordon", party: "Republican", url: "https://governor.wyo.gov/" },
+}
+
+/** Canadian provincial premiers (province-level LOD). */
+const CA_PROVINCE_EXECUTIVES: Record<string, ExecutiveSeed> = {
+  AB: { name: "Danielle Smith", party: "United Conservative", url: "https://www.alberta.ca/premier" },
+  BC: { name: "David Eby", party: "BC NDP", url: "https://news.gov.bc.ca/office-of-the-premier" },
+  MB: { name: "Wab Kinew", party: "Manitoba NDP", url: "https://www.gov.mb.ca/premier/" },
+  NB: { name: "Susan Holt", party: "Liberal", url: "https://www2.gnb.ca/" },
+  NS: { name: "Tim Houston", party: "Progressive Conservative", url: "https://novascotia.ca/premier/" },
+  ON: { name: "Doug Ford", party: "Progressive Conservative", url: "https://www.ontario.ca/page/premier" },
+  QC: { name: "François Legault", party: "Coalition Avenir Québec", url: "https://www.quebec.ca/en/premier" },
+  SK: { name: "Scott Moe", party: "Saskatchewan Party", url: "https://www.saskatchewan.ca/government/premier-of-saskatchewan" },
+}
+
+const CA_PROVINCE_NAME_TO_CODE: Record<string, string> = {
+  alberta: "AB",
+  "british columbia": "BC",
+  manitoba: "MB",
+  "new brunswick": "NB",
+  "nova scotia": "NS",
+  ontario: "ON",
+  quebec: "QC",
+  québec: "QC",
+  saskatchewan: "SK",
 }
 
 const CITY_MAYORS: Record<string, { name: string; party?: string }> = {
@@ -172,6 +320,36 @@ function resolveStateCode(state?: string | null): string | null {
   const trimmed = state.trim()
   if (/^[A-Za-z]{2}$/.test(trimmed)) return trimmed.toUpperCase()
   return STATE_NAME_TO_CODE[trimmed.toLowerCase()] ?? null
+}
+
+function resolveCountryCode(country?: string | null): string | null {
+  if (!country) return null
+  const trimmed = country.trim()
+  if (/^[A-Za-z]{2}$/.test(trimmed)) {
+    const upper = trimmed.toUpperCase()
+    if (NATIONAL_EXECUTIVES[upper]) return upper
+  }
+  return COUNTRY_NAME_TO_CODE[trimmed.toLowerCase()] ?? null
+}
+
+function resolveCaProvinceCode(province?: string | null): string | null {
+  if (!province) return null
+  const trimmed = province.trim()
+  if (/^[A-Za-z]{2}$/.test(trimmed) && CA_PROVINCE_EXECUTIVES[trimmed.toUpperCase()]) {
+    return trimmed.toUpperCase()
+  }
+  return CA_PROVINCE_NAME_TO_CODE[trimmed.toLowerCase()] ?? null
+}
+
+function appendNationalExecutives(countryCode: string | null, officials: CivicFallbackOfficial[]) {
+  if (!countryCode) return
+  const nationals = NATIONAL_EXECUTIVES[countryCode]
+  if (!nationals?.length) return
+  const seen = new Set(officials.map((o) => o.id))
+  for (const official of nationals) {
+    if (seen.has(official.id)) continue
+    officials.push(withPortrait(official))
+  }
 }
 
 function formatPersonName(name: Record<string, unknown> | undefined): string {
@@ -270,9 +448,15 @@ export async function fetchCivicFallback(input: {
   country?: string | null
 }): Promise<CivicFallbackResult> {
   const stateCode = resolveStateCode(input.state)
+  const countryCode = resolveCountryCode(input.country)
+  const provinceCode = countryCode === "CA" ? resolveCaProvinceCode(input.state) : null
   const jurisdictionLabel = [input.city, input.state, input.country].filter(Boolean).join(", ")
   const officials: CivicFallbackOfficial[] = []
 
+  // National leadership (head of state / government) — surfaces at country LOD.
+  appendNationalExecutives(countryCode, officials)
+
+  // U.S. state governor.
   if (stateCode && STATE_EXECUTIVES[stateCode]) {
     const exec = STATE_EXECUTIVES[stateCode]
     officials.push(
@@ -282,8 +466,23 @@ export async function fetchCivicFallback(input: {
         office: `Governor of ${input.state ?? stateCode}`,
         party: exec.party,
         jurisdiction_name: input.state ?? stateCode,
-        urls: [`https://www.usa.gov/state-governor`],
-        term_start: "2019-01-07",
+        urls: [exec.url ?? "https://www.usa.gov/state-governor"],
+        term_end: null,
+      }),
+    )
+  }
+
+  // Canadian provincial premier.
+  if (provinceCode && CA_PROVINCE_EXECUTIVES[provinceCode]) {
+    const premier = CA_PROVINCE_EXECUTIVES[provinceCode]
+    officials.push(
+      withPortrait({
+        id: `premier:${provinceCode}`,
+        name: premier.name,
+        office: `Premier of ${input.state ?? provinceCode}`,
+        party: premier.party,
+        jurisdiction_name: input.state ?? provinceCode,
+        urls: premier.url ? [premier.url] : [],
         term_end: null,
       }),
     )

--- a/lib/crep/executive-portraits.ts
+++ b/lib/crep/executive-portraits.ts
@@ -46,6 +46,28 @@ const PORTRAIT_BY_NAME: Record<string, string> = {
     "https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Joe_Biden_presidential_portrait.jpg/440px-Joe_Biden_presidential_portrait.jpg",
   "donald trump":
     "https://upload.wikimedia.org/wikipedia/commons/thumb/5/56/Donald_Trump_official_portrait.jpg/440px-Donald_Trump_official_portrait.jpg",
+  "donald j. trump":
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/5/56/Donald_Trump_official_portrait.jpg/440px-Donald_Trump_official_portrait.jpg",
+  // Below use Wikimedia's Special:FilePath resolver (filename → current file,
+  // hash-independent). A wrong filename 404s and the card falls back to an icon.
+  "jd vance": commonsPortrait("JD Vance Vice Presidential Portrait.jpg"),
+  "claudia sheinbaum": commonsPortrait("Claudia Sheinbaum Pardo (cropped).jpg"),
+  "mark carney": commonsPortrait("Mark Carney 2020 (cropped).jpg"),
+  "jb pritzker": commonsPortrait("JB Pritzker (cropped).jpg"),
+  "gretchen whitmer": commonsPortrait("Gretchen Whitmer (cropped).jpg"),
+  "josh shapiro": commonsPortrait("Josh Shapiro (cropped).jpg"),
+  "glenn youngkin": commonsPortrait("Glenn Youngkin (cropped).jpg"),
+  "wes moore": commonsPortrait("Wes Moore (cropped).jpg"),
+  "brian kemp": commonsPortrait("Brian Kemp (cropped).jpg"),
+  "maura healey": commonsPortrait("Maura Healey (cropped).jpg"),
+  "andy beshear": commonsPortrait("Andy Beshear (cropped).jpg"),
+  "jared polis": commonsPortrait("Jared Polis (cropped).jpg"),
+  "doug ford": commonsPortrait("Doug Ford (cropped).jpg"),
+}
+
+/** Wikimedia Commons file → stable resolver URL (no hash path required). */
+function commonsPortrait(filename: string): string {
+  return `https://commons.wikimedia.org/wiki/Special:FilePath/${encodeURIComponent(filename)}?width=440`
 }
 
 function bioguidePhotoUrl(id?: string): string | null {

--- a/lib/crep/jurisdiction-layers.ts
+++ b/lib/crep/jurisdiction-layers.ts
@@ -199,7 +199,12 @@ export function addJurisdictionLayers(map: any, options?: {
       minzoom: 2,
     })
 
-    // State names — dark-matter-nolabels strips place_state; add dedicated labels.
+    // State / province / region names — dark-matter-nolabels strips place_state.
+    // Only render once the operator has zoomed into a region (minzoom 4): at
+    // planet/global view these stacked on top of each other (allow-overlap) and
+    // flooded the globe on refresh, hurting both readability and FPS. Collision
+    // detection (allow-overlap:false) now reveals labels progressively as you
+    // zoom in, so a title only appears when its area is actually in focus.
     safeLayer({
       id: "crep-state-labels",
       type: "symbol",
@@ -209,13 +214,14 @@ export function addJurisdictionLayers(map: any, options?: {
       layout: {
         visibility: stateVisible,
         "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
-        "text-size": ["interpolate", ["linear"], ["zoom"], 3, 12, 5, 14, 8, 16],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 4, 12, 6, 14, 9, 16],
         "text-font": ["Montserrat Medium", "Open Sans Bold", "Arial Unicode MS Bold"],
         "text-transform": "uppercase",
         "text-max-width": 10,
         "text-letter-spacing": 0.06,
-        "text-allow-overlap": true,
+        "text-allow-overlap": false,
         "text-ignore-placement": false,
+        "text-padding": 6,
       },
       paint: {
         "text-color": "#e0f2fe",
@@ -223,7 +229,7 @@ export function addJurisdictionLayers(map: any, options?: {
         "text-halo-color": "#020617",
         "text-halo-width": 2,
       },
-      minzoom: 3,
+      minzoom: 4,
       maxzoom: 12,
     })
 

--- a/lib/crep/viewport-leadership.ts
+++ b/lib/crep/viewport-leadership.ts
@@ -37,7 +37,11 @@ function officeLower(office: string): string {
 
 export function isFederalExecutive(office: string): boolean {
   const v = officeLower(office)
-  return v.includes("president") || v.includes("vice president")
+  return (
+    v.includes("president") ||
+    v.includes("vice president") ||
+    v.includes("prime minister")
+  )
 }
 
 export function isStateExecutive(office: string): boolean {
@@ -46,7 +50,8 @@ export function isStateExecutive(office: string): boolean {
     v.includes("governor") ||
     v.includes("lieutenant governor") ||
     v.includes("lt. governor") ||
-    v.includes("lt governor")
+    v.includes("lt governor") ||
+    v.includes("premier")
   )
 }
 


### PR DESCRIPTION
## Summary

Audit + fixes for the Earth Simulator (which renders the CREP dashboard). This first pass lands the concrete, verified items from the request; the remaining live-only items are tracked below.

### MYCA view (`components/crep/panels/MycaViewportPanel.tsx`)
- **Removed the "Viewport imagery" hero** at the top of the MYCA view (the satellite thumbnail block).
- **Removed the "Latest events" auto-rotating carousel** ("not good there"). Events still feed the MYCA AI summary and appear as fly-to chips.
- **"Worth mentioning" chips fixed**: they no longer auto-rotate/fade — that motion was stealing taps and is why they weren't reliably "fly-to selectable". Chips are now stable, larger, single-tap fly-to targets. **Clicked chips are saved to `sessionStorage` and never shown again** in the session.
- Net effect also removes two `setInterval` timers + fade re-renders from the panel.

### Region/state/district titles (`lib/crep/jurisdiction-layers.ts`)
- `crep-state-labels` previously rendered at **minzoom 3 with `text-allow-overlap: true`**, so every state/region name stacked on the globe at refresh (the "visual stupidity and lag" on the planet view).
- Now **minzoom 4 + collision detection** (`text-allow-overlap: false`, `text-padding`): no titles at the global/planet view; labels reveal progressively as you zoom into a region. Basemap is `dark-matter-nolabels`, so this layer is the only state-label source.

### Live cameras (`eagle-live-stream.tsx`, `VideoWallWidget.tsx`)
- HLS players now **follow the live edge** (`lowLatencyMode`, `liveSyncDurationCount`, no back-buffer, seek-to-edge on manifest-load and on recovery) instead of replaying buffered seconds — addresses "repeating seconds of a single clip, not live." VOD playlists still play normally (only live playlists are snapped to the edge).

### Viewport Intelligence — North America (`civic-fallback.ts`, `viewport-leadership.ts`, `executive-portraits.ts`)
- The civic fallback only had 5 governors and one state's federal delegation, so most of North America showed nothing. Added:
  - **National leaders** for the US, Canada, and Mexico (with office address / phone / official site).
  - **All 50 US governors** with party + official `.gov` site.
  - **Canadian provincial premiers** with official sites.
- Mapped **`prime minister` → federal LOD** and **`premier` → state LOD** so Canada/Mexico leaders appear at the right zoom.
- Added portraits for key leaders via Wikimedia `Special:FilePath` (cards already fall back to an icon on a miss).
- Verified live against `/api/crep/viewport-intel`: US view → Trump + Vance; California → + Newsom + CA delegation (portraits + URLs); Canada → PM Carney.

## Still to do (need live interaction / profiling)
- **Full per-button audit + the "click causes refresh/crash" repro.** The MYCA carousel bounce is fixed; pinning down the specific button(s) that reload/crash the simulator needs a repro (which button, what zoom/layer state).
- **Device-tier FPS profiling.** The label-flood fix is the biggest known win on the global view; deeper LOD tuning for low-end devices should be profiled live.

> Note on data freshness: governor/leader names reflect early-2026 knowledge and are a *fallback* — live MINDEX civic data overrides them when available. A couple of seats decided in late-2025 elections may need a refresh.

## Test plan
- [ ] Open `/natureos/earth-simulator`; confirm no state/region titles at planet view, and they appear when zooming into a region.
- [ ] MYCA tab: confirm imagery hero + Latest-events carousel are gone; tap a "Worth mentioning" chip → it flies there and disappears for the session.
- [ ] Intel tab over the US / a state / Canada: confirm leaders, parties, official-site links, and portraits render.
- [ ] Click an Eagle Eye camera with an HLS feed: confirm it plays live (at the edge), not a looping clip.

https://claude.ai/code/session_012RyGMiTdPeqgrQ14PZPbCo

---
_Generated by [Claude Code](https://claude.ai/code/session_012RyGMiTdPeqgrQ14PZPbCo)_

## Summary by Sourcery

Clean up the MYCA viewport UI, improve live HLS playback behavior, and enrich North American civic fallback data and labeling in the Earth Simulator.

New Features:
- Persist dismissal of MYCA "Worth mentioning" chips per session so previously selected items are not resurfaced.
- Provide comprehensive civic fallback coverage for US national leadership, all US governors, and Canadian national and provincial leaders, including URLs and portrait support.

Bug Fixes:
- Ensure MYCA "Worth mentioning" chips are stable, tappable fly-to targets instead of auto-rotating elements that can steal taps.
- Make HLS-based Eagle Eye live streams follow the live edge and recover at "now" rather than replaying buffered seconds.
- Prevent excessive overlapping state labels at global zoom by delaying label rendering and enabling collision detection.

Enhancements:
- Simplify the MYCA viewport panel by removing the satellite imagery hero and the latest-events carousel.
- Improve executive portrait handling by adding Wikimedia-based portrait mappings for key leaders.