### PR TITLE
fix(earth-sim): Eagle Eye camera coverage + map-anchored sensor widgets

### DIFF
--- a/app/api/eagle/sources/route.ts
+++ b/app/api/eagle/sources/route.ts
@@ -370,13 +370,21 @@ export async function GET(req: NextRequest) {
   const provider = url.searchParams.get("provider") || undefined
   const requestedLimit = Math.min(Number(url.searchParams.get("limit") || 10000), 50000)
   const mapMetadataRequest = Boolean(bbox && !kind && !provider)
-  const limit = mapMetadataRequest ? Math.min(requestedLimit, 180) : requestedLimit
+  // Jun 13, 2026 (camera-coverage fix): a dense metro viewport (e.g. Caltrans
+  // District 4 / SF Bay alone has 633 live cams) needs far more than 180, or the
+  // map shows only a handful of baked-seed pins. Raise the map cap to 2000.
+  const limit = mapMetadataRequest ? Math.min(requestedLimit, 2000) : requestedLimit
   const directLiveFanoutEnabled =
     process.env.EAGLE_WEBSITE_ALLOW_DIRECT_LIVE_FANOUT !== "0"
+  // Jun 13, 2026: the `&& !mapMetadataRequest` clause forced skipLive=true for
+  // EVERY plain map bbox request, so the overlay's explicit live=1 never ran the
+  // live state-DOT fan-out (Caltrans D4, etc.) — the map only ever got the small
+  // baked seed (SF showed ~1 cam). Honour live=1 for map requests; the ?fast=1
+  // first-paint path still returns the baked tier immediately, and the live tier
+  // is bbox/district-filtered + bounded by the 18s allSettled timeout.
   const liveFanoutAllowed =
     directLiveFanoutEnabled &&
-    url.searchParams.get("live") === "1" &&
-    !mapMetadataRequest
+    url.searchParams.get("live") === "1"
   const skipLive = !liveFanoutAllowed
   // Apr 22, 2026 — Morgan: "needs first load fast". ?fast=1 returns the
   // fast-tier connectors (public-webcams + 511 + border + webcamtaxi

--- a/components/crep/layers/eagle-eye-overlay.tsx
+++ b/components/crep/layers/eagle-eye-overlay.tsx
@@ -640,7 +640,7 @@ export default function EagleEyeOverlay({ map, enabled, bbox, mapZoom = 0 }: Pro
         const fastMode = !loadedRef.current.cams && !bakedPainted
         const isTabletViewport = window.innerWidth <= 1100 || window.innerHeight <= 820
         const cameraQuery = new URLSearchParams({
-          limit: String(isTabletViewport ? 96 : 180),
+          limit: String(isTabletViewport ? 600 : 1500),
           live: fastMode || isTabletViewport ? "0" : "1",
         })
         if (activeBboxKey) cameraQuery.set("bbox", activeBboxKey)

--- a/components/crep/mojave/MojaveSiteWidget.tsx
+++ b/components/crep/mojave/MojaveSiteWidget.tsx
@@ -40,6 +40,9 @@ const CATEGORY_META: Record<string, { label: string; accent: string; ring: strin
 
 export default function MojaveSiteWidget() {
   const [site, setSite] = useState<ClickDetail | null>(null)
+  // Anchor the card over its map icon and follow the map, above the panels
+  // (Jun 13, 2026) — same fix as OysterSiteWidget.
+  const [anchor, setAnchor] = useState<{ x: number; y: number; visible: boolean } | null>(null)
 
   useEffect(() => {
     const onClick = (e: Event) => {
@@ -49,6 +52,27 @@ export default function MojaveSiteWidget() {
     window.addEventListener("crep:mojave:site-click", onClick as any)
     return () => window.removeEventListener("crep:mojave:site-click", onClick as any)
   }, [])
+
+  useEffect(() => {
+    if (!site || typeof site.lat !== "number" || typeof site.lng !== "number") { setAnchor(null); return }
+    const map = (window as any).__crep_map
+    if (!map?.project) { setAnchor(null); return }
+    const update = () => {
+      try {
+        const p = map.project([site.lng as number, site.lat as number])
+        const canvas = map.getCanvas?.()
+        const w = canvas?.clientWidth ?? window.innerWidth
+        const h = canvas?.clientHeight ?? window.innerHeight
+        const visible = p.x >= -40 && p.y >= -40 && p.x <= w + 40 && p.y <= h + 40
+        setAnchor({ x: p.x, y: p.y, visible })
+      } catch { setAnchor(null) }
+    }
+    update()
+    map.on("move", update); map.on("zoom", update); map.on("rotate", update); map.on("pitch", update)
+    return () => {
+      try { map.off("move", update); map.off("zoom", update); map.off("rotate", update); map.off("pitch", update) } catch { /* map gone */ }
+    }
+  }, [site?.lat, site?.lng])
 
   if (!site) return null
 
@@ -68,7 +92,14 @@ export default function MojaveSiteWidget() {
 
   return (
     <div
-      className={`fixed right-4 top-24 z-[60] w-[360px] rounded-xl backdrop-blur-xl ${meta.accent} ring-1 ${meta.ring} shadow-2xl p-4 text-sm`}
+      className={`fixed z-[2100] w-[360px] rounded-xl backdrop-blur-xl ${meta.accent} ring-1 ${meta.ring} shadow-2xl p-4 text-sm ${anchor ? "" : "right-4 top-24"}`}
+      style={anchor ? {
+        left: anchor.x,
+        top: anchor.y,
+        transform: anchor.x > (typeof window !== "undefined" ? window.innerWidth - 380 : 1200) ? "translate(-372px, -50%)" : "translate(16px, -50%)",
+        opacity: anchor.visible ? 1 : 0,
+        pointerEvents: anchor.visible ? "auto" : "none",
+      } : undefined}
       onClick={(e) => e.stopPropagation()}
     >
       <div className="flex items-start justify-between gap-2 mb-3">

--- a/components/crep/oyster/OysterSiteWidget.tsx
+++ b/components/crep/oyster/OysterSiteWidget.tsx
@@ -77,6 +77,11 @@ export default function OysterSiteWidget() {
   // observation fetched from /api/crep/buoy/[station]. Auto-refresh
   // every 60 s while the widget is open.
   const [buoyObs, setBuoyObs] = useState<any | null>(null)
+  // Jun 13, 2026 (Morgan): the sensor card must anchor OVER its map icon and
+  // ride the map like the species/device popups — not dock to the right edge
+  // behind the MYCA panel. Project the site lng/lat to screen via the shared
+  // MapLibre instance (window.__crep_map) and re-project on every camera change.
+  const [anchor, setAnchor] = useState<{ x: number; y: number; visible: boolean } | null>(null)
 
   useEffect(() => {
     const onClick = (e: Event) => {
@@ -130,6 +135,28 @@ export default function OysterSiteWidget() {
     return () => { cancelled = true; clearInterval(iv) }
   }, [site?.id, site?.kind])
 
+  // Anchor the card over the clicked icon and follow the map on pan/zoom.
+  useEffect(() => {
+    if (!site || typeof site.lat !== "number" || typeof site.lng !== "number") { setAnchor(null); return }
+    const map = (window as any).__crep_map
+    if (!map?.project) { setAnchor(null); return }
+    const update = () => {
+      try {
+        const p = map.project([site.lng as number, site.lat as number])
+        const canvas = map.getCanvas?.()
+        const w = canvas?.clientWidth ?? window.innerWidth
+        const h = canvas?.clientHeight ?? window.innerHeight
+        const visible = p.x >= -40 && p.y >= -40 && p.x <= w + 40 && p.y <= h + 40
+        setAnchor({ x: p.x, y: p.y, visible })
+      } catch { setAnchor(null) }
+    }
+    update()
+    map.on("move", update); map.on("zoom", update); map.on("rotate", update); map.on("pitch", update)
+    return () => {
+      try { map.off("move", update); map.off("zoom", update); map.off("rotate", update); map.off("pitch", update) } catch { /* map gone */ }
+    }
+  }, [site?.lat, site?.lng])
+
   if (!site) return null
 
   const meta = CATEGORY_META[site.category] || CATEGORY_META["sensor"]
@@ -147,7 +174,15 @@ export default function OysterSiteWidget() {
 
   return (
     <div
-      className={`fixed right-4 top-24 z-[60] w-[360px] max-h-[80vh] overflow-y-auto rounded-xl backdrop-blur-xl ${meta.accent} ring-1 ${meta.ring} shadow-2xl p-4 text-sm`}
+      className={`fixed z-[2100] w-[360px] max-h-[80vh] overflow-y-auto rounded-xl backdrop-blur-xl ${meta.accent} ring-1 ${meta.ring} shadow-2xl p-4 text-sm ${anchor ? "" : "right-4 top-24"}`}
+      style={anchor ? {
+        left: anchor.x,
+        top: anchor.y,
+        // Sit just right of the icon; flip to the left near the right screen edge so the card never spills off.
+        transform: anchor.x > (typeof window !== "undefined" ? window.innerWidth - 380 : 1200) ? "translate(-372px, -50%)" : "translate(16px, -50%)",
+        opacity: anchor.visible ? 1 : 0,
+        pointerEvents: anchor.visible ? "auto" : "none",
+      } : undefined}
       onClick={(e) => e.stopPropagation()}
     >
       <div className="flex items-start justify-between gap-2 mb-3">


### PR DESCRIPTION
Two fixes from live testing. (1) CAMERA COVERAGE: /api/eagle/sources never ran the live state-DOT connectors for map requests (skipLive forced true), so SF showed ~1 camera while Caltrans D4 has 633. Honour live=1 for map requests + raise caps (180->2000 server, 180/96->1500/600 client). (2) SENSOR WIDGET: the environmental-sensor card docked to the right edge behind the MYCA panel; now anchors over its map icon, follows the map, z-2100 above panels (OysterSiteWidget + MojaveSiteWidget). Branched off main; disjoint files from #193 so no conflict.

## Summary by Sourcery

Improve Eagle Eye camera coverage and align sensor site widgets to their corresponding map icons.

Bug Fixes:
- Allow live state-DOT camera fanout for map bbox requests while retaining fast first-paint behavior.
- Increase server- and client-side camera limits so dense metro viewports show full camera coverage instead of a small baked subset.
- Anchor Oyster and Mojave site widgets to their map icons and keep them visible above panels while following map movements.

Enhancements:
- Adjust viewport-dependent client camera query limits to better balance coverage and performance for desktop and tablet viewports.