### PR TITLE
feat(earth-sim): elevated 3D satellites + orbit rings (deck overlay, desktop)

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -339,6 +339,8 @@ import { MAJOR_PORTS, MAJOR_DATACENTERS } from "@/lib/crep/static-infra";
 import { usePowerPlantLayers, type PlantStats, type PowerPlant } from "@/components/crep/layers/power-plant-bubbles";
 import type { Datacenter } from "@/components/crep/layers/datacenter-diamonds";
 import { ScatterplotLayer as InfraScatterplotLayer, PathLayer as InfraPathLayer } from "@deck.gl/layers";
+import { IconLayer as SatIconLayer } from "@deck.gl/layers";
+import { MapboxOverlay as SatMapboxOverlay } from "@deck.gl/mapbox";
 import { PlantPopup } from "@/components/crep/popups/plant-popup";
 import { InfraDetailWidget, type InfraAsset, type InfraAssetType } from "@/components/crep/popups/infra-detail-widget";
 import { UnifiedSearch, type SearchResult } from "@/components/crep/search/unified-search";
@@ -16534,8 +16536,11 @@ export default function CREPDashboardPage({
     }));
 
     if (!isSatelliteAnimationRunning()) {
-      // First start â€” launch the animation loop
-      startSatelliteAnimation(map, satInputs);
+      // First start â€” launch the animation loop. Orbit rings (computeOrbitPaths)
+      // only on desktop, where the elevated-satellite deck overlay renders them.
+      startSatelliteAnimation(map, satInputs, {
+        computeOrbitPaths: earthSimViewportPerfClass === "desktop",
+      });
     } else {
       // Already running â€” just update the satellite set (adds new ones)
       updateSatelliteAnimation(satInputs);
@@ -16548,6 +16553,125 @@ export default function CREPDashboardPage({
       stopSatelliteAnimation();
     };
   }, []);
+
+  // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
+  // ELEVATED 3D SATELLITES (Step 2) â€” desktop + globe only.
+  // Native crep-live-satellites layers are surface-clamped (can't elevate). A
+  // dedicated deck.gl overlay reads the SAME SGP4-populated source and floats the
+  // satellite icons + their orbit rings to (exaggerated) orbital altitude so they
+  // read as "in the atmosphere at an angle" on the tilted globe. deck.gl honours
+  // the 3rd (Z) coordinate as radial elevation on the MapLibre globe. The native
+  // flat layers are hidden ONLY while the overlay has data (so satellites never
+  // vanish), and restored on teardown â€” tablet/phone/flat-map are untouched.
+  // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
+  useEffect(() => {
+    if (!isEarthSimulatorRoute) return;
+    if (earthSimViewportPerfClass !== "desktop") return;
+    if (projectionMode !== "globe") return;
+    const map = mapNativeRef.current as any;
+    if (!map || typeof map.getSource !== "function") return;
+
+    const EARTH_R_M = 6_371_000;
+    // Exaggerate altitude: true 400km LEO is only ~6% of Earth's radius, too flat
+    // to read. EXAG=6 makes LEO clearly hover; clamp so GEO (~35,786km) doesn't
+    // shoot far off-screen.
+    const EXAG = 6;
+    const visualZ = (altMeters: number) =>
+      Math.min((Number(altMeters) || 0) * EXAG, EARTH_R_M * 1.5);
+    const tierColor = (altKm: number): [number, number, number, number] =>
+      altKm >= 20000 ? [251, 191, 36, 255] : altKm >= 2000 ? [168, 85, 247, 255] : [34, 211, 238, 255];
+
+    const satFeatures = () => ((map.getSource("crep-live-satellites") as any)?._data?.features ?? []) as any[];
+    const orbitFeatures = () => ((map.getSource("crep-live-satellite-orbits") as any)?._data?.features ?? []) as any[];
+    const setNativeVisible = (vis: "visible" | "none") => {
+      for (const id of ["crep-live-satellites-dot", "crep-live-satellites-glow", "crep-live-satellite-orbits-line"]) {
+        try { if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", vis); } catch {}
+      }
+    };
+    const buildLayers = () => {
+      const sats = satFeatures();
+      const orbits = orbitFeatures();
+      // Hide native flat satellites ONLY when the overlay actually has data to
+      // render (so a transient empty source never leaves the globe blank).
+      setNativeVisible(sats.length > 0 ? "none" : "visible");
+      const posOf = (f: any) => {
+        const c = f.geometry?.coordinates ?? [0, 0, 0];
+        return [c[0], c[1], visualZ(c[2] ?? 0)] as [number, number, number];
+      };
+      return [
+        new InfraPathLayer({
+          id: "crep-sat-elev-orbits", data: orbits,
+          getPath: (f: any) => (f.geometry?.coordinates ?? []).map((c: any[]) => [c[0], c[1], visualZ(c[2])]),
+          getColor: [192, 132, 252, 90], getWidth: 1, widthUnits: "pixels", widthMinPixels: 1,
+          parameters: { depthTest: false }, pickable: false,
+        } as any),
+        // Guaranteed-render elevated dot (base): satellites never vanish even if
+        // the icon sprite fails to load.
+        new InfraScatterplotLayer({
+          id: "crep-sat-elev-dots", data: sats, getPosition: posOf,
+          getRadius: 4, radiusUnits: "pixels", radiusMinPixels: 3, radiusMaxPixels: 14,
+          getFillColor: (f: any) => tierColor(Number(f.properties?.altitude_km) || 0),
+          getLineColor: [255, 255, 255, 220], lineWidthMinPixels: 1, stroked: true,
+          parameters: { depthTest: false }, pickable: false,
+        } as any),
+        // The satellite SPRITE (icons, not dots â€” to match planes/boats),
+        // billboarded at altitude on top of the dot.
+        new SatIconLayer({
+          id: "crep-sat-elev-icons", data: sats, getPosition: posOf,
+          getIcon: () => ({ url: "/crep/icons/satellite.svg", width: 64, height: 64, anchorX: 32, anchorY: 32, mask: false }),
+          getSize: 26, sizeUnits: "pixels", billboard: true,
+          parameters: { depthTest: false }, pickable: false,
+        } as any),
+      ];
+    };
+
+    let overlay: any = null;
+    let disposed = false;
+    let rebuildQueued = false;
+    try {
+      overlay = new SatMapboxOverlay({ interleaved: false, layers: buildLayers() });
+      map.addControl(overlay as any);
+      const rebuild = () => {
+        rebuildQueued = false;
+        if (disposed || !overlay) return;
+        try { overlay.setProps({ layers: buildLayers() }); } catch {}
+      };
+      const onData = (e: any) => {
+        if (e?.sourceId === "crep-live-satellites" || e?.sourceId === "crep-live-satellite-orbits") {
+          if (!rebuildQueued) { rebuildQueued = true; requestAnimationFrame(rebuild); }
+        }
+      };
+      map.on("data", onData);
+      // QA probe (no screenshots needed): __crep_deckSat.probe() returns the
+      // screen-Y delta between a ground point and the same point at LEO altitude.
+      // A clearly negative deltaY (elevated point higher on screen) under a tilted
+      // camera proves the overlay floats above the surface; ~0 means Z is ignored.
+      (window as any).__crep_deckSat = {
+        overlay, visualZ, sampleCount: () => satFeatures().length,
+        probe: (lng = 0, lat = 0) => {
+          try {
+            const vp = overlay?._deck?.getViewports?.()?.[0];
+            if (!vp) return { error: "no viewport" };
+            const g = vp.project([lng, lat, 0]); const h = vp.project([lng, lat, visualZ(800_000)]);
+            return { groundY: g?.[1], highY: h?.[1], deltaY: (h?.[1] ?? 0) - (g?.[1] ?? 0), sats: satFeatures().length };
+          } catch (err) { return { error: String((err as any)?.message || err) }; }
+        },
+      };
+      return () => {
+        disposed = true;
+        try { map.off("data", onData); } catch {}
+        try { setNativeVisible("visible"); } catch {}
+        try { if (overlay) map.removeControl(overlay); } catch {}
+        overlay = null;
+        try { delete (window as any).__crep_deckSat; } catch {}
+      };
+    } catch {
+      // Overlay failed â€” restore the native flat satellites so nothing is lost.
+      try { setNativeVisible("visible"); } catch {}
+      try { if (overlay) map.removeControl(overlay); } catch {}
+      return;
+    }
+  }, [isEarthSimulatorRoute, earthSimViewportPerfClass, projectionMode, mapRef]);
 
   useEffect(() => {
     if (auditAllOffMode || assetIsolationMode || isEarthSimulatorRoute || isSearchEmbedded || !isStreaming || !embeddedAllowsLiveEntityStream) {

--- a/lib/crep/satellite-animation.ts
+++ b/lib/crep/satellite-animation.ts
@@ -51,6 +51,11 @@ const MAX_ORBIT_PATHS = 200
 let animationFrameId: number | null = null
 let mapRef: any = null
 let propagator: SGP4Propagator | null = null
+// Dedicated main-thread propagator for orbit-path rings. The SGP4 worker only
+// returns positions, so when orbit rings are enabled (desktop) we load the
+// top-N satellites here and compute their tracks on the main thread every 60s.
+let orbitPropagator: SGP4Propagator | null = null
+let computeOrbitPaths = false
 let lastTickTime = 0
 let lastOrbitPathTime = 0
 let running = false
@@ -82,7 +87,10 @@ function positionsToFeatureCollection(positions: SatellitePosition[]) {
       },
       geometry: {
         type: "Point" as const,
-        coordinates: [p.lng, p.lat],
+        // 3rd coord = altitude in METERS. Native MapLibre circle/symbol layers
+        // ignore it (they clamp to the surface), but the elevated-satellite deck
+        // overlay reads it to float the icon at orbital altitude on the globe.
+        coordinates: [p.lng, p.lat, Math.round(p.altitude_km) * 1000],
       },
     })),
   }
@@ -94,7 +102,7 @@ function positionsToFeatureCollection(positions: SatellitePosition[]) {
  * across the map when orbits cross from 180 to -180.
  */
 function orbitPathsToFeatureCollection(
-  paths: Array<{ id: string; path: [number, number][] }>
+  paths: Array<{ id: string; path: [number, number, number][] }>
 ) {
   const features: any[] = []
 
@@ -102,7 +110,7 @@ function orbitPathsToFeatureCollection(
     if (!path || path.length < 2) continue
 
     // Split at antimeridian crossings
-    const segments: [number, number][][] = [[]]
+    const segments: [number, number, number][][] = [[]]
     for (let i = 0; i < path.length; i++) {
       const current = path[i]
       segments[segments.length - 1].push(current)
@@ -125,7 +133,10 @@ function orbitPathsToFeatureCollection(
         properties: { id, type: "orbit-path" },
         geometry: {
           type: "LineString",
-          coordinates: segment,
+          // [lng, lat, altitude_m] — altitude in METERS so the deck overlay can
+          // lift the ring to the same height as the dot (native line layer
+          // ignores the 3rd coord and draws the ground track).
+          coordinates: segment.map((p) => [p[0], p[1], (p[2] || 0) * 1000]),
         },
       })
     }
@@ -191,12 +202,16 @@ function tick(timestamp: number) {
     if (satSource?.setData) {
       satSource.setData(positionsToFeatureCollection(positions))
     }
-    // Orbit paths (only when using main-thread propagator — worker doesn't
-    // compute orbit tracks yet; they're recomputed every 60s on main thread
-    // anyway so they don't block the render tick.)
-    if (timestamp - lastOrbitPathTime > ORBIT_PATH_INTERVAL_MS) {
+  }
+
+  // Orbit rings (desktop only — gated by computeOrbitPaths). Recomputed every
+  // 60s so they never block the render tick. Worker mode uses the dedicated
+  // top-N orbitPropagator; fallback mode reuses the full main-thread propagator.
+  if (computeOrbitPaths && timestamp - lastOrbitPathTime > ORBIT_PATH_INTERVAL_MS) {
+    const orbitProp = useWorker ? orbitPropagator : propagator
+    if (orbitProp && orbitProp.size > 0) {
       lastOrbitPathTime = timestamp
-      updateOrbitPaths(prop, now, map)
+      updateOrbitPaths(orbitProp, now, map)
     }
   }
 
@@ -211,7 +226,7 @@ function updateOrbitPaths(prop: SGP4Propagator, now: Date, map: any) {
 
   // Only compute paths for a subset to avoid excessive computation
   const satellitesToPath = currentSatellites.slice(0, MAX_ORBIT_PATHS)
-  const paths: Array<{ id: string; path: [number, number][] }> = []
+  const paths: Array<{ id: string; path: [number, number, number][] }> = []
 
   for (const sat of satellitesToPath) {
     const path = prop.propagateOrbitPath(
@@ -239,13 +254,15 @@ function updateOrbitPaths(prop: SGP4Propagator, now: Date, map: any) {
  */
 export function startSatelliteAnimation(
   map: any,
-  satellites: SatelliteInput[]
+  satellites: SatelliteInput[],
+  options?: { computeOrbitPaths?: boolean }
 ): void {
   // Stop any existing animation first
   stopSatelliteAnimation()
 
   mapRef = map
   currentSatellites = satellites
+  computeOrbitPaths = options?.computeOrbitPaths ?? false
 
   // Fix E (Apr 18, 2026): try the Web Worker first. If it's supported we
   // hand the TLEs to the worker and SGP4 math runs off the main thread.
@@ -283,6 +300,14 @@ export function startSatelliteAnimation(
     )
   }
 
+  // Orbit rings in worker mode: the worker returns positions only, so load the
+  // top-N into a main-thread propagator to compute their tracks. (Fallback mode
+  // already has a full main-thread propagator and reuses it.)
+  if (computeOrbitPaths && useWorker) {
+    orbitPropagator = new SGP4Propagator()
+    orbitPropagator.loadSatellites(satellites.slice(0, MAX_ORBIT_PATHS))
+  }
+
   running = true
   lastTickTime = 0
   lastOrbitPathTime = 0
@@ -301,6 +326,9 @@ export function stopSatelliteAnimation(): void {
   }
   propagator?.clear()
   propagator = null
+  orbitPropagator?.clear()
+  orbitPropagator = null
+  computeOrbitPaths = false
   if (worker) {
     try { worker.clear() } catch {}
     // Don't terminate — keep singleton for next start
@@ -318,6 +346,9 @@ export function stopSatelliteAnimation(): void {
  */
 export function updateSatelliteAnimation(satellites: SatelliteInput[]): void {
   currentSatellites = satellites
+  if (computeOrbitPaths && orbitPropagator) {
+    orbitPropagator.loadSatellites(satellites.slice(0, MAX_ORBIT_PATHS))
+  }
   if (useWorker && worker) {
     const tles: WorkerSatInput[] = satellites
       .map((s) => {

--- a/lib/crep/sgp4-propagator.ts
+++ b/lib/crep/sgp4-propagator.ts
@@ -299,11 +299,13 @@ export class SGP4Propagator {
     startDate: Date,
     minutes = 90,
     stepMinutes = 1
-  ): [number, number][] | null {
+  ): [number, number, number][] | null {
     const satrec = this.satrecCache.get(id)
     if (!satrec) return null
 
-    const points: [number, number][] = []
+    // [lng, lat, altitude_km] — the altitude is carried so the orbit ring can be
+    // elevated to the same height as the satellite dot in the 3D globe overlay.
+    const points: [number, number, number][] = []
     const steps = Math.ceil(minutes / stepMinutes)
 
     for (let i = 0; i <= steps; i++) {
@@ -319,7 +321,7 @@ export class SGP4Propagator {
         const lng = satellite.radiansToDegrees(geo.longitude)
 
         if (Number.isFinite(lat) && Number.isFinite(lng)) {
-          points.push([lng, lat])
+          points.push([lng, lat, Number.isFinite(geo.height) ? geo.height : 0])
         }
       } catch {
         // Skip invalid points


### PR DESCRIPTION
Step 2 of the satellite-altitude work (Step 1 = render satellites on desktop, #198).

Native MapLibre circle/symbol layers are surface-clamped and cannot elevate, so a dedicated **deck.gl MapboxOverlay** reads the SAME SGP4-populated source and floats the satellite **icons (sprite, not dots)** + their **orbit rings** to exaggerated orbital altitude on the globe. Tier-coloured by orbit class (LEO cyan / MEO purple / GEO amber).

**Foundation:** `propagateOrbitPath` returns `[lng,lat,altKm]`; altitude (meters) threaded into position + orbit GeoJSON (native layers ignore the 3rd coord); orbit rings now generated on the **default worker path** via a top-N `orbitPropagator`, gated by a new `computeOrbitPaths` option (desktop only).

**Safety / graceful degradation:**
- desktop + globe + earth-sim **only** — tablet/phone/flat-map untouched
- native flat layers hidden **only while the overlay has data** → satellites never vanish
- a ScatterplotLayer dot renders under the icon → a sprite-load failure still shows *elevated* satellites
- everything in try/catch; native restored on error/teardown

**Verification without screenshots:** `window.__crep_deckSat.probe()` returns the screen-Y delta between a ground point and the same point at LEO altitude — a clearly negative `deltaY` under a tilted camera proves the overlay floats above the surface (~0 = Z ignored, would trigger the fallback discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)