### PR TITLE
docs: publish sanitized Earth Simulator technical reference + README

### DIFF
--- a/docs/EARTH_SIMULATOR_DOCS_INDEX.md
+++ b/docs/EARTH_SIMULATOR_DOCS_INDEX.md
@@ -1,294 +1,124 @@
 # Earth Simulator Documentation Index
 
-**Date**: January 9, 2026  
-**Purpose**: Quick reference guide to all Earth Simulator documentation
-
-## Documentation Overview
-
-This directory contains comprehensive documentation for the Earth Simulator implementation, covering status, setup, errors, and fixes.
-
-## Documentation Files
-
-### 1. EARTH_SIMULATOR_STATUS.md
-**Purpose**: Complete implementation status and overview  
-**Contents**:
-- Current implementation status
-- Completed features
-- Partially implemented features
-- Technical architecture
-- File structure
-- Dependencies
-- Performance metrics
-- Browser compatibility
-- Next steps
-
-**When to use**: Get a complete overview of what's been implemented and what's pending.
+**Date:** June 13, 2026  
+**Purpose:** Quick reference to Earth Simulator / CREP documentation  
+**Production stack:** MapLibre CREP globe (Cesium deprecated May 2026)
 
 ---
 
-### 2. GOOGLE_EARTH_ENGINE_API_SETUP.md
-**Purpose**: Guide for setting up Google Earth Engine API integration  
-**Contents**:
-- Current status (what's working)
-- What needs setup
-- Google Earth Engine vs Google Earth explanation
-- Step-by-step setup instructions
-- API endpoints reference
-- Environment variables
-- GEE datasets of interest
-- Implementation examples
-- Cost considerations
-- Troubleshooting
+## Start here (current)
 
-**When to use**: When you need to set up Google Earth Engine integration or understand the difference between GEE and Google Maps tiles.
+| Document | Description |
+|----------|-------------|
+| **[`docs/earth-simulator/README.md`](earth-simulator/README.md)** | **Public README** — what Earth Simulator is, who it is for, marketing feature overview + condensed developer reference |
+| **[`docs/EARTH_SIMULATOR_TECHNICAL_REFERENCE.md`](EARTH_SIMULATOR_TECHNICAL_REFERENCE.md)** | **Technical Outline** — definitive capability index (20 sections, file:line refs, layer registry, APIs, QA test plan). **Sanitized for public sharing** (no private IPs, internal hosts, or deployment secrets). [GitHub](https://github.com/MycosoftLabs/website/blob/main/docs/EARTH_SIMULATOR_TECHNICAL_REFERENCE.md) |
+| `lib/crep/earth-simulator-boot.ts` | Staged boot layer ON/OFF profile (source of truth in code) |
+| `lib/devices/field-deployments.ts` | Field MycoBrain deployments (Mushroom1, Hyphae1, Psathyrella) |
+| `app/dashboard/crep/CREPDashboardClient.tsx` | Main MapLibre + deck.gl implementation |
+
+**Canonical URL:** `/natureos/earth-simulator`  
+**Aliases:** `/dashboard/crep`, `/natureos/crep`, `/defense/crep`  
+**Legacy redirect:** `/apps/earth-simulator` → canonical (Cesium removed from public routes)
 
 ---
 
-### 3. EARTH_SIMULATOR_ERRORS_AND_FIXES.md
-**Purpose**: Complete catalog of errors, their causes, fixes, and remaining issues  
-**Contents**:
-- Error categories (8 major categories)
-- Detailed error messages
-- Root causes for each error
-- Fixes applied
-- Remaining issues
-- Recommended solutions
-- Priority fix list
-- Testing checklist
-- Quick fix commands
+## Deprecated (Cesium era — January 2026)
 
-**When to use**: When encountering console errors or troubleshooting issues.
+The following docs describe the **superseded CesiumJS** implementation. They remain in the repo for historical reference only. **Do not use for new development.**
 
----
-
-### 4. EARTH_SIMULATOR_IMPLEMENTATION_SUMMARY.md
-**Purpose**: Quick reference guide and summary of implementation  
-**Contents**:
-- Quick status overview (table format)
-- What was implemented
-- File structure
-- Key features (working and pending)
-- Known issues summary
-- Quick start guide
-- Next steps (prioritized)
-- Performance metrics
-- Success metrics
-- Changelog
-
-**When to use**: For a quick overview or when onboarding new developers.
+| Document | Status |
+|----------|--------|
+| `docs/earth-simulator/ARCHITECTURE.md` | ⚠️ Deprecated — Cesium component tree |
+| `docs/earth-simulator/API.md` | ⚠️ Deprecated — partial; see README API catalog |
+| `docs/earth-simulator/GRID_SYSTEM.md` | ⚠️ Partially valid — grid APIs still exist under `/api/earth-simulator` |
+| `docs/earth-simulator/DEPLOYMENT.md` | ⚠️ Deprecated — use README deployment section |
+| `docs/earth-simulator/PERFORMANCE.md` | ⚠️ Deprecated — MapLibre LOD policy replaced Cesium tuning |
+| `docs/earth-simulator/UIUX.md` | ⚠️ Deprecated — mobile shell replaced desktop-only Cesium UX |
+| `docs/EARTH_SIMULATOR_STATUS.md` | ⚠️ Deprecated — Cesium status (if present at repo root) |
+| `docs/EARTH_SIMULATOR_ERRORS_AND_FIXES.md` | ⚠️ Deprecated — Cesium error catalog |
+| `docs/EARTH_SIMULATOR_IMPLEMENTATION_SUMMARY.md` | ⚠️ Deprecated |
+| `docs/GOOGLE_EARTH_ENGINE_API_SETUP.md` | ⚠️ Partially valid — GEE proxy still at `/api/earth-simulator/gee` |
 
 ---
 
-## Quick Reference Guide
+## CREP & recent handoffs (May–June 2026)
 
-### I want to...
-
-#### ...understand the current status
-→ Read **EARTH_SIMULATOR_STATUS.md**
-
-#### ...set up Google Earth Engine
-→ Read **GOOGLE_EARTH_ENGINE_API_SETUP.md**
-
-#### ...fix console errors
-→ Read **EARTH_SIMULATOR_ERRORS_AND_FIXES.md**
-
-#### ...get a quick overview
-→ Read **EARTH_SIMULATOR_IMPLEMENTATION_SUMMARY.md**
-
-#### ...implement missing features
-→ Read all documents, focus on "Next Steps" sections
+| Document | Topic |
+|----------|-------|
+| `docs/crep plan.md` | CREP roadmap |
+| `docs/CREP_INFRASTRUCTURE_DEPLOYMENT.md` | Infra deployment |
+| `docs/CREP_API_CACHING_FEB18_2026.md` | API caching |
+| `docs/CREP_PLANES_BOATS_SATELLITES_FEB12_2026.md` | Live entity layers |
+| `docs/CREP_DECK_GL_FIX_FEB12_2026.md` | deck.gl entity rendering |
+| `docs/codex-handoffs/EARTH_SIMULATOR_FIRST_PAINT_CLOUD_SESSION_HANDOFF_JUN12_2026.md` | First-paint / cloud session |
+| `docs/codex-handoffs/EARTH_SIMULATOR_DEVICE_BACKEND_CURSOR_HANDOFF_JUN12_2026.md` | Device backend |
+| `docs/codex-handoffs/EARTH_SIMULATOR_PRODUCTION_MAP_FIX_HANDOFF_JUN12_2026.md` | Production map fix |
+| `docs/codex-handoffs/EARTH_SIMULATOR_GLOBAL_MAP_BACKEND_HANDOFF_JUN03_2026.md` | Global map backend |
+| `docs/codex-handoffs/EARTH_SIMULATOR_AIRNOW_CIVIC_MAS_MINDEX_HANDOFF_JUN03_2026.md` | AirNow + civic layers |
+| `docs/reports/earth-field-mycobrain-devices-2026-05-27.md` | Field device audit |
 
 ---
 
-## Current Status at a Glance
+## Quick tasks
 
-| Aspect | Status | Details |
-|--------|--------|---------|
-| **Cesium Globe** | ✅ Complete | Google Earth-like 3D globe with satellite imagery |
-| **Satellite Imagery** | ✅ Working | ESRI World Imagery with GEE support |
-| **Navigation** | ✅ Working | Full rotation, zoom, pan capabilities |
-| **Side Panel** | ✅ Working | Comprehensive data display |
-| **Layer Controls** | ✅ Working | Advanced UI with grouped layers |
-| **Fungal Data** | ✅ **Complete** | **Primary feature - fully functional** |
-| **Grid System** | ✅ **Complete** | **24x24 land grid - fully implemented** |
-| **Land Tiles API** | ✅ **Complete** | **7 actions - fully functional** |
-| **Fungal API** | ✅ **Complete** | **GeoJSON export - fully functional** |
-| **iNaturalist API** | ✅ **Complete** | **GET & POST - fully functional** |
-| **GEE Integration** | ✅ **Ready** | **Service account configured** |
-| **Custom Tile Layers** | ⚠️ Pending | Tile generation algorithms needed |
+### Open Earth Simulator locally
+
+```
+npm run dev:next-only   # port 3010
+http://localhost:3010/natureos/earth-simulator
+```
+
+CREP-only (lighter):
+
+```
+npm run dev:crep        # port 3020
+http://localhost:3020/dashboard/crep
+```
+
+### Check device API
+
+```
+GET http://localhost:3010/api/earth-simulator/devices
+```
+
+### Inspect boot profile in browser console
+
+On `/natureos/earth-simulator`, after load:
+
+```js
+window.EARTH_SIMULATOR_BOOT_PROFILE
+window.__crep_boot_profile
+```
+
+### Deploy to sandbox
+
+See [`docs/earth-simulator/README.md` § Deployment](earth-simulator/README.md#deployment).
 
 ---
 
-## Common Tasks
+## API surface summary
 
-### View the Earth Simulator
-```
-URL: http://localhost:3002/natureos
-Tab: "Earth Simulator"
-```
+| Prefix | Route count | Role |
+|--------|-------------|------|
+| `/api/earth-simulator/*` | 15 | Grid, tiles, GEE, devices, iNaturalist, aggregation |
+| `/api/crep/*` | 38 | Unified CREP, fungal atlas, viewport intel, regional projects |
+| `/api/oei/*` | 37 | OEI connectors (aviation, maritime, satellites, infra, events) |
+| `/api/earth2/*` | 12 | Earth-2 forecast/nowcast/spore tiles via MAS + GPU legion |
 
-### Check for Errors
-```
-1. Open browser console (F12)
-2. Navigate to Earth Simulator
-3. Check for 404 errors (expected for missing APIs)
-4. Check for Cesium worker errors (may occur if CDN blocked)
-5. Refer to EARTH_SIMULATOR_ERRORS_AND_FIXES.md
-```
-
-### Implement Missing API
-```
-1. Check EARTH_SIMULATOR_ERRORS_AND_FIXES.md for endpoint details
-2. Create API route: app/api/earth-simulator/{endpoint}/route.ts
-3. Implement tile generation or data fetching
-4. Test with Earth Simulator UI
-5. Update status in EARTH_SIMULATOR_STATUS.md
-```
-
-### Fix Console Errors
-```
-1. Check console for error messages
-2. Match error to category in EARTH_SIMULATOR_ERRORS_AND_FIXES.md
-3. Apply recommended fix
-4. Test to verify fix
-5. Document any new errors
-```
-
-### Set Up Google Earth Engine
-```
-1. Follow GOOGLE_EARTH_ENGINE_API_SETUP.md
-2. Get GEE access (1-3 business days)
-3. Install earthengine-api Python package
-4. Authenticate with earthengine authenticate
-5. Update tile proxy to use GEE
-```
+Full tables: [`EARTH_SIMULATOR_TECHNICAL_REFERENCE.md` § MYCA Panel & Full API Index](EARTH_SIMULATOR_TECHNICAL_REFERENCE.md) and [`docs/earth-simulator/README.md` § API catalog](earth-simulator/README.md#api-catalog).
 
 ---
 
-## File Locations
+## Version history
 
-### Frontend Components
-```
-components/earth-simulator/
-├── cesium-globe.tsx              # Main globe with fungal markers ✅
-├── earth-simulator-container.tsx # Container with controls ✅
-├── comprehensive-side-panel.tsx  # Left data panel ✅
-├── layer-controls.tsx            # Advanced layer toggles ✅
-├── fungal-layer.tsx              # Fungal markers ✅
-├── device-markers.tsx            # Device markers ✅
-├── hud.tsx                       # Viewport display ✅
-├── controls.tsx                  # Navigation ✅
-├── data-panel.tsx                # Data display ✅
-├── statistics.tsx                # Stats display ✅
-├── species-list.tsx              # Species list ✅
-└── [other components]            # Additional components ✅
-```
-
-### API Routes
-```
-app/api/earth-simulator/
-├── gee/                          # GEE proxy ✅
-├── inaturalist/                  # iNaturalist data ✅
-├── land-tiles/                   # Grid tiles ✅ (7 actions)
-├── aggregate/                    # Data aggregation ✅
-├── search/                       # Geospatial search ✅
-├── devices/                      # Device locations ✅
-├── cell/[cellId]/                # Cell-specific data ✅
-├── mycelium-probability/         # Probability calculations ✅
-├── layers/                       # Layer metadata ✅
-├── grid/                         # Grid utilities ✅
-└── tiles/[z]/[x]/[y]/           # Generic tile server ✅
-
-app/api/earth/
-└── fungal/                       # Fungal GeoJSON API ✅
-```
-
-### Documentation
-```
-docs/
-├── EARTH_SIMULATOR_DOCS_INDEX.md        # This file
-├── EARTH_SIMULATOR_STATUS.md            # Status overview
-├── GOOGLE_EARTH_ENGINE_API_SETUP.md     # GEE setup guide
-├── EARTH_SIMULATOR_ERRORS_AND_FIXES.md  # Error catalog
-└── EARTH_SIMULATOR_IMPLEMENTATION_SUMMARY.md  # Quick reference
-```
+| Date | Change |
+|------|--------|
+| **June 13, 2026** | Public marketing README + link to Technical Outline (`EARTH_SIMULATOR_TECHNICAL_REFERENCE.md`) |
+| **June 12, 2026** | Replaced Cesium-first index with MapLibre CREP pointers; canonical README rewritten |
+| **May 2026** | Cesium `/apps/earth-simulator` deprecated; staged boot profile shipped |
+| **January 9, 2026** | Original Cesium-focused documentation set |
 
 ---
 
-## Next Steps
-
-### Immediate (Priority 1) ✅ COMPLETE
-1. ✅ Verify iNaturalist API route exists (DONE)
-2. ✅ Verify grid API is implemented (DONE)
-3. ✅ Verify fungal API is implemented (DONE)
-4. ✅ Verify GEE integration is ready (DONE)
-5. ⚠️ Delete/archive legacy WebGL files (cleanup task)
-
-### Short Term (Priority 2)
-1. ✅ Grid tile API implemented (DONE)
-2. ⚠️ Create tile server stubs for custom layers (mycelium, heat, weather)
-3. ✅ Comprehensive error boundaries added (DONE)
-
-### Medium Term (Priority 3)
-1. ⚠️ Implement mycelium probability tile generator
-2. ⚠️ Implement heat map tile generator
-3. ⚠️ Implement weather tile generator
-
-### Long Term (Priority 4)
-1. ✅ Google Earth Engine configured and ready (DONE)
-2. ⚠️ Add 3D terrain with Cesium Ion (optional)
-3. ⚠️ Implement real-time data streaming (enhancement)
-
----
-
-## Support & Troubleshooting
-
-### Common Issues
-
-**Globe not loading**: Check Cesium CDN connectivity  
-**Console errors**: Refer to EARTH_SIMULATOR_ERRORS_AND_FIXES.md  
-**API 404s**: Expected for missing endpoints, see implementation guide  
-**Performance issues**: Check tile limits and debouncing settings
-
-### Getting Help
-
-1. Check relevant documentation file
-2. Review error messages in console
-3. Check EARTH_SIMULATOR_ERRORS_AND_FIXES.md
-4. Verify API endpoints are accessible
-5. Test with minimal configuration
-
----
-
-## Version History
-
-### January 9, 2026 (Updated)
-- ✅ Verified all API routes are implemented
-- ✅ Confirmed fungal data integration is complete
-- ✅ Verified grid system is fully functional
-- ✅ Confirmed GEE integration is ready
-- ✅ Updated all documentation with accurate status
-- ✅ Fixed all critical errors
-
-### January 9, 2026 (Initial)
-- ✅ Initial documentation created
-- ✅ Cesium globe integrated
-- ✅ Comprehensive documentation added
-- ✅ Error catalog created
-- ✅ Setup guides added
-
----
-
-**Last Updated**: January 9, 2026 (Updated)  
-**Documentation Status**: Complete and up-to-date with accurate implementation status
-
-## Summary of Updates
-
-### January 9, 2026 (Updated)
-- ✅ Verified all API routes are implemented and functional
-- ✅ Confirmed fungal data integration is complete
-- ✅ Verified grid system is fully functional (7 API actions)
-- ✅ Confirmed GEE integration is ready (service account configured)
-- ✅ Updated all documentation with accurate status
-- ✅ Fixed all critical errors
-- ✅ Documented all working features accurately
+**Last updated:** June 13, 2026  
+**Maintainer:** Mycosoft Platform / NatureOS team

--- a/docs/EARTH_SIMULATOR_TECHNICAL_REFERENCE.md
+++ b/docs/EARTH_SIMULATOR_TECHNICAL_REFERENCE.md
@@ -1,7 +1,10 @@
 # Earth Simulator — Technical Feature Reference & Capability Index
 
+> **Public overview:** [`docs/earth-simulator/README.md`](earth-simulator/README.md) — product README for visitors and GitHub (what Earth Simulator is, who it is for, live links).
 > **Route:** `/natureos/earth-simulator` (the operator-facing branding of the CREP — *Common Relevant Environmental Picture* — dashboard).
 > **Generated:** 2026-06-13. Built by a 21-agent codebase survey + completeness-critic backfill against `WEBSITE/website` (the canonical ~23,200-line `CREPDashboardClient.tsx` plus its layer/lib/api tree). **The code is the source of truth**; every claim below carries `file:line` references.
+> **Public distribution:** This document describes product capabilities and code references. **Private network addresses, internal hostnames, deployment runbooks, and credential values are redacted.** Configure all service URLs via environment variables in your own deployment.
+
 > **Purpose:** the definitive feature/capability index for the Earth Simulator, and the test plan for live production QA.
 
 ## Table of Contents
@@ -400,14 +403,14 @@ These are sibling routes the proxy and dashboard lean on; both verified to exist
 The proxy's species fallback (`FALLBACK_ROUTES.species = "/api/crep/fungal"`, `:121`) is yet another path (verified present at `app/api/crep/fungal/route.ts`) — it is the route invoked when the proxy's MINDEX species layer is empty and `liveFallback` is enabled but `preferLive` was not set.
 
 #### Key file references
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\natureos\earth-simulator\page.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\natureos\earth-simulator\EarthSimulatorViewportLock.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\natureos\crep\page.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\dashboard\crep\page.tsx`, `CREPDashboardLoader.tsx`, `CREPDashboardEmbedded.tsx`, `CREPDashboardClient.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\lib\crep\earth-simulator-boot.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\next.config.js`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\api\mindex\proxy\[source]\route.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\api\crep\species\search\route.ts`, `app\api\crep\nature\preloaded\route.ts`, `app\api\crep\fungal\route.ts`
+- `WEBSITE/website/app\natureos\earth-simulator\page.tsx`
+- `WEBSITE/website/app\natureos\earth-simulator\EarthSimulatorViewportLock.tsx`
+- `WEBSITE/website/app\natureos\crep\page.tsx`
+- `WEBSITE/website/app\dashboard\crep\page.tsx`, `CREPDashboardLoader.tsx`, `CREPDashboardEmbedded.tsx`, `CREPDashboardClient.tsx`
+- `WEBSITE/website/lib\crep\earth-simulator-boot.ts`
+- `WEBSITE/website/next.config.js`
+- `WEBSITE/website/app/api/mindex\proxy\[source]\route.ts`
+- `WEBSITE/website/app/api/crep\species\search\route.ts`, `app\api\crep\nature\preloaded\route.ts`, `app\api\crep\fungal\route.ts`
 
 ---
 
@@ -627,7 +630,7 @@ The phone shell does not help: `CrepMobileShell`'s `useIsPhone()` (`crep-mobile-
 
 **QA note:** because the classifier is width+pointer based, reproducing the freeze in a desktop browser requires emulating **both** a >1180px width **and** a fine pointer with `maxTouchPoints > 1` — DevTools device emulation that forces `(pointer: coarse)` will incorrectly demote to `tablet` and mask the bug. Test on physical iPad Pro hardware (both 11″ and 12.9″, landscape, with Magic Keyboard attached) and in iPadOS Safari's default desktop-site mode.
 
-**Relevant files:** `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\dashboard\crep\CREPDashboardClient.tsx`, `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\mobile\crep-mobile-shell.tsx`, `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\lib\crep\earth-simulator-boot.ts`, `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\globals.css`.
+**Relevant files:** `WEBSITE/website/app\dashboard\crep\CREPDashboardClient.tsx`, `WEBSITE/website/components\crep\mobile\crep-mobile-shell.tsx`, `WEBSITE/website/lib\crep\earth-simulator-boot.ts`, `WEBSITE/website/app\globals.css`.
 
 ---
 
@@ -763,7 +766,7 @@ All 183 layers, grouped by `category`, with literal default-enabled state. Categ
 | `satellites` | Satellites (TLE Live) | ON | 0.9 | CelesTrak live satellite positions. *(mover-merged)* (`:10039`) |
 | `liveTransit` | Live Transit (Trains/Buses) | ON | 0.9 | Live US transit (MTA/WMATA/BART/MBTA/511-Bay/CTA/TriMet/MARTA/Amtrak/SEPTA/Metrolink/DART), polled `/api/transit/all` every 15 s. (`:10072`) |
 | `ports` | Global Seaports | ON | 0.9 | 3,600+ seaports (WPI/NGA + UNCTAD + MarineCadastre + MINDEX). (`:10108`) |
-| `cctv` | CCTV / Webcams | ON | 0.85 | Public webcams + Shinobi CCTV (MINDEX `crep.cctv_cameras` + Shinobi on MAS VM). (`:10112`) |
+| `cctv` | CCTV / Webcams | ON | 0.85 | Public webcams + Shinobi CCTV (MINDEX `crep.cctv_cameras` + internal Shinobi connector). (`:<internal-connector-port>`) |
 | `eagleEyeCameras` | Eagle Eye — Cameras | ON | 0.9 | Permanent video — Shinobi + Caltrans/511 + Windy + EarthCam + NPS/USGS + ALERTWildfire/HPWREN + Surfline. (`:10119`) |
 | `eiaOperating` | EIA-860M Operating | ON | 0.85 | EIA Feb 2026 — 27,716 operating utility-scale generators. *(panel-merged into "Power Plants (all sources)")* (`:10128`) |
 | `eiaPlanned` | EIA-860M Planned (Projected) | ON | 0.9 | EIA-860M — 1,946 planned generators. *(power-merged)* (`:10129`) |
@@ -2079,14 +2082,14 @@ Relevant constants from `lib/crep/lod-policy.ts`: `TELECOM_DETAIL_MIN_ZOOM = 5` 
 ---
 
 **Key files referenced:**
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\layers\signal-heatmap-layer.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\layers\proposal-overlays.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\api\oei\radio-stations\route.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\lib\crep\registries\radio-station-registry.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\lib\crep\lod-policy.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\lib\crep\production-first-load.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\dashboard\crep\CREPDashboardClient.tsx` (signalHeatmap/cellTowerPoints, ProposalOverlays mount + gate, submarine cables block)
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\public\data\crep\submarine-cables.geojson` (710 TeleGeography cables, primary cable source)
+- `WEBSITE/website/components\crep\layers\signal-heatmap-layer.tsx`
+- `WEBSITE/website/components\crep\layers\proposal-overlays.tsx`
+- `WEBSITE/website/app/api/oei\radio-stations\route.ts`
+- `WEBSITE/website/lib\crep\registries\radio-station-registry.ts`
+- `WEBSITE/website/lib\crep\lod-policy.ts`
+- `WEBSITE/website/lib\crep\production-first-load.ts`
+- `WEBSITE/website/app\dashboard\crep\CREPDashboardClient.tsx` (signalHeatmap/cellTowerPoints, ProposalOverlays mount + gate, submarine cables block)
+- `WEBSITE/website/public\data\crep\submarine-cables.geojson` (710 TeleGeography cables, primary cable source)
 
 ---
 
@@ -2718,7 +2721,7 @@ The single tile endpoint the map uses for cached satellite imagery:
 - **Mapbox token resolution:** `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` → `MAPBOX_ACCESS_TOKEN` → `NEXT_PUBLIC_MAPBOX_TOKEN` (`:44-48`).
 - **Resolution order** (`:149-191`): (1) MINDEX NAS cache `{MINDEX_TILE_CACHE_URL or MINDEX_API_URL}/api/mindex/tile-cache/{basemap}/{z}/{x}/{y}.jpg` (weekly-refreshed); (2) upstream fetch; (3) on 200, proxy + async write-back to MINDEX.
 - **MINDEX circuit breaker** (`:80-104`): probe timeout 500 ms; on network failure trips a 60 s back-off (`MINDEX_UNAVAILABLE_TTL_MS`) so tile requests skip MINDEX while it's unreachable; a 404 is a valid miss (does not trip the breaker).
-- **Cache headers:** MINDEX hit → `s-maxage=604800` (1 wk) / SWR 30 d (`X-Tile-Source: mindex-cache`); upstream → `s-maxage=86400` / SWR 1 wk (`X-Tile-Source: upstream`). Weekly refresh is driven by `scripts/etl/crep/prefetch-satellite-tiles.mjs` on VM 189 (z0–14, atomic staging swap).
+- **Cache headers:** MINDEX hit → `s-maxage=604800` (1 wk) / SWR 30 d (`X-Tile-Source: mindex-cache`); upstream → `s-maxage=86400` / SWR 1 wk (`X-Tile-Source: upstream`). Weekly refresh is driven by `scripts/etl/crep/prefetch-satellite-tiles.mjs` on MINDEX infrastructure (z0–14, atomic staging swap).
 
 ##### 6.6 Known limitations
 - ESRI satellite/bathymetry are free, keyless, but ESRI imagery vintage/coverage varies; bathymetry capped at `maxzoom 14`, terrarium DEM at `maxzoom 15`.
@@ -2956,7 +2959,7 @@ Each effect (a) attaches once on first enable or first-load bootstrap, (b) on di
 
 ##### 3.5 Cached HD satellite proxy (`app/api/crep/tiles/satellite/[basemap]/[z]/[x]/[y]/route.ts`)
 
-A server route giving a single tile endpoint with MINDEX-NAS fallback. Basemaps (`:53`–`64`): `mapbox-sat-streets` (Mapbox satellite-streets-v12 `@2x`, needs `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`), `mapbox-sat` (satellite-v9 `@2x`, needs token), `esri-world-imagery` (ESRI World Imagery, no key). Resolution order: (1) MINDEX cache at `{MINDEX_TILE_BASE}/{basemap}/{z}/{x}/{y}.jpg`, (2) upstream fetch, (3) async write-back to MINDEX. A 60 s circuit breaker (`mindexUnavailableUntil`, `MINDEX_PROBE_TIMEOUT_MS=500`, `:80`–`104`) skips MINDEX when unreachable so tiles don't block. Weekly refresh by `scripts/etl/crep/prefetch-satellite-tiles.mjs` (systemd timer on VM 189), zooms 0–14.
+A server route giving a single tile endpoint with MINDEX-NAS fallback. Basemaps (`:53`–`64`): `mapbox-sat-streets` (Mapbox satellite-streets-v12 `@2x`, needs `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`), `mapbox-sat` (satellite-v9 `@2x`, needs token), `esri-world-imagery` (ESRI World Imagery, no key). Resolution order: (1) MINDEX cache at `{MINDEX_TILE_BASE}/{basemap}/{z}/{x}/{y}.jpg`, (2) upstream fetch, (3) async write-back to MINDEX. A 60 s circuit breaker (`mindexUnavailableUntil`, `MINDEX_PROBE_TIMEOUT_MS=500`, `:80`–`104`) skips MINDEX when unreachable so tiles don't block. Weekly refresh by `scripts/etl/crep/prefetch-satellite-tiles.mjs` (systemd timer on MINDEX infrastructure), zooms 0–14.
 
 ---
 
@@ -3123,20 +3126,20 @@ All three default to `true` while layer state hydrates (so they paint on refresh
 
 #### Key files (absolute paths)
 
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\lib\crep\gibs-layers.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\layers\gibs-base-layers.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\earth2\gibs-eo-overlays.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\layers\proposal-overlays.tsx` (satImagery/bathymetry/topography raster engine, §3)
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\layers\aurora-overlay.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\layers\realistic-cloud-layer.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\layers\sun-earth-impact-layer.tsx`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\earth2\` (index.ts, earth2-tile-raster-layers.tsx, cloud-layer.tsx, earth2-layer-control.tsx, et al.)
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\api\crep\tiles\satellite\[basemap]\[z]\[x]\[y]\route.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\api\oei\space-weather\aurora\route.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\api\oei\sun-earth-correlation\route.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\api\eagle\weather\multi\route.ts`
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\dashboard\crep\CREPDashboardClient.tsx` (wiring + gates)
-- `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\lib\crep\earth-simulator-boot.ts` (boot profile)
+- `WEBSITE/website/lib\crep\gibs-layers.ts`
+- `WEBSITE/website/components\crep\layers\gibs-base-layers.tsx`
+- `WEBSITE/website/components\crep\earth2\gibs-eo-overlays.tsx`
+- `WEBSITE/website/components\crep\layers\proposal-overlays.tsx` (satImagery/bathymetry/topography raster engine, §3)
+- `WEBSITE/website/components\crep\layers\aurora-overlay.tsx`
+- `WEBSITE/website/components\crep\layers\realistic-cloud-layer.tsx`
+- `WEBSITE/website/components\crep\layers\sun-earth-impact-layer.tsx`
+- `WEBSITE/website/components\crep\earth2\` (index.ts, earth2-tile-raster-layers.tsx, cloud-layer.tsx, earth2-layer-control.tsx, et al.)
+- `WEBSITE/website/app/api/crep\tiles\satellite\[basemap]\[z]\[x]\[y]\route.ts`
+- `WEBSITE/website/app/api/oei\space-weather\aurora\route.ts`
+- `WEBSITE/website/app/api/oei\sun-earth-correlation\route.ts`
+- `WEBSITE/website/app/api/eagle\weather\multi\route.ts`
+- `WEBSITE/website/app\dashboard\crep\CREPDashboardClient.tsx` (wiring + gates)
+- `WEBSITE/website/lib\crep\earth-simulator-boot.ts` (boot profile)
 
 ---
 
@@ -3648,7 +3651,7 @@ Sequenced and `resolveSeq`-guarded:
 
 **Live fan-out gating (`:374-385`):** `live=1` **and** not a "map-metadata request" (`bbox && !kind && !provider`) **and** `EAGLE_WEBSITE_ALLOW_DIRECT_LIVE_FANOUT !== "0"`. So plain bbox map polling never triggers the heavy fan-out (it relies on MINDEX + baked).
 
-**Env:** `MINDEX_API_URL`/`NEXT_PUBLIC_MINDEX_API_URL` (default `http://192.168.0.189:8000`), `MINDEX_INTERNAL_TOKEN(S)`, `MINDEX_API_KEY`, `EAGLE_CONNECTOR_FETCH_BASE`/`EAGLE_INTERNAL_ORIGIN` (loopback base for self-fetches), `MIN_SOURCES = 1`.
+**Env:** `MINDEX_API_URL`/`NEXT_PUBLIC_MINDEX_API_URL` (default `{configured-service-url}`), `MINDEX_INTERNAL_TOKEN(S)`, `MINDEX_API_KEY`, `EAGLE_CONNECTOR_FETCH_BASE`/`EAGLE_INTERNAL_ORIGIN` (loopback base for self-fetches), `MIN_SOURCES = 1`.
 
 Response: `{ source, total, by_provider, by_kind, sources[], generatedAt, baked_seed_used, live_fanout_used, note }`. `Cache-Control: s-maxage=30, swr=120`.
 
@@ -4100,7 +4103,7 @@ Returns bbox-scoped permanent cameras. Source priority: **MINDEX `eagle.video_so
 | `live` | `=1` enables live fan-out (and only when not a map-metadata request and `EAGLE_WEBSITE_ALLOW_DIRECT_LIVE_FANOUT !== "0"`) | off |
 | `fast` | `=1` → fast-tier-only first paint | off |
 
-Key constants: `MIN_SOURCES = 1` (`:60`, only fan out when MINDEX truly empty); `MINDEX_BASE` from `MINDEX_API_URL`/`NEXT_PUBLIC_MINDEX_API_URL` else `http://192.168.0.189:8000` (`:74-77`); auth header `X-Internal-Token` (`MINDEX_INTERNAL_TOKEN[S]`) or `X-API-Key` (`MINDEX_API_KEY`) (`:79-111`).
+Key constants: `MIN_SOURCES = 1` (`:60`, only fan out when MINDEX truly empty); `MINDEX_BASE` from `MINDEX_API_URL`/`NEXT_PUBLIC_MINDEX_API_URL` else `{configured-service-url}` (`:74-77`); auth header `X-Internal-Token` (`MINDEX_INTERNAL_TOKEN[S]`) or `X-API-Key` (`MINDEX_API_KEY`) (`:79-111`).
 
 - `connectorFetchBase(req)` (`:93-105`): self-fetch base — `EAGLE_CONNECTOR_FETCH_BASE`/`EAGLE_INTERNAL_ORIGIN` override; on Vercel the request origin; otherwise loopback to the Node port (`http://localhost:{port}`), avoiding Docker hairpin/TLS.
 - `loadBakedSources` (`:128-169`): reads the 7 seed files from `public/data/crep`, dedupes by id, defaults `source_status` to `"online"` and `permissions` to `{access:"public"}`.
@@ -4219,24 +4222,24 @@ The Devices & Telemetry domain covers the physical and registered MycoBrain hard
 
 `/api/earth-simulator/devices` is the canonical device-marker endpoint. It merges up to five sources into a single `byId` map (`app/api/earth-simulator/devices/route.ts:18-24, :570-751`), where **later sources win** for the same id:
 
-| Order | Source | `source` tag | Backend | Works on prod w/o LAN? |
+| Order | Source | `source` tag | Backend | Works without private-network agents? |
 |-------|--------|--------------|---------|------------------------|
 | 1 | `KNOWN_DEVICE_CATALOG` (device-type roster) | `catalog` | Static — `lib/devices/catalog.ts` | Yes |
 | 2 | `FIELD_MYCOBRAIN_DEPLOYMENTS` (3 fixed sites) | `field` | Static — `lib/devices/field-deployments.ts` | Yes |
 | 3 | MAS device registry (MQTT/heartbeat) | `mas` | `GET {MAS}/api/devices?include_offline=true` | Yes |
-| 4 | LAN operator probes (`:8787`) | `operator` | `probeAllOperatorAgents()` → `GET {agent}/api/status` | LAN only |
-| 5 | Local MycoBrain serial service (`:8003`) | `live` | `GET {mycobrain}/devices` | LAN/host only |
+| 4 | Field operator probes | `operator` | `probeAllOperatorAgents()` → `GET {agent}/api/status` | Private network only |
+| 5 | Local MycoBrain gateway service | `live` | `GET {mycobrain}/devices` | Host-local only |
 
-- **MAS base URL** resolves to `http://192.168.0.188:8001` by default; loopback env values are rewritten to the LAN VM on the server unless `ALLOW_LOOPBACK_MAS=1` (`lib/mas-server-url.ts:9, :20-37`).
-- **Local MycoBrain service URL**: `process.env.MYCOBRAIN_SERVICE_URL || MYCOBRAIN_API_URL || "http://localhost:8003"` (`route.ts:571-574`). The standalone resolver defaults to `http://192.168.0.196:8003`, also loopback-guarded (`lib/mycobrain-service-url.ts:24, :41-51`).
-- **Operator URLs**: `MYCOBRAIN_OPERATOR_URLS`, default `http://192.168.0.228:8787,http://192.168.0.123:8787` (`lib/devices/operator-probe.ts:5-11`).
+- **MAS base URL** resolves to `{configured-service-url}` by default; loopback env values are rewritten to configured platform hosts on the server unless `explicit loopback override env flag` (`lib/mas-server-url.ts:9, :20-37`).
+- **Local MycoBrain service URL**: `process.env.MYCOBRAIN_SERVICE_URL || MYCOBRAIN_API_URL || "configured local MycoBrain gateway URL"` (`route.ts:571-574`). The standalone resolver defaults to `{configured-service-url}`, also loopback-guarded (`lib/mycobrain-service-url.ts:24, :41-51`).
+- **Operator URLs**: `MYCOBRAIN_OPERATOR_URLS`, default `{configured-service-url},{configured-service-url}` (`lib/devices/operator-probe.ts:5-11`).
 
 ##### Caching, refresh, and bootstrap (`route.ts:59, :80-81, :803-897`)
 - TTL: `DEVICES_CACHE_TTL_MS = 25_000` (25 s). Single in-flight refresh guarded by `devicesInFlight`.
 - Query params: `?refresh=1` forces a background refresh; `?wait=1` or `?blocking=1` awaits the fresh payload before responding.
 - **Cold start** returns a synchronous **bootstrap payload** (catalog + field seeds with a location, `cache.bootstrap:true`) and kicks off the real refresh (`buildBootstrapDevicesPayload`, `route.ts:554-568, :864-875`).
 - Stale-while-revalidate: a cache older than TTL is returned immediately with `cache.stale:true, revalidating:true` while a refresh runs.
-- Response envelope: `{ success, devices[], count, sources:{mas, operator, field_deployments}, mas_url, timestamp, cache }`.
+- Response envelope: `{ success, devices[], count, sources:{mas, operator, field_deployments}, platform_api_url, timestamp, cache }`.
 
 ##### Status stabilization / "online grace" (perf + flap suppression) (`route.ts:60-61, :753-793`)
 - `stabilizeDevicePayload` keeps a module-level `lastConnectedDevices` map. A device that flips to `offline`/`stale`/`""` is held at its last `connected`/`online` status (with remembered telemetry/lastSeen/source) within a grace window:
@@ -4252,12 +4255,12 @@ Defined once server-side in `FIELD_MYCOBRAIN_DEPLOYMENTS` (`lib/devices/field-de
 | Field | Mushroom 1 | Hyphae 1 | Psathyrella Aquatic Buoy |
 |-------|-----------|----------|--------------------------|
 | `catalog_id` / marker id | `mushroom-1` | `hyphae-1` | `psathyrella-buoy-com4` |
-| `registry_id` | `mycobrain-mushroom1-jetson-123` | `mycobrain-hyphae1-jetson-228` | `mycobrain-COM4` |
+| `registry_id` | `mycobrain-mushroom1-field` | `mycobrain-hyphae1-field` | `mycobrain-COM4` |
 | `role` / `device_type` | `mushroom1` | `hyphae1` | `psathyrella` |
-| `host_ip` | `192.168.0.123` | `192.168.0.228` | `192.168.0.241` |
-| `agent_port` | `8787` | `8787` | `8003` |
-| `agent_url` | `http://192.168.0.123:8787` | `http://192.168.0.228:8787` | `http://192.168.0.241:8003` (client seed uses `http://localhost:8003`) |
-| `openclaw_url` | `http://192.168.0.123:18789` | `http://192.168.0.228:18789` | `""` |
+| `host_ip` | `[private-host]` | `[private-host]` | `[private-host]` |
+| `agent_port` | configured | configured | configured |
+| `agent_url` | `{configured-service-url}` | `{configured-service-url}` | `{configured-service-url}` (client seed uses `configured local MycoBrain gateway URL`) |
+| `operator_ui_url` | `{configured-service-url}` | `{configured-service-url}` | `""` |
 | `location` (lat,lon) | `32.715736, -117.161087` | `32.640278, -117.085833` | `32.56289, -117.13570` |
 | `location_label` | "San Diego, CA (Jetson WiFi)" | "Southwestern College, 900 Otay Lakes Rd, Chula Vista, CA" | "Project Oyster - North Reef buoy position" |
 | `mdp_device_id` | `mycobrain-sidea-10b41d` | `mycobrain-sidea-10b41d` | `mycobrain-COM4` |
@@ -4318,7 +4321,7 @@ All share `firmware_repo: "mycobrain/firmware"` (Agaric variants: `mycobrain/fir
 `force-dynamic` route (`app/api/natureos/devices/telemetry/route.ts`) that aggregates **real connected-device telemetry** across three backends and returns a flat array (no envelope). `fetchRealDeviceTelemetry` order (`:225-345`):
 
 1. **Local MycoBrain service** `GET {mycoBrainUrl}/devices` → deviceId `mycobrain-{port}`, reads `sensor_data.bme688_1/_2`, `device_info.uptime/lora_status/firmware/mdp_version` (`:234-283`). Timeout `MYCOBRAIN_SERVICE_TIMEOUT_MS` (1200).
-2. **Wi-Fi operator endpoints** (`OPERATOR_DEVICE_URLS`, default the two `:8787` Jetsons) — `fetchOperatorDevice` reads `GET /api/status` (parses `lastLines[]` JSON telemetry frames + `lastSensorReading`) and `GET /api/sensor`, deduped by `sensor_slot|address|node_id|device_id` (`:167-222`). `normalizeOperatorReading` resolves the site via `deploymentByHost` and surfaces compensated metrics (`temperature_c_comp`, `humidity_pct_comp`, `gas_resistance_ohm_comp`, `iaq_static`, `iaq_accuracy`, `gas_percentage`, `eco2_ppm`, `bvoc_ppm`, `valid`) (`:114-165`). Timeouts: status 4500 ms, sensor 1800 ms.
+2. **Field operator endpoints** (`MYCOBRAIN_OPERATOR_URLS`, configured per deployment) — `fetchOperatorDevice` reads `GET /api/status` (parses `lastLines[]` JSON telemetry frames + `lastSensorReading`) and `GET /api/sensor`, deduped by `sensor_slot|address|node_id|device_id` (`:167-222`). `normalizeOperatorReading` resolves the site via `deploymentByHost` and surfaces compensated metrics (`temperature_c_comp`, `humidity_pct_comp`, `gas_resistance_ohm_comp`, `iaq_static`, `iaq_accuracy`, `gas_percentage`, `eco2_ppm`, `bvoc_ppm`, `valid`) (`:114-165`). Timeouts: status 4500 ms, sensor 1800 ms.
 3. **MINDEX** `GET {mindexUrl}/api/devices?type=mycobrain` (offline devices included), only if not already present (`:294-329`). Timeout `MINDEX_DEVICE_TIMEOUT_MS` (1500).
 4. **Earth Simulator registry fallback** `GET /api/earth-simulator/devices` normalized via `normalizeEarthSimDevice` (`:46-112`), deduped against existing ids/registryIds. Timeout `EARTH_DEVICE_FALLBACK_TIMEOUT_MS` (1200). This is also the top-level catch-all if the whole pass throws.
 
@@ -4335,7 +4338,7 @@ Debug logging is gated on `CREP_DEBUG_DEVICE_TELEMETRY=1`.
 Thin proxy to the MINDEX FastAPI device registry with an Earth-Simulator fallback (`app/api/mindex/devices/route.ts`).
 - Query params: `page` (default 1), `pageSize` (default 50), `type`.
 - If `env.integrationsEnabled` is false (requires `INTEGRATIONS_ENABLED=true` **or** `MINDEX_API_KEY` + a MINDEX URL — `lib/env.ts:61-63`), it falls back to `/api/earth-simulator/devices?refresh=1&wait=1` (6.5 s timeout), client-filters by `type`/`role`/`device_type`, and returns `{ data, devices, meta, total, source:"earth-simulator-devices-fallback", dataSource, upstream }` with header `X-MINDEX-Warning: mindex-devices-unavailable-using-earth-simulator-devices` (`:19-72`).
-- When enabled it calls `getDevices({page,pageSize})` (`lib/integrations/mindex.ts:106-113` → `GET /devices?page&page_size`), filters by `type`, and on error repeats the same Earth-Simulator fallback. MINDEX auth uses `X-API-Key` (+ optional `x-internal-token`), base URL `resolveMindexServerBaseUrl()` → `http://192.168.0.189:8000` (loopback-guarded, `lib/mindex-base-url.ts:25, :51-76`). Debug: `CREP_DEBUG_MINDEX_DEVICES=1`.
+- When enabled it calls `getDevices({page,pageSize})` (`lib/integrations/mindex.ts:106-113` → `GET /devices?page&page_size`), filters by `type`, and on error repeats the same Earth-Simulator fallback. MINDEX auth uses `X-API-Key` (+ optional `x-internal-token`), base URL `resolveMindexServerBaseUrl()` → `{configured-service-url}` (loopback-guarded, `lib/mindex-base-url.ts:25, :51-76`). Debug: `CREP_DEBUG_MINDEX_DEVICES=1`.
 
 #### 6. Mycosoft-Devices proxy — `/api/crep/mycosoft-devices`
 
@@ -4359,11 +4362,11 @@ The device widget routes commands through `sendSelectedDeviceControl` / `DeviceM
 - **All other registry devices** → `POST /api/devices/network/{registryId}/command` with `{ command, params, timeout:5 }`.
 
 `/api/devices/network/[deviceId]/command/route.ts` (`requireAdmin` gated, `:213-214`) resolves the command via `networkCommandToOperator` and tries, in order:
-1. **Local serial** for `:8003` field deployments — guarded by `isSafeLocalSerialCommand` (`:23-64`): blocks `flash/erase/factory/bootloader/ota/format` and GPIO/pin/I²C-reconfig; allows status/sensor/scan + actuator commands (`beep`, `led rgb/brightness/pattern rainbow`, `coin`, `bump`, `1up`, `morgio`, etc.). A blocked low-level command returns **HTTP 423** "COM4 safety interlock active" (`:148-161`).
-2. **Field operator** `:8787` `POST /api/cmd` `{cmd}` (`forwardFieldOperatorCommand`, `:66-136`) — the fast path for the two Jetsons; no delayed MAS fallback is queued (to avoid commands physically firing late).
+1. **Local serial** for field gateway deployments — guarded by `isSafeLocalSerialCommand` (`:23-64`): blocks `flash/erase/factory/bootloader/ota/format` and GPIO/pin/I²C-reconfig; allows status/sensor/scan + actuator commands (`beep`, `led rgb/brightness/pattern rainbow`, `coin`, `bump`, `1up`, `morgio`, etc.). A blocked low-level command returns **HTTP 423** with a serial safety interlock message (`:148-161`).
+2. **Field operator** `POST /api/cmd` `{cmd}` on configured agent URL (`forwardFieldOperatorCommand`, `:66-136`) — fast path for field operator agents; no delayed MAS fallback is queued (to avoid commands physically firing late).
 3. **MAS** `POST {MAS}/api/devices/{id}/command`, with field-operator fallback on failure (`:243-281`).
 
-`MAS_API_URL` here is the raw `process.env.MAS_API_URL || "http://localhost:8001"` (not the loopback-guarded resolver). `/api/devices/network/[deviceId]/telemetry/route.ts` mirrors this: field-operator probe first, then MAS per-device telemetry, then MAS registry snapshot.
+`MAS_API_URL` here uses the configured MAS base URL from environment (may differ from the loopback-guarded resolver used elsewhere). `/api/devices/network/[deviceId]/telemetry/route.ts` mirrors this: field-operator probe first, then MAS per-device telemetry, then MAS registry snapshot.
 
 Control-result handling: `earthDeviceControlResultOk` accepts `success`/`status:"ok"`/`ok`/`result.ok!==false`; failures toast a context-aware message — auth failures (401/403 or "admin"/"unauthorized") → "Admin sign-in required…"; field devices → "Command relay did not confirm. This field device still reports online." (`CREPDashboardClient.tsx:1902-1928`). The `earthSimControlToOperatorCommand` mapper distinguishes neopixel rainbow/off, buzzer beep, and raw `cmd` actions (`:4312-4317`).
 
@@ -4419,12 +4422,12 @@ A subset of device layers is also driven by the `groundFilter` object (voice/MYC
 - **`partners` and `smartfence` layers have no backing data source or marker renderer** — they are deliberate UI placeholders.
 - **Mushroom 1 / Hyphae 1 coordinate disagreement** between `catalog.ts` and `field-deployments.ts` (field wins); both share one `mdp_device_id`.
 - **Inconsistent default coordinates** in the telemetry route: Chula Vista (`32.6401,−117.0842`) vs NYC (`40.7128,−74.006`) depending on which backend produced the row.
-- **LAN-dependence:** operator (`:8787`) and local-serial (`:8003`) sources only resolve from a host on the lab LAN; on prod the map relies on catalog + field seeds + MAS-VM registry. Loopback env values for MAS/MINDEX/MycoBrain are silently rewritten to LAN VM IPs unless the matching `ALLOW_LOOPBACK_*` escape hatch is set.
+- **Network scope:** operator and local-gateway device sources require reachability from the application host; production deployments typically rely on catalog + field seeds + MAS platform registry. Loopback service URLs in environment variables may be rewritten to configured platform hosts unless an explicit loopback override is enabled.
 - **COM4 safety interlock** blocks firmware/GPIO/I²C-reconfig commands (HTTP 423); all network commands require an admin session.
 - **Status "stickiness":** the 10-min (field) / 2-min (other) online-grace window means a marker can read `connected` for minutes after a device actually drops — intentional flap suppression, but it can mask short outages.
 - **Map-source comment drift:** the GeoJSON source comment references `/api/crep/mycosoft-devices` as the populator, but the live client effect actually fills `crep-mycosoft-devices` from the `devices` React state (sourced from `/api/earth-simulator/devices`).
 
-Relevant files: `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\app\api\earth-simulator\devices\route.ts`, `…\app\api\natureos\devices\telemetry\route.ts`, `…\app\api\mindex\devices\route.ts`, `…\app\api\crep\mycosoft-devices\route.ts`, `…\app\api\devices\network\[deviceId]\command\route.ts`, `…\app\api\devices\network\[deviceId]\telemetry\route.ts`, `…\lib\devices\field-deployments.ts`, `…\lib\devices\catalog.ts`, `…\lib\devices\operator-probe.ts`, `…\lib\devices\dev-bench-location.ts`, `…\lib\devices\mqtt-config.ts`, `…\lib\integrations\mindex.ts`, `…\lib\mas-server-url.ts`, `…\lib\mindex-base-url.ts`, `…\lib\mycobrain-service-url.ts`, and `…\app\dashboard\crep\CREPDashboardClient.tsx`.
+Relevant files: `WEBSITE/website/app/api/earth-simulator\devices\route.ts`, `…/app\api\natureos\devices\telemetry\route.ts`, `…/app\api\mindex\devices\route.ts`, `…/app\api\crep\mycosoft-devices\route.ts`, `…/app\api\devices\network\[deviceId]\command\route.ts`, `…/app\api\devices\network\[deviceId]\telemetry\route.ts`, `…/lib\devices\field-deployments.ts`, `…/lib\devices\catalog.ts`, `…/lib\devices\operator-probe.ts`, `…/lib\devices\dev-bench-location.ts`, `…/lib\devices\mqtt-config.ts`, `…/lib\integrations\mindex.ts`, `…/lib\mas-server-url.ts`, `…/lib\mindex-base-url.ts`, `…/lib\mycobrain-service-url.ts`, and `…/app\dashboard\crep\CREPDashboardClient.tsx`.
 
 ---
 
@@ -4490,7 +4493,7 @@ The MDP (MycoBrain Data Protocol) version is surfaced from device telemetry but 
 
 ##### 1.2 Operator telemetry normalization (`fetchOperatorDevice` / `normalizeOperatorReading`)
 
-- Operator device URLs come from `MYCOBRAIN_OPERATOR_URLS` (default `http://192.168.0.228:8787,http://192.168.0.123:8787`, `route.ts:8`).
+- Operator device URLs come from `MYCOBRAIN_OPERATOR_URLS` (default `{configured-service-url},{configured-service-url}`, `route.ts:8`).
 - Timeouts (env-tunable): service `MYCOBRAIN_SERVICE_TIMEOUT_MS=1200`, operator status `=4500`, operator sensor `=1800`, MINDEX device `=1500`, earth-sim fallback `=1200` (`route.ts:15-19`).
 - `normalizeOperatorReading` (`:114`) maps firmware fields → metrics: `temperature_c_comp`/`ambient_temperature_c`/`temperature_c` → `temperature`; compensated humidity/gas; `iaq`, `iaq_static`, `iaq_accuracy`, `eco2_ppm`, `bvoc_ppm`, `gas_percentage`, `uptime_s`, `sensor_slot`, `address`, `valid`. Device identity & location resolve from `deploymentByHost(host)` (`lib/devices/field-deployments.ts`) with catalog_id/role/location/registry_id; falls back to default coordinates `32.6401, -117.0842` (Imperial Beach lab) (`:31`, `:64-65`).
 - Merge order in `fetchRealDeviceTelemetry` (`:225`): (1) MycoBrain service `/devices`, (2) operator HTTP, (3) MINDEX `/api/devices?type=mycobrain` (offline included, deduped by `deviceId`), (4) Earth Simulator registry fallback (`/api/earth-simulator/devices`). On total failure it returns the earth-sim fallback only (`:343`).
@@ -4580,7 +4583,7 @@ On the dashboard, AQI is painted by `LiveAqiLayer` gated by `liveAqiLayerReady &
 
 Source: `app/api/oei/buoys/route.ts` (`dynamic="force-dynamic"`).
 
-- **Sources (parallel):** (1) NOAA NDBC `https://www.ndbc.noaa.gov/data/latest_obs/latest_obs.txt` (free, no key, ~1300 buoys; 6s timeout, `:171`), (2) MINDEX `${MINDEX_URL}/api/mindex/earth/map/bbox?layer=buoys&...&limit=2000` (`:192`, 2.5s timeout, `X-API-Key`). `MINDEX_URL` resolves `MINDEX_API_URL || NEXT_PUBLIC_MINDEX_URL || http://192.168.0.189:8000`; key `MINDEX_API_KEY || "local-dev-key"` (`:54-59`).
+- **Sources (parallel):** (1) NOAA NDBC `https://www.ndbc.noaa.gov/data/latest_obs/latest_obs.txt` (free, no key, ~1300 buoys; 6s timeout, `:171`), (2) MINDEX `${MINDEX_URL}/api/mindex/earth/map/bbox?layer=buoys&...&limit=2000` (`:192`, 2.5s timeout, `X-API-Key`). `MINDEX_URL` resolves `MINDEX_API_URL || NEXT_PUBLIC_MINDEX_URL || {configured-service-url}`; key `MINDEX_API_KEY || "<configured-api-key>"` (`:54-59`).
 - **NDBC parser** (`parseNDBCText` `:73`): whitespace-delimited, 2 header rows (names + units), `MM` = missing; column index map for `STN, LAT, LON, YYYY/YY, MM, DD, hh, mm, WDIR, WSPD, GST, WVHT, DPD, ATMP, WTMP, PRES, VIS, DEWP`. Invalid/out-of-range coords skipped. `parseNDBCFloat` (`:161`) treats `MM/999/99.0/999.0/9999.0/99.00` as null.
 - **`BuoyObservation` shape** (`:22`): `id, station_id, lat, lng, wind_speed (m/s), wind_direction (deg), wind_gust (m/s), wave_height (m), dominant_wave_period (s), water_temp (°C), air_temp (°C), pressure (hPa), visibility (nmi), dew_point (°C), timestamp (ISO), source ("ndbc"|"mindex")`.
 - **Dedup:** by `station_id`, NDBC overwrites MINDEX (`:305-316`).
@@ -5033,7 +5036,7 @@ From `lib/crep/lod-policy.ts`:
 
 ---
 
-Key files: `D:\Users\admin2\Desktop\MYCOSOFT\CODE\WEBSITE\website\components\crep\layers\{tijuana-estuary-layer,mojave-preserve-layer,project-nyc-dc-layer,sdtj-coverage-layer,proposal-overlays,v3-overlays}.tsx`; `lib\crep\{metro-infra-layer-bridge,jurisdiction-layers,lod-policy}.ts`; `lib\crep\registries\radar-registry.ts`; `components\crep\controls\fly-to-projects.tsx`; military bases + jurisdiction mounting inline in `app\dashboard\crep\CREPDashboardClient.tsx`.
+Key files: `WEBSITE/website/components\crep\layers\{tijuana-estuary-layer,mojave-preserve-layer,project-nyc-dc-layer,sdtj-coverage-layer,proposal-overlays,v3-overlays}.tsx`; `lib\crep\{metro-infra-layer-bridge,jurisdiction-layers,lod-policy}.ts`; `lib\crep\registries\radar-registry.ts`; `components\crep\controls\fly-to-projects.tsx`; military bases + jurisdiction mounting inline in `app\dashboard\crep\CREPDashboardClient.tsx`.
 
 ---
 
@@ -5156,7 +5159,7 @@ All three bounds keys use the **identical zoom-precision ladder** as `makeViewpo
 
 ##### `/api/crep/viewport-intel/route.ts`
 - `dynamic = "force-dynamic"`, `revalidate = 86400`. Params: `north, south, east, west, zoom` (each `finiteNumber(...)` with fallback `0`; zoom default `4`). Bounds are normalized so `north = max, south = min`.
-- **MINDEX-first:** proxies `${MINDEX_API}/api/mindex/civic/viewport-intel` with `X-Internal-Token` (first of comma-split `MINDEX_INTERNAL_TOKEN(S)`) and `X-API-Key` (`MINDEX_API_KEY` or `local-dev-key`), under a **900 ms** abort budget (`MINDEX_TIMEOUT_MS`).
+- **MINDEX-first:** proxies `${MINDEX_API}/api/mindex/civic/viewport-intel` with `X-Internal-Token` (first of comma-split `MINDEX_INTERNAL_TOKEN(S)`) and `X-API-Key` (`MINDEX_API_KEY` or `<configured-api-key>`), under a **900 ms** abort budget (`MINDEX_TIMEOUT_MS`).
 - In parallel it runs `enrichPlaceFromBounds` (local hint → `reverseGeocodePlace` only when LOD-specific enrichment is needed via `placeNeedsLodEnrichment`).
 - **Three response tiers:** (a) MINDEX-live merged with country-government profiles + civic fallback (`:502-549`, sets `Server-Timing` and `Cache-Control: public, s-maxage=86400, stale-while-revalidate=604800`); (b) upstream-down → `fetchFallbackForViewport` (country profiles or `fetchCivicFallback`) (`:361-419`); (c) total failure → `buildEmptyCivicResponse` (`:255-300`). US-vs-international routing is decided by `shouldUseUnitedStatesFallback` / `centerAppearsInsideUnitedStates`. Every tier reports `meta.timings` against a **1200 ms** budget.
 
@@ -5420,7 +5423,7 @@ Every `route.ts` under the six base directories. HTTP methods in parentheses whe
 | `eagle/connectors/border-crossing` | GET | Tijuana/US-MX border crossing camera + data feed |
 | `eagle/connectors/mastodon` | GET | Mastodon timeline ephemeral video posts |
 | `eagle/connectors/public-webcams` | GET/POST | Windy + EarthCam + NPS + USGS + ALERTWildfire + HPWREN + Surfline + static-seed webcams |
-| `eagle/connectors/shinobi` | GET/POST | Shinobi NVR monitor list (MAS 188 instance) |
+| `eagle/connectors/shinobi` | GET/POST | Shinobi NVR monitor list (MAS platform instance) |
 | `eagle/connectors/state-dot-cctv` | GET | State DOT CCTV camera connector |
 | `eagle/connectors/traffic-511` | GET/POST | Union of three 511 traveler-info camera feeds |
 | `eagle/connectors/twitch` | GET | Twitch live streams (geo) connector |

--- a/docs/earth-simulator/README.md
+++ b/docs/earth-simulator/README.md
@@ -1,277 +1,625 @@
-# Earth Simulator - NatureOS Environmental Intelligence Platform
+# Earth Simulator
 
-## 🌍 Overview
+**The fungal-first planetary intelligence map.**
 
-The Earth Simulator is a comprehensive, real-time 3D visualization and analysis platform for environmental intelligence, mycelium network mapping, and global ecosystem monitoring. Built on CesiumJS and integrated with Google Earth Engine, it provides scientific-grade geospatial analysis capabilities for the Mycosoft NatureOS platform.
+![Status](https://img.shields.io/badge/status-production-green)
+![Platform](https://img.shields.io/badge/platform-mycosoft.com-2d6a4f)
+![Data](https://img.shields.io/badge/data-live%20feeds%20only-0d9488)
+![Mobile](https://img.shields.io/badge/mobile-full%20map%20experience-6366f1)
 
-## 🎯 Mission
-
-To create the world's most advanced environmental intelligence platform that:
-- **Visualizes** global ecosystems in real-time 3D
-- **Tracks** mycelium networks and fungal intelligence across continents
-- **Monitors** environmental conditions through MycoBrain sensor networks
-- **Analyzes** biodiversity, climate patterns, and ecological interactions
-- **Predicts** ecosystem changes using Nature Learning Models (NLM)
-- **Enables** scientific research and conservation efforts at planetary scale
-
-## 🚀 Core Capabilities
-
-### 1. **24x24 Inch Land Grid System**
-- Unique tile IDs for every landmass on Earth (75,168+ tiles)
-- Excludes all ocean areas automatically
-- Supports multiple resolutions: Coarse (1°), Medium (0.5°), Fine (0.1°)
-- Viewport-based lazy loading (max 2000 tiles) for optimal performance
-- Region-based color coding for visual distinction
-- Click-to-inspect tile details (ID, region, area, coordinates)
-
-### 2. **Real-Time 3D Globe Visualization**
-- High-resolution satellite imagery (ESRI World Imagery / Google Earth Engine)
-- Smooth camera controls (drag, zoom, rotate)
-- Multiple view modes (3D, 2D, orthographic)
-- WebGL-accelerated rendering
-- Responsive to viewport changes
-
-### 3. **Environmental Data Layers**
-- **Mycelium Networks**: Visualize fungal intelligence networks
-- **Heat Maps**: Temperature and thermal anomaly detection
-- **Organisms**: iNaturalist biodiversity data integration
-- **Weather**: Real-time meteorological data
-- **Device Markers**: MycoBrain sensor locations and telemetry
-
-### 4. **Google Earth Engine Integration**
-- Satellite imagery processing
-- Elevation data (SRTM)
-- Land cover classification (ESA WorldCover)
-- Vegetation indices (NDVI, MODIS)
-- Custom dataset support
-
-### 5. **MycoBrain Device Integration**
-- Real-time sensor data visualization
-- Device location mapping
-- Telemetry overlays
-- Environmental monitoring dashboards
-
-### 6. **Scientific Analysis Tools**
-- Viewport statistics
-- Species observation counts
-- Grid cell analysis
-- Probability mapping
-- Data aggregation
-
-## 📐 Architecture
-
-### Frontend Components
-```
-components/earth-simulator/
-├── cesium-globe.tsx          # Main 3D globe renderer
-├── earth-simulator-container.tsx  # Main container component
-├── comprehensive-side-panel.tsx   # Data visualization panel
-├── layer-controls.tsx         # Layer toggle controls
-├── hud.tsx                    # Heads-up display overlay
-├── controls.tsx               # Navigation controls
-├── mycelium-layer.tsx         # Mycelium network visualization
-├── heat-layer.tsx             # Thermal data layer
-├── organism-layer.tsx         # Biodiversity markers
-├── weather-layer.tsx          # Meteorological data
-└── device-markers.tsx         # MycoBrain device locations
-```
-
-### API Endpoints
-```
-app/api/earth-simulator/
-├── land-tiles/                # 24x24 grid system API
-├── gee/                       # Google Earth Engine proxy
-├── gee/tile/[type]/[z]/[x]/[y]/  # GEE tile proxy
-├── grid/                      # Grid cell calculations
-├── inaturalist/               # Biodiversity data
-├── devices/                    # MycoBrain device data
-├── layers/                     # Layer data aggregation
-├── aggregate/                  # Data aggregation
-├── mycelium-probability/       # Fungal network predictions
-└── search/                     # Location search
-```
-
-### Core Libraries
-- **CesiumJS**: 3D globe rendering engine
-- **Google Earth Engine**: Satellite imagery and geospatial analysis
-- **Next.js**: React framework with API routes
-- **TypeScript**: Type-safe development
-- **Tailwind CSS**: Styling and responsive design
-
-## 🎨 UI/UX Design Philosophy
-
-### Scientific Clarity
-- Clean, uncluttered interface
-- Data-first visualization
-- Color-coded regions for quick identification
-- Real-time statistics and metrics
-
-### Performance Optimization
-- Viewport-based lazy loading
-- Debounced viewport updates (500ms)
-- Maximum tile limits (2000 per viewport)
-- WebGL hardware acceleration
-
-### User Experience
-- Intuitive camera controls
-- Contextual information panels
-- Click-to-inspect interactions
-- Responsive design (desktop, tablet, mobile)
-
-### Accessibility
-- Keyboard navigation support
-- Screen reader compatibility
-- High contrast mode support
-- Touch gesture support
-
-## 🔧 Technical Specifications
-
-### Performance Metrics
-- **Initial Load**: < 3 seconds
-- **Viewport Updates**: < 500ms
-- **Tile Loading**: Max 2000 tiles per viewport
-- **Memory Usage**: ~4MB per viewport (vs 150MB for full globe)
-- **Frame Rate**: 60 FPS target
-
-### Browser Requirements
-- Chrome/Edge 90+
-- Firefox 88+
-- Safari 14+
-- WebGL 2.0 support required
-
-### Memory Management
-- Viewport-based tile loading
-- Automatic tile cleanup on viewport change
-- Debounced API calls
-- Efficient entity management in Cesium
-
-## 📊 Data Sources
-
-### Primary Sources
-- **ESRI World Imagery**: High-resolution satellite imagery
-- **Google Earth Engine**: Advanced geospatial datasets
-- **iNaturalist API**: Biodiversity observations
-- **MycoBrain Devices**: Real-time sensor telemetry
-- **MINDEX Database**: Mycelium network data
-
-### Grid System Data
-- **Total Land Tiles**: 75,168 (at 0.5° resolution)
-- **Ocean Tiles**: Excluded automatically
-- **Regions**: North America, South America, Europe, Africa, Asia, Australia, Antarctica, Greenland
-
-## 🚧 Current Status
-
-### ✅ Implemented
-- [x] 24x24 land grid system with unique tile IDs
-- [x] Viewport-based lazy loading
-- [x] CesiumJS 3D globe integration
-- [x] ESRI World Imagery support
-- [x] Google Earth Engine tile proxy
-- [x] Grid controls and statistics
-- [x] Region-based color coding
-- [x] Click-to-inspect tile details
-- [x] Responsive UI components
-- [x] Memory optimization
-
-### 🚧 In Progress
-- [ ] Full Google Earth Engine dataset integration
-- [ ] Mycelium network visualization
-- [ ] Real-time device telemetry overlays
-- [ ] Weather data layer
-- [ ] Heat map layer
-- [ ] Organism markers from iNaturalist
-
-### 📋 Planned Features
-- [ ] Advanced filtering and search
-- [ ] Data export capabilities
-- [ ] Custom layer creation
-- [ ] Collaborative annotations
-- [ ] Time-series analysis
-- [ ] Predictive modeling visualization
-- [ ] Mobile app integration
-- [ ] VR/AR support
-
-## 🔮 Future Vision
-
-### Short-Term (3-6 months)
-- Complete all planned data layers
-- Integrate full MycoBrain device network
-- Implement advanced filtering
-- Add data export features
-
-### Medium-Term (6-12 months)
-- Machine learning predictions overlay
-- Real-time collaboration features
-- Mobile application
-- API for third-party integrations
-
-### Long-Term (12+ months)
-- VR/AR immersive experiences
-- Global mycelium network AI predictions
-- Climate change modeling
-- Conservation impact tracking
-- Scientific publication integration
-
-## 🛠️ Development
-
-### Getting Started
-```bash
-# Install dependencies
-npm install
-
-# Run development server
-npm run dev
-
-# Navigate to Earth Simulator
-http://localhost:3002/apps/earth-simulator
-```
-
-### Environment Variables
-```env
-# Google Earth Engine (optional)
-GEE_PROJECT_ID=your-project-id
-GEE_SERVICE_ACCOUNT_EMAIL=your-service-account@project.iam.gserviceaccount.com
-GEE_PRIVATE_KEY=your-private-key
-GEE_CLIENT_ID=your-client-id
-```
-
-### Building for Production
-```bash
-npm run build
-npm start
-```
-
-## 📚 Documentation
-
-- [Architecture Overview](./ARCHITECTURE.md)
-- [API Reference](./API.md)
-- [UI/UX Design Guide](./UIUX.md)
-- [Grid System Specification](./GRID_SYSTEM.md)
-- [Performance Optimization](./PERFORMANCE.md)
-- [Deployment Guide](./DEPLOYMENT.md)
-
-## 🤝 Contributing
-
-This is part of the Mycosoft NatureOS platform. For contributions:
-1. Follow the existing code style
-2. Add comprehensive tests
-3. Update documentation
-4. Submit pull requests for review
-
-## 📄 License
-
-Part of the Mycosoft platform. See main repository license.
-
-## 🙏 Acknowledgments
-
-- **CesiumJS**: 3D globe rendering
-- **Google Earth Engine**: Geospatial data platform
-- **ESRI**: Satellite imagery
-- **iNaturalist**: Biodiversity data
-- **Mycosoft Team**: Platform development
+**Live:** [mycosoft.com/natureos/earth-simulator](https://mycosoft.com/natureos/earth-simulator)  
+**Last updated:** June 13, 2026
 
 ---
 
-**Version**: 1.0.0  
-**Last Updated**: January 2026  
-**Status**: Active Development
+## What is Earth Simulator?
+
+**Earth Simulator** is Mycosoft’s public-facing name for the **CREP** — the *Common Relevant Environmental Picture*: a full-screen, intelligence-grade map of the planet that puts **fungi, biodiversity, and field biology** at the center, then layers in everything else an operator, scientist, or citizen needs to understand what is happening on Earth *right now*.
+
+Open the map and you get a living globe (or flat map on mobile) with satellite imagery, submarine cables, power plants, earthquakes, wildfires, live aircraft and ships, satellites in orbit, air quality, civic facilities, regional science projects, and **MycoBrain field sensors** streaming real environmental telemetry — all toggleable from one layer panel. Pan anywhere; the **viewport intelligence** panel summarizes conditions, sensors, and context for what you are looking at. Ask **MYCA** for an AI brief of the visible area.
+
+This is not a static GIS demo. Earth Simulator is wired to **40+ live data connectors**, the **MINDEX** mycological database, the **MAS** multi-agent system, optional **NVIDIA Earth-2** weather and spore models, and deployed **Mushroom 1**, **Hyphae 1**, and **Psathyrella** buoy hardware in the field. Every production path uses **real API data** — empty states when a feed is down, never fabricated placeholders.
+
+> **Why fungal-first?** Mycosoft’s mission is to make fungal intelligence visible at planetary scale. Earth Simulator opens with the **Ectomycorrhizal (EcM) fungal atlas**, live iNaturalist and MINDEX nature observations, and mycelium probability layers — because understanding the hidden mycelial layer is how we understand ecosystems, carbon, water, and resilience.
+
+---
+
+## What you can explore
+
+### The living map
+
+- **Satellite basemap** with bathymetry and topography — zoom from continental view to street-scale detail
+- **Globe or map mode** — desktop globe projection; mobile-optimized flat map with full layer access
+- **Staged boot** — the map paints in seconds with the layers that matter first; heavy live feeds stream in without blocking first paint
+- **Works on your phone** — full Earth Simulator on iOS and Android via the CREP mobile shell (layer drawers, intel panels, touch controls)
+
+### Nature, species & fungal intelligence
+
+- **Fungal Atlas (EcM)** — default raster overlay of ectomycorrhizal fungal distribution
+- **Live observations** — fungi, plants, birds, and marine life from iNaturalist, GBIF, eBird, OBIS, and MINDEX
+- **Mycelium probability** — modeled likelihood grids and heat tiles
+- **Species search** — find taxa and jump to observations on the map
+
+### Hazards & natural events
+
+- **Earthquakes, volcanoes, wildfires, storms, lightning, tornadoes, floods** — global event layers with viewport-aware loading
+- **Space weather** — solar activity, aurora forecasts, sun–earth correlation (opt-in)
+- **NWS alerts** and **USGS** feeds for authoritative hazard data
+
+### Sky, sea & orbit
+
+- **Live aviation** — aircraft positions from OpenSky and FlightRadar24
+- **Maritime** — vessels via AIS; fishing activity; global ports
+- **Satellites & debris** — multi-source orbital catalog (CelesTrak, Space-Track, amateur TLE networks)
+- **Orbit paths** — deck.gl-rendered tracks for selected space objects
+
+### Infrastructure & energy
+
+- **Submarine cables** and **transmission lines** — the backbone of the internet and grid
+- **Power plants**, substations, pipelines, factories, ports, airports
+- **Cell towers**, data centers, radio stations — telecom and compute footprint
+- **Railways** — network geometry plus live train positions where available
+
+### Air, water & environment
+
+- **Air quality** — OpenAQ and AirNow live AQI
+- **NOAA buoys** — coastal and offshore sensor stations
+- **Carbon Mapper** plumes and pollution overlays (where configured)
+- **Border wait times**, **H₂S monitoring** (San Diego region), **Tijuana estuary** project layers
+
+### Field science & MycoBrain devices
+
+Earth Simulator is the **operator console for deployed Mycosoft hardware**:
+
+| Device | What it does on the map |
+|--------|-------------------------|
+| **Mushroom 1** | Jetson field node — San Diego lab; BME688 VOC / environmental telemetry |
+| **Hyphae 1** | Jetson field node — Southwestern College, Chula Vista; live sensor stream |
+| **Psathyrella buoy** | Aquatic MycoBrain buoy — Project Oyster reef; water-adjacent gas and env sensing |
+
+Click a device marker for live readings, status, and operator controls when a field gateway is connected. Device data merges from the MAS registry, field agents, and the MycoBrain gateway — **no mock devices**.
+
+### Regional science projects
+
+Purpose-built layers for active Mycosoft field work:
+
+- **Project Oyster** — plume and emit visualization on the San Diego coast
+- **San Diego / Tijuana corridor** — estuary, border, and cross-border environmental context
+- **Mojave** and other project-scoped overlays — enabled when you zoom into the region
+
+### MYCA & viewport intelligence
+
+- **Viewport environment** — weather, air, and context for the bounds you are viewing
+- **Viewport sensors** — rollup of buoys, stations, and devices in view
+- **Viewport intel** — fused operational picture for the visible map
+- **AI summary** — MYCA-generated brief of what matters in your current viewport
+
+### Earth-2 weather & spore models (optional)
+
+When the Earth-2 GPU stack is enabled, layers for **forecast**, **nowcast**, **wind**, **temperature**, **precipitation**, and **spore dispersal** can be toggled on — powered by MAS orchestration and NVIDIA Earth-2 inference.
+
+### Eagle Eye & live cameras
+
+Public **CCTV**, **YouTube live**, and **Eagle Eye** camera feeds can be placed on the map for ground-truth visual confirmation of events and sites.
+
+---
+
+## Who it is for
+
+| Audience | How they use Earth Simulator |
+|----------|------------------------------|
+| **Scientists & mycologists** | Fungal atlas, species observations, mycelium models, field device telemetry |
+| **Conservation & ecology** | Biodiversity hotspots, habitat layers, iNaturalist/MINDEX nature stream |
+| **Environmental operators** | Hazards, air quality, buoys, regional project monitors (H₂S, estuary, oyster) |
+| **Infrastructure & telecom** | Cables, grid, data centers, cell coverage, ports and transport |
+| **Defense & situational awareness** | CREP entry at `/defense/crep`; live movers, civic facilities, fused viewport intel |
+| **Educators & the public** | Free exploration of a real, live planetary map — fungi first, everything else on demand |
+
+---
+
+## Try it
+
+| Entry | URL |
+|-------|-----|
+| **Canonical (NatureOS)** | [mycosoft.com/natureos/earth-simulator](https://mycosoft.com/natureos/earth-simulator) |
+| **Dashboard** | [mycosoft.com/dashboard/crep](https://mycosoft.com/dashboard/crep) |
+| **Defense CREP** | [mycosoft.com/defense/crep](https://mycosoft.com/defense/crep) |
+| **Sandbox** | [sandbox.mycosoft.com/natureos/earth-simulator](https://sandbox.mycosoft.com/natureos/earth-simulator) |
+
+Legacy `/apps/earth-simulator` redirects to the canonical URL. The old Cesium 3D globe (January 2026) is **deprecated**; production Earth Simulator is the MapLibre + deck.gl CREP stack (May 2026+).
+
+---
+
+## Documentation
+
+| Document | Audience | Description |
+|----------|----------|-------------|
+| **[Technical Outline](../EARTH_SIMULATOR_TECHNICAL_REFERENCE.md)** | Engineers, QA, integrators | **Definitive capability index** — layer registry, API catalog, boot sequence, and architecture (internal deployment details are maintained separately; not for public redistribution) |
+| **[Documentation Index](../EARTH_SIMULATOR_DOCS_INDEX.md)** | Everyone | Master index of Earth Simulator / CREP docs, handoffs, and deprecated Cesium-era files |
+| **This README** | Public + developers | Product overview (above) and developer reference (below) |
+
+**Historical reference (Cesium era, January 2026):** `ARCHITECTURE.md`, `API.md`, `GRID_SYSTEM.md`, `DEPLOYMENT.md`, `PERFORMANCE.md`, `UIUX.md` in this folder — superseded by the Technical Outline and this README; retained for archive.
+
+**Recent handoffs (May–June 2026):** see the [Documentation Index](../EARTH_SIMULATOR_DOCS_INDEX.md#crep--recent-handoffs-mayjune-2026) for device backend, first-paint, production map, and field-device audit reports.
+
+---
+
+## For developers
+
+The sections below describe the **public integration surface** — routes, APIs, and architecture at a high level. **Internal hostnames, private network addresses, VM layout, and deployment runbooks are not published here.** Mycosoft operators should use internal documentation for environment configuration and production operations.
+
+For exhaustive feature coverage (layer IDs, boot gates, file references), see the in-repo **[Technical Outline](../EARTH_SIMULATOR_TECHNICAL_REFERENCE.md)** (maintained for engineering; sanitize before any external release).
+
+### Overview & mission
+
+The **Earth Simulator** is Mycosoft's production **CREP** implementation — a fungal-first, real-time planetary intelligence map backed by MapLibre GL, deck.gl, PMTiles, and a Next.js BFF. It unifies environmental feeds, infrastructure, biodiversity, field MycoBrain sensors, orbital objects, and optional Earth-2 model layers.
+
+**Engineering goals:**
+
+- Visualize **fungal intelligence** (EcM atlas, iNaturalist/MINDEX nature stream, mycelium probability) as the default first-paint focus
+- Integrate **live movers** (aviation, maritime, satellites) and **natural events** when enabled
+- Surface **field MycoBrain devices** with real BME688 telemetry — no mock or placeholder data
+- Power **viewport intelligence** (environment, sensors, AI summary) for visible map bounds
+- Connect to **MAS**, **MINDEX**, **OEI connectors**, and optional **Earth-2** inference through the Next.js backend-for-frontend (BFF)
+
+**Repository:** `WEBSITE/website` (Next.js 15 App Router)
+
+---
+
+## Capabilities & features
+
+### Globe & map
+
+| Feature | Description |
+|--------|-------------|
+| **MapLibre GL** basemap | Satellite imagery, bathymetry, topography; ESRI/GIBS/Mapbox tile proxies via CREP BFF |
+| **Staged boot profile** | `lib/crep/earth-simulator-boot.ts` — layers ON/OFF at refresh for fast first paint |
+| **deck.gl EntityDeckLayer** | Aircraft, vessels, satellites with orbit paths (single orbit source) |
+| **LOD policy** | Zoom-aware DOM caps, infra deferral, fungal marker thresholds |
+| **Mobile shell** | `CrepMobileShell` — full map on phone with bottom-sheet layer/intel drawers |
+| **24×24 land grid** | Viewport-based land tile IDs via `/api/earth-simulator/land-tiles` and grid APIs |
+| **Photo3D** | `/dashboard/crep/photo3d` — photorealistic 3D tiles (opt-in layer) |
+
+### Layers (boot profile summary)
+
+**ON at refresh** (`EARTH_SIM_PROFILE_ON_LAYER_IDS`):
+
+- Base: `satImagery`, `bathymetry`, `topography`, `fungalAtlasECM`
+- Infra lines: submarine cables, global transmission lines; deferred infra points (power plants, cell towers, ports, factories, pipelines, etc.)
+- Events: earthquakes, volcanoes, wildfires, storms, lightning, tornadoes, floods
+- Devices: MycoBrain boot layers, fungi/biodiversity, buoys, live AQI, live transit, railway trains
+- Boundaries: country, state, county jurisdictions
+- Civic: hospitals, fire stations, universities, police, libraries
+- Telecom: IM3 data centers, signal heatmap
+
+**OFF at refresh** (user enables via layer panel):
+
+- Movers: aviation, ships, satellites, fishing, containers
+- Earth-2: forecast, nowcast, spore dispersal, wind/temp/precip overlays
+- Space weather: solar, aurora, sun–earth impact
+- Military movers, factories (duplicate toggles), weather population layers, project-scoped regional layers
+
+Set `NEXT_PUBLIC_EARTH_SIM_STAGED_BOOT=0` to revert to legacy mount behavior.
+
+### Fungal intelligence
+
+- **Fungal Atlas EcM** raster (default; AM layer mutually exclusive at boot)
+- **CREP fungal API** — observations, atlas samples, deployment metadata, vector tiles
+- **iNaturalist** proxy with MINDEX-backed nature stream and preloaded bbox cache
+- **Mycelium probability** grid and tile endpoints
+- Fungi-only ground filter at first paint (other kingdoms opt-in)
+
+### OEI feeds (Orbital Earth Intelligence)
+
+Live and static connectors under `/api/oei/*`: OpenSky/FlightRadar24 aviation, AISstream maritime, multi-source satellite registry (CelesTrak, Space-Track, N2YO, MINDEX), USGS/EONET events, GBIF/eBird/OBIS biodiversity, OpenAQ air quality, infrastructure (power grid, submarine cables, cell towers, railways), space weather, military bases, factories, and more. All routes return **real API data** or explicit empty/error states — never fabricated records.
+
+### Earth-2 integration
+
+Optional GPU-backed weather and spore layers via `/api/earth2/*`, proxied through MAS to the Earth-2 inference service. Layers start **disabled** at boot.
+
+### Field devices & MycoBrain
+
+| Device | Role |
+|--------|------|
+| **Mushroom 1** | Field Jetson node — San Diego lab; BME688 VOC / environmental telemetry |
+| **Hyphae 1** | Field Jetson node — Southwestern College, Chula Vista; live sensor stream |
+| **Psathyrella buoy** | Aquatic MycoBrain buoy — Project Oyster reef; water-adjacent gas and env sensing |
+
+`GET /api/earth-simulator/devices` merges device catalog entries, known field deployments, the MAS device registry, operator agent probes, and MycoBrain gateway telemetry into a single map layer.
+
+Operator commands (buzzer/beep, LEDs) route through the device command API when a gateway is reachable.
+
+### Viewport intelligence
+
+- `GET /api/crep/viewport-environment` — environmental context for bounds
+- `GET /api/crep/viewport-sensors` — sensor rollup
+- `GET /api/crep/viewport-intel` — fused intel picture
+- `POST /api/crep/viewport-ai-summary` — MYCA/LLM summary for viewport
+- `GET /api/crep/infra/viewport-stats` — infrastructure counts in view
+
+### Projects & regional layers
+
+Project-scoped layers (San Diego/Tijuana corridor, Mojave, Oyster plume, SDAPCD H₂S, Tijuana estuary, border wait times) load via `/api/crep/*` regional routes. Generic project layer IDs are detected by prefix in `earth-simulator-boot.ts`.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph Browser
+    UI[CREPDashboardClient<br/>MapLibre + deck.gl]
+    Boot[earth-simulator-boot.ts]
+  end
+
+  subgraph NextJS["Next.js BFF (website API)"]
+    ES["/api/earth-simulator/*"]
+    CREP["/api/crep/*"]
+    OEI["/api/oei/*"]
+    E2["/api/earth2/*"]
+    MB["/api/mycobrain/*"]
+    WV["/api/worldview/v1/*"]
+    SVC[crep-data-service.ts]
+  end
+
+  subgraph Platform["Mycosoft platform services"]
+    MAS[MAS Orchestrator]
+    MINDEX[MINDEX API]
+    Redis[(Redis cache)]
+    PG[(PostgreSQL)]
+  end
+
+  subgraph GPU["GPU inference (optional)"]
+    E2GPU[Earth-2 API]
+    Voice[PersonaPlex voice bridge]
+  end
+
+  subgraph External["External connectors"]
+    OEIAPI[OpenSky, AISstream, CelesTrak, USGS, GBIF, OpenAQ, …]
+    GEE[Google Earth Engine]
+    Field[Field agents / MycoBrain gateway]
+  end
+
+  UI --> Boot
+  UI --> ES & CREP & OEI & E2 & MB
+  ES & CREP & OEI --> SVC
+  SVC --> MAS & MINDEX & Redis
+  OEI --> OEIAPI
+  ES --> GEE
+  MB & ES --> Field
+  E2 --> MAS --> E2GPU
+  CREP --> Voice
+  WV --> MINDEX
+```
+
+**Main implementation files:**
+
+| Layer | Path |
+|-------|------|
+| Page (canonical) | `app/natureos/earth-simulator/page.tsx` |
+| Dashboard client | `app/dashboard/crep/CREPDashboardClient.tsx` |
+| Lazy loader | `app/dashboard/crep/CREPDashboardLoader.tsx` |
+| Boot profile | `lib/crep/earth-simulator-boot.ts` |
+| Data service | `lib/crep/crep-data-service.ts` |
+| Field devices | `lib/devices/field-deployments.ts` |
+| Entity rendering | `components/crep/layers/deck-entity-layer.tsx` |
+| Map controls | `components/crep/map-controls.tsx` |
+| API URL config | `lib/config/api-urls.ts` |
+
+---
+
+## Routes index (pages)
+
+| Route | Role |
+|-------|------|
+| **`/natureos/earth-simulator`** | **Canonical** Earth Simulator (CREP MapLibre) |
+| `/dashboard/crep` | Same dashboard (dashboard entry) |
+| `/natureos/crep` | Same dashboard (NatureOS alias) |
+| `/defense/crep` | Same dashboard (defense entry) |
+| `/earth-simulator` | **301 redirect** → `/natureos/earth-simulator` (`next.config.js`) |
+| `/natureos/tools/earth-simulator` | **301 redirect** → canonical |
+| `/apps/earth-simulator` | **Server redirect** → canonical (Cesium deprecated May 2026) |
+| `/dashboard/crep/photo3d` | Photorealistic 3D CREP view |
+| `/defense` | Defense hub |
+| `/defense/oei` | OEI monitoring dashboard |
+| `/defense/fusarium` | FUSARIUM biosecurity view |
+| `/docs/apps/earth-simulator` | In-app documentation page |
+
+---
+
+## API catalog
+
+All routes live under the website Next.js `app/api/` tree. Methods below reflect `route.ts` exports in the production codebase (June 2026).
+
+### `/api/earth-simulator/*` (15 routes)
+
+| Endpoint | Methods | Purpose |
+|----------|---------|---------|
+| `/aggregate` | POST | Viewport data aggregation, mycelium probability |
+| `/cell/[cellId]` | GET | Grid cell detail |
+| `/devices` | GET | Merged MycoBrain / MAS / field device markers |
+| `/gee` | GET, POST | Google Earth Engine proxy (status, datasets, stats) |
+| `/gee/tile/[type]/[z]/[x]/[y]` | GET | GEE tile proxy |
+| `/grid` | GET, POST | Land grid utilities |
+| `/heat-tiles/[z]/[x]/[y]` | GET | Thermal heat map tiles |
+| `/inaturalist` | GET, POST | iNaturalist observation proxy |
+| `/land-tiles` | GET | 24×24 land grid tile manifest |
+| `/layers` | GET | Layer metadata |
+| `/mycelium-probability` | GET, POST | Mycelium probability model |
+| `/mycelium-tiles/[z]/[x]/[y]` | GET | Mycelium raster tiles |
+| `/search` | GET | Geospatial search |
+| `/tiles/[z]/[x]/[y]` | GET | Generic Earth Simulator tiles |
+| `/weather-tiles/[z]/[x]/[y]` | GET | Weather raster tiles |
+
+### `/api/crep/*` (38 routes)
+
+| Endpoint | Methods | Purpose |
+|----------|---------|---------|
+| `/unified` | GET | Cached multi-domain CREP bundle (aircraft, vessels, satellites, fungal, devices, events) |
+| `/health` | GET | CREP BFF health |
+| `/status` | GET | Service status |
+| `/services` | GET | Connector registry |
+| `/fungal` | GET | Fungal observations GeoJSON |
+| `/fungal-atlas` | GET | Atlas metadata |
+| `/fungal-atlas/deployment` | GET | Atlas deployment info |
+| `/fungal-atlas/samples` | GET | Atlas sample points |
+| `/fungal-atlas/tiles/[layer]/[z]/[x]/[y]` | GET | Atlas raster tiles |
+| `/nature/preloaded` | GET | Preloaded nature bbox cache |
+| `/nature-stream` | GET | SSE/streaming nature observations |
+| `/species/search` | GET | Species search |
+| `/mycosoft-devices` | GET | CREP device list |
+| `/viewport-environment` | GET | Viewport environmental summary |
+| `/viewport-sensors` | GET | Viewport sensor rollup |
+| `/viewport-intel` | GET | Viewport fused intel |
+| `/viewport-ai-summary` | POST | AI-generated viewport brief |
+| `/infra/viewport-stats` | GET | Infrastructure stats in bounds |
+| `/geocode` | GET | Forward geocode |
+| `/reverse-geocode` | GET | Reverse geocode |
+| `/preferences` | GET, POST | User CREP preferences |
+| `/waypoints` | GET, POST | Saved waypoints |
+| `/waypoints/[id]` | PATCH, DELETE | Single waypoint update/delete |
+| `/tiles/[...tile]` | GET | CREP tile catch-all |
+| `/tiles/satellite/[basemap]/[z]/[x]/[y]` | GET | Satellite basemap proxy (ESRI/Mapbox/GIBS) |
+| `/tile-render/[layer]/[z]/[x]/[y]` | GET | Dynamic layer tile render |
+| `/airnow/bbox` | GET | AirNow AQI by bbox |
+| `/airnow/current` | GET | Current AQI |
+| `/biodiversity-hotspots` | GET | Hotspot layer |
+| `/border-wait-times` | GET | US–Mexico border wait times |
+| `/buoy/[station]` | GET | NOAA buoy detail |
+| `/mojave` | GET | Mojave project layer |
+| `/oyster/emit` | GET | Project Oyster emit layer |
+| `/oyster/plume` | GET | Oyster plume model |
+| `/sdapcd/h2s` | GET | SDAPCD H₂S monitoring |
+| `/sdapcd/h2s/chart` | GET | H₂S chart data |
+| `/sdapcd/h2s/collect` | GET, POST | H₂S data collection |
+| `/tijuana-estuary` | GET | Tijuana estuary project |
+
+### `/api/oei/*` (37 routes)
+
+| Endpoint | Methods | Purpose |
+|----------|---------|---------|
+| `/opensky` | GET | OpenSky aviation |
+| `/flightradar24` | GET | FlightRadar24 (keyed) |
+| `/flight-history/[id]` | GET | Flight track history |
+| `/aisstream` | GET | AIS maritime (keyed WebSocket cache) |
+| `/satellites` | GET | Multi-source satellite registry |
+| `/orbital-objects` | GET | Orbital catalog |
+| `/debris` | GET | Orbital debris |
+| `/space-weather` | GET | SWPC space weather |
+| `/space-weather/aurora` | GET | Aurora forecast |
+| `/sun-earth-correlation` | GET | Sun–Earth correlation |
+| `/events` | GET | Global events |
+| `/eonet` | GET | NASA EONET |
+| `/nws-alerts` | GET | NWS alerts |
+| `/usgs-volcano` | GET | USGS volcanoes |
+| `/gbif` | GET | GBIF occurrences |
+| `/ebird` | GET | eBird observations |
+| `/obis` | GET | OBIS marine life |
+| `/openaq` | GET | OpenAQ air quality |
+| `/buoys` | GET | NOAA buoys |
+| `/fishing` | GET | Fishing vessel activity |
+| `/ports` | GET | Global ports |
+| `/railways` | GET | Railway network |
+| `/railway-live` | GET | Live train positions |
+| `/power-grid` | GET | Power grid features |
+| `/power-plants` | GET | Power plant locations |
+| `/transmission-lines-global` | GET | Transmission lines |
+| `/submarine-cables` | GET | Submarine cables |
+| `/cell-towers-global` | GET | Cell towers |
+| `/radio-stations` | GET | Radio stations |
+| `/radar` | GET | Weather radar |
+| `/cctv` | GET | Public CCTV feeds |
+| `/youtube-live` | GET | YouTube live cameras |
+| `/carbon-mapper` | GET | Carbon Mapper plumes |
+| `/factories` | GET | Factory/industrial sites |
+| `/military` | GET | Military installations |
+| `/drone-no-fly` | GET | Drone no-fly zones |
+| `/overpass` | GET | OpenStreetMap Overpass proxy |
+| `/sdr/listen` | GET | SDR listen metadata |
+
+### `/api/earth2/*` (12 routes)
+
+| Endpoint | Methods | Purpose |
+|----------|---------|---------|
+| `(root)` | GET | Earth-2 status via MAS proxy |
+| `/health` | GET | Service health |
+| `/forecast` | GET, POST | Atlas forecast runs |
+| `/nowcast` | GET | Nowcast |
+| `/nowcast/storms` | GET | Storm nowcast |
+| `/alerts` | GET | Weather alerts |
+| `/models` | GET | Available models |
+| `/layers` | GET | Layer catalog |
+| `/layers/grid` | GET | Grid layer metadata |
+| `/layers/wind` | GET | Wind layer |
+| `/spore-dispersal` | GET, POST | Spore dispersal model |
+| `/tiles/[variable]/[z]/[x]/[y]` | GET | Earth-2 raster tiles |
+
+### Related APIs
+
+| Prefix | Purpose |
+|--------|---------|
+| `/api/mycobrain/*` | Serial gateway, telemetry, buzzer/beep, device control |
+| `/api/worldview/v1/*` | MINDEX Worldview public search/API keys |
+| `/api/stream/crep` | CREP real-time stream |
+| `/api/search/crep` | CREP search integration |
+
+---
+
+## Data sources & external connectors
+
+**Policy:** No mock, fake, or placeholder data in production paths. If an upstream API is unavailable or rate-limited, the UI shows empty states, cached stale data, or explicit error messages.
+
+| Domain | Sources |
+|--------|---------|
+| **Aviation** | OpenSky Network, FlightRadar24 (API key) |
+| **Maritime** | AISstream (API key), fishing registries |
+| **Satellites** | CelesTrak, Space-Track, N2YO (optional key), UCS enrichment, MINDEX ingest |
+| **Biodiversity** | iNaturalist, GBIF, eBird, OBIS, MINDEX nature stream |
+| **Weather & hazards** | NWS, USGS, NASA EONET, SWPC space weather |
+| **Air quality** | OpenAQ, AirNow |
+| **Infrastructure** | OpenStreetMap Overpass, power grid datasets, submarine cable registry, EIA power plants |
+| **Basemap** | ESRI World Imagery, NASA GIBS, Mapbox (token), Google Earth Engine (when configured) |
+| **Fungal** | MINDEX fungal atlas, CREP fungal layers, mycelium probability model |
+| **Devices** | MAS device registry, field agent APIs, MycoBrain gateway |
+| **Earth-2** | MAS Earth-2 orchestration → GPU inference service |
+
+Data is cached server-side (`crep-data-service.ts`, Redis when `REDIS_URL` is set) with stale-while-revalidate patterns to protect upstream rate limits.
+
+---
+
+## Field devices & controls
+
+### Boot-on MycoBrain layers
+
+At refresh, Earth Simulator enables a fixed set of device-related layers (MycoBrain field nodes, SporeBase, Psathyrella, partners, and related markers). Layer IDs are defined in `lib/crep/earth-simulator-boot.ts`.
+
+### Device API merge order
+
+`GET /api/earth-simulator/devices` combines:
+
+1. Known product catalog entries  
+2. Registered field deployments  
+3. MAS device registry heartbeats  
+4. Operator agent health probes (when configured)  
+5. MycoBrain gateway telemetry (when configured)
+
+### Operator controls
+
+Device actuators (buzzer, LEDs, and related MDP commands) are exposed through the MycoBrain control API when a gateway is online. See `lib/devices/operator-commands.ts` in the website repo.
+
+---
+
+## Configuration (high level)
+
+Earth Simulator reads backend URLs and connector credentials from environment variables at build/runtime. **Do not commit secrets or private network addresses to git.**
+
+| Category | Examples (names only) |
+|----------|------------------------|
+| **Platform APIs** | `MAS_API_URL`, `MINDEX_API_URL`, `NEXT_PUBLIC_MAS_API_URL` |
+| **Devices** | `MYCOBRAIN_SERVICE_URL` |
+| **Earth-2** | `EARTH2_API_URL` |
+| **Caching** | `REDIS_URL` |
+| **Basemap** | `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` |
+| **Boot behavior** | `NEXT_PUBLIC_EARTH_SIM_STAGED_BOOT` |
+| **Live feeds (optional)** | `AISSTREAM_API_KEY`, `FLIGHTRADAR24_API_KEY`, `N2YO_API_KEY`, `SPACETRACK_USER`, `SPACETRACK_PASS` |
+
+Mycosoft operators: use the internal environment template and deployment docs — not this public README — for hostnames, ports, and production values.
+
+---
+
+## Local development
+
+```bash
+npm install
+npm run dev:next-only   # full site + Earth Simulator
+# or
+npm run dev:crep        # CREP-focused dev server
+```
+
+Open **http://localhost:3010/natureos/earth-simulator** (default dev port). Point `MAS_API_URL` and `MINDEX_API_URL` at your configured Mycosoft platform endpoints to load live data.
+
+---
+
+## Deployment
+
+Production Earth Simulator ships with the **mycosoft.com** website container. Releases follow Mycosoft’s standard commit → build → deploy → CDN cache purge pipeline. **Internal VM addresses, SSH steps, and container run commands are not documented in this public README.**
+
+Verify after release: [mycosoft.com/natureos/earth-simulator](https://mycosoft.com/natureos/earth-simulator)
+
+---
+
+## Key source files
+
+```
+app/
+├── natureos/earth-simulator/page.tsx      # Canonical page
+├── dashboard/crep/
+│   ├── page.tsx
+│   ├── CREPDashboardClient.tsx            # Main MapLibre + deck.gl client
+│   ├── CREPDashboardLoader.tsx            # Dynamic import, mobile shell
+│   └── photo3d/page.tsx
+├── defense/crep/page.tsx                  # Re-exports loader
+├── apps/earth-simulator/page.tsx          # Redirect → canonical
+└── api/
+    ├── earth-simulator/**/route.ts
+    ├── crep/**/route.ts
+    ├── oei/**/route.ts
+    └── earth2/**/route.ts
+
+lib/
+├── crep/
+│   ├── earth-simulator-boot.ts            # Staged boot ON/OFF layers
+│   ├── crep-data-service.ts               # Unified fetch + cache
+│   ├── data-cache.ts
+│   └── registries/satellite-registry.ts
+├── devices/
+│   ├── field-deployments.ts               # Mushroom1, Hyphae1, Psathyrella
+│   └── operator-commands.ts               # Buzzer/beep, actuator commands
+├── config/api-urls.ts                     # Platform API URL configuration
+└── google-earth-engine.ts                 # GEE proxy helpers
+
+components/crep/
+├── layers/deck-entity-layer.tsx
+├── map-controls.tsx
+├── crep-resource-hints.tsx
+└── mobile/crep-mobile-shell.tsx
+```
+
+---
+
+## Related documentation
+
+| Document | Notes |
+|----------|-------|
+| **[`docs/EARTH_SIMULATOR_TECHNICAL_REFERENCE.md`](../EARTH_SIMULATOR_TECHNICAL_REFERENCE.md)** | **Technical Outline** — engineering capability index (internal; may contain ops detail — review before external release) |
+| [`docs/EARTH_SIMULATOR_DOCS_INDEX.md`](../EARTH_SIMULATOR_DOCS_INDEX.md) | Master index (updated June 2026) |
+| `docs/crep plan.md` | CREP roadmap |
+| `docs/CREP_INFRASTRUCTURE_DEPLOYMENT.md` | Infra deployment |
+| `docs/CREP_API_CACHING_FEB18_2026.md` | Caching strategy |
+| `docs/codex-handoffs/EARTH_SIMULATOR_*_JUN*.md` | Recent implementation handoffs |
+| `docs/reports/earth-field-mycobrain-devices-2026-05-27.md` | Field device audit |
+| MAS `docs/CREP_*` | Collector and voice-control docs |
+
+**In-repo legacy (Cesium era — reference only):**
+
+- `docs/earth-simulator/ARCHITECTURE.md`, `API.md`, `GRID_SYSTEM.md` — January 2026 Cesium docs; superseded by this README
+
+---
+
+## Legacy appendix: Cesium Earth Simulator (deprecated)
+
+| Item | Status |
+|------|--------|
+| Route `/apps/earth-simulator` | Redirects to `/natureos/earth-simulator` (May 21, 2026) |
+| `components/earth-simulator/cesium-globe.tsx` | Unreachable from public routes; candidate for removal |
+| CesiumJS 3D globe | Replaced by **MapLibre GL + deck.gl** CREP stack |
+| Google Earth Engine | Still supported via `/api/earth-simulator/gee/*` as tile/stats proxy |
+| Port `3002` / NatureOS tab embed | Obsolete — use `/natureos/earth-simulator` |
+
+Do not build new features on the Cesium components. All new Earth Simulator work belongs in `app/dashboard/crep/` and `lib/crep/`.
+
+---
+
+## License & attribution
+
+Part of the [Mycosoft](https://mycosoft.com) NatureOS platform. External data sources retain their respective licenses and rate-limit terms; see connector implementations under `lib/oei/` and `app/api/oei/`.


### PR DESCRIPTION
Publishes the redacted public docs to main so the canonical GitHub URLs resolve for sharing on X.

**Files (3):** `docs/EARTH_SIMULATOR_TECHNICAL_REFERENCE.md`, `docs/earth-simulator/README.md`, `docs/EARTH_SIMULATOR_DOCS_INDEX.md`.

**Sanitization (by Cursor, verified by secret-scan here):** private IPs (192.168.x → placeholders), field-device host_ip/agent_url/OpenClaw URLs → env placeholders, internal ports → generic gateway URLs, registry host hints (jetson-*) → generic IDs, dev paths (D:\Users\…) → WEBSITE/website/…, dev keys/localhost defaults removed, LAN topology prose rewritten. Scan for private IPs / dev paths / host hints / internal ports / API keys came back **clean**.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Publish updated public Earth Simulator documentation that reflects the current MapLibre-based CREP implementation while sanitizing internal infrastructure details.

Documentation:
- Replace the Earth Simulator README with a comprehensive public-facing overview that explains the product, audiences, key capabilities, routes, APIs, and high-level architecture without exposing internal infrastructure details.
- Rewrite the Earth Simulator documentation index to prioritize the new README and technical reference, clearly distinguish deprecated Cesium-era docs, and surface recent CREP-related handoffs and references.
- Sanitize and update the technical reference document to remove private network specifics and local paths, replacing them with generic repository and service URL placeholders while preserving its role as a detailed capability index.