### PR TITLE
feat(aircraft): wire OpenSky OAuth2 (graceful, creds-later)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,13 @@ AZURE_MAPS_KEY=
 # External Data APIs
 # -----------------------------------------------------------------------------
 AISSTREAM_API_KEY=
+# OpenSky OAuth2 client-credentials (free account at opensky-network.org).
+# Restores the broad ~6500-aircraft global feed; without these, aircraft fall
+# back to the small adsb.lol free sample (~290 globally).
+OPENSKY_CLIENT_ID=
+OPENSKY_CLIENT_SECRET=
+# Optional: ADS-B Exchange (RapidAPI) for additional aircraft coverage.
+ADSBX_API_KEY=
 EBIRD_API_KEY=
 NEXT_PUBLIC_NEWS_API_KEY=
 NEXT_PUBLIC_TMDB_API_KEY=

--- a/lib/crep/registries/aircraft-registry.ts
+++ b/lib/crep/registries/aircraft-registry.ts
@@ -58,6 +58,12 @@ const MINDEX_API_KEY = process.env.MINDEX_API_KEY || "local-dev-key"
 
 const ADSBX_API_KEY = process.env.ADSBX_API_KEY || ""
 
+// OpenSky moved to OAuth2 client-credentials; anonymous /states/all is now
+// heavily rate-limited (often returns nothing). Set both to restore the broad
+// ~6500-aircraft global feed (incl. regions adsb.lol's free sample misses).
+const OPENSKY_CLIENT_ID = process.env.OPENSKY_CLIENT_ID || ""
+const OPENSKY_CLIENT_SECRET = process.env.OPENSKY_CLIENT_SECRET || ""
+
 const configuredMovingSourceTimeout = Number(process.env.CREP_MOVING_SOURCE_TIMEOUT_MS)
 const SOURCE_TIMEOUT_MS =
   Number.isFinite(configuredMovingSourceTimeout) && configuredMovingSourceTimeout > 0
@@ -108,16 +114,51 @@ async function fetchFromMINDEX(): Promise<AircraftRecord[]> {
   return entities.map((a) => normaliseGeneric(a, "mindex"))
 }
 
+// OpenSky OAuth2 client-credentials token, cached until just before expiry
+// (~30 min). Returns null when no credentials are configured, in which case
+// fetchFromOpenSky falls back to (rate-limited) anonymous access unchanged.
+let openSkyToken: { value: string; expiresAt: number } | null = null
+async function getOpenSkyToken(): Promise<string | null> {
+  if (!OPENSKY_CLIENT_ID || !OPENSKY_CLIENT_SECRET) return null
+  const now = Date.now()
+  if (openSkyToken && now < openSkyToken.expiresAt) return openSkyToken.value
+  try {
+    const res = await fetch(
+      "https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: OPENSKY_CLIENT_ID,
+          client_secret: OPENSKY_CLIENT_SECRET,
+        }),
+        signal: AbortSignal.timeout(8_000),
+      },
+    )
+    if (!res.ok) return null
+    const data = (await res.json()) as { access_token?: string; expires_in?: number }
+    if (!data?.access_token) return null
+    const ttlSec = Number(data.expires_in) || 1800
+    openSkyToken = { value: data.access_token, expiresAt: now + (ttlSec - 60) * 1000 }
+    return data.access_token
+  } catch {
+    return null
+  }
+}
+
 /**
- * Source 3 — OpenSky Network (free, no key, 10 s cache)
+ * Source 3 — OpenSky Network
  *
- * Returns all aircraft with active transponders worldwide.
- * Free tier: ~1 req/10 s, ~6000-10000 aircraft per response.
+ * Returns all aircraft with active transponders worldwide (~6000-10000).
+ * Authenticated via OAuth2 client-credentials when OPENSKY_CLIENT_ID/SECRET are
+ * set — anonymous access is now heavily rate-limited and often returns nothing.
  *
  * Response shape: { time: number, states: [icao24, callsign, origin_country, ...] }
  */
 async function fetchFromOpenSky(): Promise<AircraftRecord[]> {
   const url = "https://opensky-network.org/api/states/all"
+  const token = await getOpenSkyToken()
   // OpenSky payload is ~2-4MB globally, can take 5-12s. Use a longer timeout
   // specifically for this source since it's our largest single-source returns
   // (~6500 global aircraft vs FR24's ~1500).
@@ -129,6 +170,9 @@ async function fetchFromOpenSky(): Promise<AircraftRecord[]> {
       // Some upstream CDNs block default Node fetch UA with 403. Identify
       // ourselves so OpenSky doesn't rate-limit us as a scraper.
       "User-Agent": "Mycosoft-CREP/1.0 (+https://mycosoft.com)",
+      // OAuth2 bearer when credentials are configured (raises the rate limit
+      // from near-zero anonymous to the authenticated tier).
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
   })
   if (!res.ok) return []


### PR DESCRIPTION
Live QA of the aircraft feed found **4 of 5 sources returning 0** — `flightradar24:0, opensky:0, adsbexchange:0, mindex:0, adsb.lol:291` — so aircraft are sparse everywhere (~290 globally), not just the Gulf.

The big recoverable one is **OpenSky** (~6,500 aircraft globally). Its connector used anonymous `/states/all`, which OpenSky now rate-limits to near-zero after moving to OAuth2 client-credentials.

## Change
- Adds `OPENSKY_CLIENT_ID`/`OPENSKY_CLIENT_SECRET` (free account at opensky-network.org).
- `getOpenSkyToken()` fetches + caches a client-credentials bearer token (~30 min TTL).
- `fetchFromOpenSky` sends `Authorization: Bearer` **when creds are set** → authenticated tier → broad global feed incl. the Persian Gulf.
- **Graceful:** with no creds, returns null and falls back to anonymous access exactly as today — zero behavior change until you provision credentials.
- Documents `OPENSKY_CLIENT_*` + optional `ADSBX_API_KEY` in `.env.example`.

**To activate:** create a free OpenSky account → API client → set the two env vars in prod. No code change needed after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable authenticated OpenSky aircraft feed using OAuth2 client-credentials while preserving existing anonymous fallback behavior.

Enhancements:
- Add support for OpenSky OAuth2 client-credentials with cached bearer tokens and use them in the aircraft registry when configured.

Documentation:
- Document optional OpenSky OAuth2 client credentials and ADSBX API key configuration in the environment example file.