### PR TITLE
fix(earth-sim): iPad/tablet starts like desktop (open panels + fungal atlas)

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -7809,10 +7809,10 @@ export default function CREPDashboardPage({
     };
   }, []);
   const [leftPanelOpen, setLeftPanelOpen] = useState(
-    () => !embedded && !(isEarthSimulatorPath() && getEarthSimViewportPerfClass() !== "desktop"),
+    () => !embedded && !(isEarthSimulatorPath() && getEarthSimViewportPerfClass() === "phone"),
   );
   const [rightPanelOpen, setRightPanelOpen] = useState(
-    () => !embedded && !(isEarthSimulatorPath() && getEarthSimViewportPerfClass() !== "desktop"),
+    () => !embedded && !(isEarthSimulatorPath() && getEarthSimViewportPerfClass() === "phone"),
   );
   const [rightPanelTab, setRightPanelTab] = useState("myca");
   const [leftPanelTab, setLeftPanelTab] = useState<"fungal" | "myca" | "infra">("fungal"); // DEFAULT TO FUNGAL
@@ -22266,7 +22266,7 @@ export default function CREPDashboardPage({
           {!auditAllOffMode &&
             assetIsolationMode !== "funga" &&
             hasEnabledLayer(layers, FUNGAL_ATLAS_LAYER_SET) &&
-            (!isEarthSimulatorRoute || earthSimDesktopOverlayBudget || fungalAtlasUserControlRef.current) && <FungalAtlasLayer
+            (!isEarthSimulatorRoute || earthSimDesktopOverlayBudget || earthSimViewportPerfClass === "tablet" || fungalAtlasUserControlRef.current) && <FungalAtlasLayer
             map={mapRef}
             enabled={{
               // May 21 2026 (Morgan): every fungal atlas toggle is wired to its


### PR DESCRIPTION
Follow-up to the iPad freeze fix. Classifying iPad as tablet also gave it the reduced tablet UI defaults: side panels collapsed + ECM/AM fungal atlas not rendering. This restores the desktop-like START STATE on tablet - panels default open (collapse only on phone) and the FungalAtlasLayer (cheap SPUN rasters) renders on tablet - while keeping the heavy overlay/marker budget reduced so it still does not freeze. Validate on the iPad: panels open + ECM visible on load.

## Summary by Sourcery

Adjust Earth Simulator tablet defaults to use desktop-like panel and fungal atlas behavior while preserving phone-specific performance constraints.

Bug Fixes:
- Ensure left and right side panels default to open on tablet viewports instead of inheriting collapsed tablet settings.
- Allow the fungal atlas layer to render on tablet viewports even when desktop-only overlay budgets are constrained.