### PR TITLE
fix(earth-sim): iPad pan-freeze via native marker _update detach (no blink)

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -21,7 +21,7 @@
 import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, memo, startTransition, type ReactNode, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
-import { Map as MapComponent, MapControls, MapMarker, MarkerContent, MarkerPopup } from "@/components/ui/map";
+import { Map as MapComponent, MapControls, MapMarker, MarkerContent, MarkerPopup, freezeNativeMarkerUpdates, thawNativeMarkerUpdates } from "@/components/ui/map";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -8993,6 +8993,9 @@ export default function CREPDashboardPage({
     const map = mapRef;
     if (!map) return;
     const clearMapInteractionState = (reason: string) => {
+      // Re-attach native marker per-frame _update + snap markers back to their
+      // correct positions once the gesture settles (no-op if not frozen).
+      thawNativeMarkerUpdates(map);
       if (mapInteractionClearTimerRef.current != null) {
         window.clearTimeout(mapInteractionClearTimerRef.current);
         mapInteractionClearTimerRef.current = null;
@@ -9054,6 +9057,16 @@ export default function CREPDashboardPage({
       }
       mapInteractionActiveRef.current = true;
       mapInteractionStartedAtRef.current = Date.now();
+      // iPad/tablet freeze fix: detach native marker per-frame _update (project +
+      // setTransform + occlusion + frameAsync alloc, per marker per frame) so the
+      // map pans at full frame rate. Heavy perf classes only — desktop keeps live
+      // marker tracking during pan. Markers re-attach + snap on clearMapInteractionState.
+      if (
+        (earthStrictPerfMode || isGlobeCrepMapRoute) &&
+        getEarthSimViewportPerfClass() !== "desktop"
+      ) {
+        freezeNativeMarkerUpdates(map);
+      }
       try {
         (window as any).__crep_map_interaction_state = {
           active: true,
@@ -9105,6 +9118,8 @@ export default function CREPDashboardPage({
       /* map can be mid-teardown during hot reload */
     }
     return () => {
+      // Never leave markers detached if this effect re-runs mid-pan.
+      thawNativeMarkerUpdates(map);
       if (mapInteractionClearTimerRef.current != null) {
         window.clearTimeout(mapInteractionClearTimerRef.current);
         mapInteractionClearTimerRef.current = null;
@@ -9127,7 +9142,7 @@ export default function CREPDashboardPage({
       try { map.off?.("pitchend", onMoveEnd); } catch {}
       try { map.off?.("idle", onIdle); } catch {}
     };
-  }, [isGlobeCrepMapRoute, mapRef, requestViewportNatureFetch]);
+  }, [earthStrictPerfMode, isGlobeCrepMapRoute, mapRef, requestViewportNatureFetch]);
 
   useEffect(() => {
     if (!earthStrictPerfMode || !mapRef) return;
@@ -13795,18 +13810,14 @@ export default function CREPDashboardPage({
     return natureObsOn || (mapZoom ?? 0) >= EARTH_SIM_FUNGAL_DOM_MIN_ZOOM;
   }, [earthStrictPerfMode, layers, mapZoom, markerBounds, natureFiltersEnabled, natureSpeciesFiltersActive]);
 
-  // May 23 2026 regression lock (docs/codex-handoffs/2026-05-23-earth-simulator-handoff.md):
-  // kept Event/Nature DOM markers mounted through pan (update positions only) to
-  // avoid blink. That is right on desktop — but on a tablet/phone GPU, MapLibre
-  // re-projects + occlusion-tests (map.tsx Marker._update + setOccludedOpacity)
-  // every mounted DOM marker on EVERY move frame; at the tablet cap (~760) that
-  // starves the main thread and FREEZES the iPad on pan. CSS hiding doesn't help
-  // (the project() cost is JS, independent of display). So on non-desktop only,
-  // unmount the regular DOM markers during the pan/zoom gesture (the selected
-  // marker stays via the fallback below; a brief blink beats a frozen map) and
-  // remount on settle. Desktop keeps the no-blink behavior. (Jun 13, 2026 — iPad
-  // freeze P0 from live QA.)
-  const shouldRenderDomMarkers = !(isMapAnimationActive && earthSimViewportPerfClass !== "desktop");
+  // May 23 2026 regression lock: keep Event/Nature DOM markers MOUNTED through
+  // pan (update positions only) — never unmount (that caused a blink + portal
+  // churn). The iPad pan-freeze is instead handled WITHOUT unmounting by
+  // freezeNativeMarkerUpdates() (components/ui/map.tsx): on move-start for
+  // non-desktop perf classes it detaches each marker's per-frame _update
+  // (project + setTransform + occlusion + frameAsync) so the canvas pans at full
+  // frame rate, then re-attaches + snaps them back on settle. No blink.
+  const shouldRenderDomMarkers = true;
   const shouldRenderDeviceDomMarkers = !auditAllOffMode && !isEmbeddedEarthquakeSearch && !assetIsolationMode;
   const shouldRenderHeavyOverlays =
     !earthStrictPerfMode || (earthSimDeferredDataReady && !isMapAnimationActive);

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,6 +197,15 @@ body {
   overflow: hidden;
 }
 
+/* iPad / tablet pan-freeze: while a gesture is active the markers' per-frame
+   _update is detached (see freezeNativeMarkerUpdates in components/ui/map.tsx),
+   so they would otherwise sit frozen at their last screen position. Hide them
+   during the pan; they are re-projected and revealed on gesture settle.
+   Toggled on the map container only on heavy perf classes. */
+.crep-pan-hide-markers .maplibregl-marker {
+  visibility: hidden;
+}
+
 /* MapLibre control styling */
 .maplibregl-ctrl-group {
   background: var(--color-background) !important;

--- a/components/ui/map.tsx
+++ b/components/ui/map.tsx
@@ -738,6 +738,10 @@ function MapMarker({
       // off the map during pan/zoom because project() coords ≠ canvas transforms.
       marker.addTo(map);
       added = true;
+      // Track this marker so pan-freeze can detach its per-frame _update during
+      // gestures (see freezeNativeMarkerUpdates). If a pan is already frozen, the
+      // marker is detached immediately inside registerPanMarker.
+      registerPanMarker(map, marker);
       try {
         const element = marker.getElement?.();
         if (element) {
@@ -789,6 +793,9 @@ function MapMarker({
 
     return () => {
       if (!added) return;
+      // Drop from the pan-freeze registry synchronously so a thaw firing in the
+      // 96ms removal window never re-attaches `move` to a marker being removed.
+      unregisterPanMarker(map, marker);
       if (typeof window !== "undefined") {
         const debug = ((window as any).__map_marker_debug ||= {
           addToCalls: 0,
@@ -2388,6 +2395,166 @@ function MapClusterLayer<
   return null;
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+ * Tablet / iPad pan-freeze for native DOM markers
+ *
+ * Root cause (verified against maplibre-gl 5.x): every Marker subscribes to the
+ * map's `move` event in addTo() (`map.on('move', this._update)`). During a pan
+ * the map fires `move` continuously, so for EACH mounted marker `_update` runs
+ * every frame:
+ *   - map.project(lngLat)                          (globe matrix projection)
+ *   - DOM.setTransform(element, ...)               (style write per marker)
+ *   - browser.frameAsync(new AbortController())    (Promise + RAF alloc/marker)
+ *       .then(() => _updateOpacity())
+ *         -> transform.isLocationOccluded(lngLat)  (globe occlusion test)
+ *
+ * With ~760 markers at the tablet cap that is ~760 projections + style writes +
+ * AbortController/Promise/RAF allocations + occlusion tests PER FRAME — which is
+ * what freezes the iPad. None of it is gated by the element's CSS `display`, so
+ * hiding markers via CSS removes paint but leaves 100% of the per-frame JS.
+ *
+ * Fix: during a pan, detach each marker's `_update` from the map's `move` event
+ * so zero per-frame marker JS runs and the map canvas pans at full frame rate.
+ * Each marker's `moveend` subscription is left intact (and we also call _update()
+ * on thaw) so markers snap back to their correct geographic position when the
+ * gesture settles. This is the surgical equivalent of marker.remove()/re-add
+ * around the pan, but without detaching the DOM element or tearing down the
+ * React portal. A container class hides the (briefly static) markers during the
+ * pan so they are not seen frozen at their last screen position.
+ *
+ * Engaged only on heavy (phone/tablet) perf classes by the caller — desktop
+ * keeps live marker tracking during pan.
+ * ────────────────────────────────────────────────────────────────────────── */
+type PanFreezableMap = MapLibreGL.Map & {
+  __crepPanMarkerRegistry?: Set<MapLibreGL.Marker>;
+  __crepPanFrozen?: boolean;
+};
+
+function getPanMarkerRegistry(map: PanFreezableMap): Set<MapLibreGL.Marker> {
+  if (!map.__crepPanMarkerRegistry) map.__crepPanMarkerRegistry = new Set();
+  return map.__crepPanMarkerRegistry;
+}
+
+function registerPanMarker(
+  map: MapLibreGL.Map | null,
+  marker: MapLibreGL.Marker,
+): void {
+  if (!map) return;
+  const panMap = map as PanFreezableMap;
+  try {
+    getPanMarkerRegistry(panMap).add(marker);
+    // If a pan is already frozen when this marker mounts, immediately detach its
+    // per-frame _update so a marker added mid-pan does not reintroduce the cost.
+    if (panMap.__crepPanFrozen) {
+      const update = (marker as any)._update;
+      if (typeof update === "function") panMap.off("move", update);
+    }
+  } catch {
+    /* registry is a best-effort perf optimization */
+  }
+}
+
+function unregisterPanMarker(
+  map: MapLibreGL.Map | null,
+  marker: MapLibreGL.Marker,
+): void {
+  if (!map) return;
+  try {
+    (map as PanFreezableMap).__crepPanMarkerRegistry?.delete(marker);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Detach every registered marker's per-frame `_update` from the map's `move`
+ * event for the duration of a pan/zoom gesture. Idempotent. Returns the number
+ * of markers frozen. Engage only on heavy perf classes (phone/tablet).
+ */
+function freezeNativeMarkerUpdates(map: MapLibreGL.Map | null): number {
+  const panMap = map as PanFreezableMap | null;
+  if (!panMap || panMap.__crepPanFrozen) return 0;
+  panMap.__crepPanFrozen = true;
+  let frozen = 0;
+  try {
+    panMap.__crepPanMarkerRegistry?.forEach((marker) => {
+      try {
+        const update = (marker as any)._update;
+        if (typeof update === "function") {
+          panMap.off("move", update);
+          frozen += 1;
+        }
+      } catch {
+        /* per-marker best effort */
+      }
+    });
+  } catch {
+    /* ignore */
+  }
+  // Cosmetic: hide the now-static markers so they are not seen frozen at their
+  // last screen position while the map pans underneath them.
+  try {
+    panMap.getContainer?.()?.classList.add("crep-pan-hide-markers");
+  } catch {
+    /* ignore */
+  }
+  try {
+    (window as any).__crep_pan_marker_freeze = {
+      active: true,
+      frozen,
+      at: Date.now(),
+    };
+  } catch {
+    /* debug hook only */
+  }
+  return frozen;
+}
+
+/**
+ * Re-attach every registered marker's `_update` to the map's `move` event and
+ * snap each marker to its correct geographic position. Idempotent. Returns the
+ * number of markers thawed. Always safe to call — no-op when not frozen.
+ */
+function thawNativeMarkerUpdates(map: MapLibreGL.Map | null): number {
+  const panMap = map as PanFreezableMap | null;
+  if (!panMap || !panMap.__crepPanFrozen) return 0;
+  panMap.__crepPanFrozen = false;
+  let thawed = 0;
+  try {
+    panMap.__crepPanMarkerRegistry?.forEach((marker) => {
+      try {
+        const update = (marker as any)._update;
+        if (typeof update === "function") {
+          panMap.off("move", update); // guard against double-subscribe
+          panMap.on("move", update);
+          update(); // snap to correct geo position (still hidden by the class)
+          thawed += 1;
+        }
+      } catch {
+        /* per-marker best effort */
+      }
+    });
+  } catch {
+    /* ignore */
+  }
+  // Reveal markers only AFTER positions are corrected, so there is no visible jump.
+  try {
+    panMap.getContainer?.()?.classList.remove("crep-pan-hide-markers");
+  } catch {
+    /* ignore */
+  }
+  try {
+    (window as any).__crep_pan_marker_freeze = {
+      active: false,
+      frozen: thawed,
+      at: Date.now(),
+    };
+  } catch {
+    /* debug hook only */
+  }
+  return thawed;
+}
+
 export {
   Map,
   useMap,
@@ -2400,6 +2567,8 @@ export {
   MapControls,
   MapRoute,
   MapClusterLayer,
+  freezeNativeMarkerUpdates,
+  thawNativeMarkerUpdates,
 };
 
 export type { MapRef };


### PR DESCRIPTION
Supersedes the unmount-on-pan freeze fix from #198 with Cursor's better approach.

## Root cause
Every MapLibre `Marker` subscribes to `map.on('move', this._update)`. During a pan the map fires `move` continuously, so for **each** mounted marker `_update` runs every frame: `map.project()` (globe matrix) + `setTransform` + an `AbortController`/Promise/RAF alloc + an occlusion test. At the tablet DOM-marker cap (~760) that's ~760 projections + occlusion tests **per frame** → iPad freeze. None of it is gated by CSS `display`, so hiding markers doesn't help.

## Fix
On move-start (non-desktop perf classes only), **detach each marker's `_update` from the map's `move` event** so zero per-frame marker JS runs and the canvas pans at full frame rate. Markers stay mounted (no React portal teardown), are hidden via `.crep-pan-hide-markers` (`visibility:hidden`) during the gesture, and re-attach + `_update()`-snap back on settle. **No blink.**

- `components/ui/map.tsx`: marker registry + `freezeNativeMarkerUpdates`/`thawNativeMarkerUpdates`
- `app/dashboard/crep/CREPDashboardClient.tsx`: freeze on move-start / thaw on settle + cleanup; **reverts #198's `shouldRenderDomMarkers` unmount back to always-true**
- `app/globals.css`: `.crep-pan-hide-markers` hide rule

Desktop is unchanged (live marker tracking through pan). Co-authored with Cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent iPad/tablet map panning freezes by temporarily detaching native MapLibre marker updates during gestures while keeping markers mounted and restoring them on gesture end.

New Features:
- Add a pan marker registry and freeze/thaw APIs to control native MapLibre marker _update subscriptions during map gestures.
- Introduce a CSS class to hide markers visually while their per-frame updates are detached during a pan.

Bug Fixes:
- Fix Earth Simulator iPad/tablet pan-induced freezes caused by per-frame native marker updates across many DOM markers.

Enhancements:
- Always keep DOM markers mounted during pans to avoid blink while still optimizing performance via marker update freezing.
- Ensure new and removed markers correctly register/unregister with the pan-freeze system to avoid stale subscriptions and reattachment issues.
- Extend CREP dashboard map interaction handling to coordinate freeze/thaw of native marker updates based on device performance class.