### PR TITLE
fix(earth-sim): always-globe + AIS SLA cap + FDOT camera migration (P1 batch)

### DIFF
--- a/app/api/eagle/connectors/state-dot-cctv/route.ts
+++ b/app/api/eagle/connectors/state-dot-cctv/route.ts
@@ -215,30 +215,40 @@ async function pullWSDOT(): Promise<Cam[]> {
 }
 
 // ─── FDOT (Florida) ─────────────────────────────────────────────────────
+// Jun 13, 2026 (P1-4): fl511.com migrated to the Castle Rock "OneStop"
+// platform. The old /map/data/cctvs.json now 404s, so pullFDOT silently
+// returned [] and Florida showed zero cameras. The keyless camera index now
+// lives at /map/mapIcons/Cameras (item2:[{itemId, location:[lat,lng], title,
+// expando:{videoEnabled}}], ~4,800 cams) with the live JPEG snapshot at
+// /map/Cctv/{itemId} — the same contract pullCastleRock511() uses for GA/WI/PA.
 async function pullFDOT(): Promise<Cam[]> {
   try {
-    const res = await fetch("https://fl511.com/map/data/cctvs.json", {
+    const res = await fetch("https://fl511.com/map/mapIcons/Cameras", {
       headers: { Accept: "application/json", "User-Agent": "MycosoftCREP/1.0" },
       signal: AbortSignal.timeout(15_000),
     })
     if (!res.ok) return []
+    const ct = res.headers.get("content-type") || ""
+    if (!/json/i.test(ct)) return []
     const j = await res.json()
-    const items: any[] = j?.data || j?.features || (Array.isArray(j) ? j : [])
+    const items: any[] = Array.isArray(j?.item2) ? j.item2 : []
     return items
-      .map((c: any): Cam | null => {
-        const lat = Number(c.latitude ?? c.lat ?? c.geometry?.coordinates?.[1])
-        const lng = Number(c.longitude ?? c.lng ?? c.geometry?.coordinates?.[0])
+      .map((it: any): Cam | null => {
+        const loc = it?.location
+        const lat = Number(Array.isArray(loc) ? loc[0] : it?.latitude ?? it?.lat)
+        const lng = Number(Array.isArray(loc) ? loc[1] : it?.longitude ?? it?.lng)
         if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
-        const rawImg = c.imageUrl || c.snapshotUrl || null
-        const proxiedImg = rawImg ? `/api/eagle/cam-image?url=${encodeURIComponent(rawImg)}` : null
+        const itemId = it?.itemId ?? `${lat},${lng}`
+        const snapshot = `https://fl511.com/map/Cctv/${encodeURIComponent(String(itemId))}`
+        const proxiedImg = `/api/eagle/cam-image?url=${encodeURIComponent(snapshot)}`
         return {
-          id: `fdot-${c.id || c.camId || `${lat},${lng}`}`,
+          id: `fdot-${itemId}`,
           provider: "fdot",
-          name: c.description || c.roadway || c.location || "FDOT cam",
+          name: it?.title || it?.tooltip || it?.roadway || "FDOT cam",
           lat,
           lng,
-          stream_url: c.hlsUrl || null,
-          embed_url: c.url || c.videoUrl || null,
+          stream_url: null,
+          embed_url: `https://fl511.com/map/Cctv/${encodeURIComponent(String(itemId))}`,
           media_url: proxiedImg,
           category: "traffic",
         }

--- a/app/api/oei/aisstream/route.ts
+++ b/app/api/oei/aisstream/route.ts
@@ -129,7 +129,15 @@ export async function GET(request: NextRequest) {
   const lomax = searchParams.get("lomax")
   const mmsi = searchParams.get("mmsi")
   const publish = searchParams.get("publish") === "true"
-  const limit = searchParams.get("limit") ? parseInt(searchParams.get("limit")!) : undefined
+  // Hard default + max cap so an uncapped GET can never serialize the entire
+  // global vessel set (~43k objects = 5.3s, the audit's worst route). The client
+  // sends limit=earthMoverLimits.vessels (2500/900) when zoomed in; external /
+  // world-zoom callers that omit it now get a sane ceiling instead of everything.
+  // (Jun 13, 2026 — P1-2 AIS over-SLA fix.)
+  const AIS_DEFAULT_LIMIT = 4000
+  const AIS_MAX_LIMIT = 8000
+  const rawLimit = searchParams.get("limit") ? parseInt(searchParams.get("limit")!) : AIS_DEFAULT_LIMIT
+  const limit = Math.min(Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : AIS_DEFAULT_LIMIT, AIS_MAX_LIMIT)
   const forceRefresh = searchParams.get("refresh") === "true"
 
   const cacheKey = `vessels_${lamin}_${lamax}_${lomin}_${lomax}_${mmsi}_${limit}_${publish}`

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -2378,10 +2378,13 @@ function getInitialProjectionMode(): ProjectionMode {
 }
 
 function shouldStartInGlobeProjection(): boolean {
-  if (typeof window === "undefined") return true;
-  const width = window.innerWidth || 1440;
-  const coarsePointer = window.matchMedia?.("(pointer: coarse)")?.matches ?? false;
-  return width > 1180 && !coarsePointer;
+  // The Earth Simulator must ALWAYS open in the globe projection, never the flat
+  // mercator map — on every device including iPad. The earlier width/pointer gate
+  // downgraded touch/tablet/narrow viewports to mercator for GPU safety, but that
+  // is the wrong default: globe is the intended experience everywhere, and the
+  // user can still switch to map via the GlobeToggle. (Jun 13, 2026 — Morgan:
+  // "should always open in the globe, never open in the map.")
+  return true;
 }
 
 function isGlobeProjectionSafeForViewport(): boolean {

--- a/components/crep/eagle-eye/VideoWallWidget.tsx
+++ b/components/crep/eagle-eye/VideoWallWidget.tsx
@@ -1191,8 +1191,14 @@ export default function VideoWallWidget() {
       const sourceStatus = isKnownUnavailableFeedId(d.id) ? "temporarily_unavailable" : d.source_status || d.status || undefined
       const providerLc = String(d.provider || "").toLowerCase()
       const hasYouTubeUrl = isYouTubeUrl(streamUrl || "") || isYouTubeUrl(embedUrl || "")
+      // hdontap (e.g. Hotel del Coronado) ships only an embed_url to its
+      // domain-locked portal player, which rejects off-site iframes ("Oops, the
+      // livestream is unavailable on this website"). The THUMBNAIL plays fine
+      // because its resolver falls back to /api/eagle/stream/[id], which scrapes
+      // the real HLS. Route the full player through that same resolver so it
+      // plays the identical stream instead of the dead iframe. (Jun 13, 2026.)
       const resolveViaStreamApi =
-        (providerLc === "earthcam" || providerLc === "skylinewebcams" || providerLc === "surfline") &&
+        (providerLc === "earthcam" || providerLc === "skylinewebcams" || providerLc === "surfline" || providerLc === "hdontap") &&
         !hasYouTubeUrl &&
         !isHlsUrl(streamUrl)
       const directEmbed =


### PR DESCRIPTION
Batch of code-fixable findings from the live QA audit + the globe-always bug. (1) GLOBE: Earth Simulator now always opens in the 3D globe on every device incl iPad (was downgrading touch/tablet to flat map). (2) P1-2 AIS: hard default/max cap (4000/8000) so uncapped GET no longer serializes ~43k vessels (was 5.3s, 2x SLA). (3) P1-4 FDOT: fl511 migrated to Castle Rock OneStop; repointed pullFDOT at the new keyless camera index so Florida cameras return again. NOT in this PR (need you): P1-1 SPUN atlas cells = ops (prod missing MINDEX_INTERNAL_TOKEN/MINDEX_API_KEY -> MINDEX returns 401); WSDOT cameras = env (WSDOT_ACCESS_CODE). P1-3 tide/buoy 404 = audit false-positive (real paths exist and work).

## Summary by Sourcery

Ensure Earth Simulator always initializes in globe projection, cap AIS vessel responses to prevent overlarge payloads, and restore Florida FDOT camera data after provider migration.

Bug Fixes:
- Restore FDOT camera ingestion by updating the Florida CCTV connector to use the new Castle Rock OneStop camera index and snapshot endpoints.
- Prevent AIS API from returning excessively large global vessel payloads by enforcing a default and maximum limit on results.
- Guarantee Earth Simulator opens in 3D globe view on all devices by removing viewport- and input-based downgrades to flat map projection.