### PR TITLE
fix(earth-sim): raise MAS device-list timeout 1.2s -> 4s

### DIFF
--- a/app/api/earth-simulator/devices/route.ts
+++ b/app/api/earth-simulator/devices/route.ts
@@ -436,7 +436,10 @@ async function fetchMasDevices(): Promise<Record<string, unknown>[]> {
     const res = await fetch(`${MAS_API_URL}/api/devices?include_offline=true`, {
       cache: "no-store",
       headers: { Accept: "application/json" },
-      signal: AbortSignal.timeout(1200),
+      // MAS /api/devices measured ~2.1s on the lab VM; 1.2s timed out and
+      // intermittently dropped the device list to mas:0 ("was working before").
+      // (Jun 14, 2026 — live device QA.)
+      signal: AbortSignal.timeout(4000),
     });
     if (!res.ok) return [];
     const data = (await res.json()) as { devices?: Record<string, unknown>[] };


### PR DESCRIPTION
MAS `/api/devices` measures ~2.1s on the lab VM, but `fetchMasDevices` aborted at **1.2s** — so the website intermittently dropped to `mas:0` even though MAS had the devices registered (Mushroom 1, Hyphae 1, service node). This is the 'MAS devices were working before, now flaky' symptom. Raising the timeout to 4s (above MAS's real ~2.1s) makes registered devices reliably appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent MAS device discovery from timing out too early by raising the /api/devices fetch timeout from 1.2s to 4s.