### PR TITLE
fix(aisstream): self-healing reconnect (live vessel feed never dies permanently)

### DIFF
--- a/app/api/oei/aisstream/route.ts
+++ b/app/api/oei/aisstream/route.ts
@@ -84,6 +84,12 @@ function ensureAISStream(): void {
   aisState.streamCleanup = client.connectRealtime(
     { north: 90, south: -90, east: 180, west: -180 },
     (_vessel) => {
+      // Live data is flowing — clear the failure counter + backoff so a stream
+      // that recovers doesn't carry a stale count toward the stop threshold.
+      if (aisState.reconnectAttempts !== 0) {
+        aisState.reconnectAttempts = 0
+        aisState.reconnectDelay = RECONNECT_BASE_MS
+      }
       // Vessel is automatically added to the client's internal cache
     },
     (err) => {
@@ -92,8 +98,18 @@ function ensureAISStream(): void {
       aisState.reconnectAttempts++
 
       if (aisState.reconnectAttempts >= MAX_RETRIES) {
-        console.warn(`[AISStream] Stopped after ${MAX_RETRIES} failures. Service may be down.`)
-        return // Stop retrying — no more log spam
+        // Don't die permanently: after the fast-retry budget is spent, fall back
+        // to a slow keepalive at the max delay so a prolonged AISstream outage
+        // self-heals instead of serving only the stale disk cache until the
+        // process restarts. Reset the counter so the keepalive gets a fresh
+        // fast-retry budget each cycle. (Jun 14, 2026 — live feed stuck at 0.)
+        console.warn(`[AISStream] ${MAX_RETRIES} fast retries exhausted — slow keepalive every ${MAX_RECONNECT_MS / 1000}s`)
+        setTimeout(() => {
+          aisState.reconnectAttempts = 0
+          aisState.reconnectDelay = RECONNECT_BASE_MS
+          ensureAISStream()
+        }, MAX_RECONNECT_MS)
+        return
       }
 
       aisState.reconnectDelay = Math.min(aisState.reconnectDelay * 2, MAX_RECONNECT_MS)


### PR DESCRIPTION
Local live-data QA found the AIS feed serving only the **15k-vessel disk cache** (`aisstream:0`) — no live updates.

**Root cause:** after `MAX_RETRIES` (5) the error handler `return`ed without scheduling any retry, so a prolonged AISstream outage left the stream dead until the process restarted.

**Fix:**
1. A successful vessel message **resets** the failure counter + backoff (a recovered stream no longer carries a stale count toward the stop threshold).
2. When the fast-retry budget is exhausted, fall back to a **slow keepalive** at `MAX_RECONNECT_MS` (5 min) that resets the budget and reconnects — the stream self-heals instead of dying.

Note: local specifically shows `aisstream:0` because AISstream allows **1 connection per key** and prod holds it; live local vessels need a separate dev key. Vessels still render meanwhile (disk cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure the AIS live vessel feed automatically recovers from prolonged upstream outages instead of remaining stuck on the disk cache.

Bug Fixes:
- Reset AIS reconnect counters on successful vessel messages so a recovered stream no longer carries stale failures toward the retry stop threshold.
- Replace the terminal stop-after-max-retries behavior with a slow keepalive reconnect loop to restore the AIS stream after extended outages.