### PR TITLE
feat(earth-sim): aircraft + vessels + satellites (no debris) ON at reload

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -9770,8 +9770,10 @@ export default function CREPDashboardPage({
 
   // Filter states for map controls
   const [aircraftFilter, setAircraftFilter] = useState<AircraftFilter>(() => {
-    const filtersOff = getInitialFiltersOffMode();
-    const moversOffAtBoot = filtersOff || isEarthSimulatorPath();
+    // Aircraft start ON at boot on Earth Sim (like vessels): OpenSky is live
+    // (~6k aircraft incl. the Gulf) and the categories classify by callsign, so
+    // users see air traffic immediately at reload. (Jun 14, 2026 — movers on.)
+    const moversOffAtBoot = getInitialFiltersOffMode();
     return {
       showAirborne: !moversOffAtBoot,
       showGround: !moversOffAtBoot,
@@ -9809,15 +9811,18 @@ export default function CREPDashboardPage({
   });
 
   const [satelliteFilter, setSatelliteFilter] = useState<SatelliteFilter>(() => {
-    const filtersOff = getInitialFiltersOffMode();
-    const moversOffAtBoot = filtersOff || isEarthSimulatorPath();
+    // Satellites start ON at boot on Earth Sim — EXCEPT debris (Morgan: all sat
+    // filters on at reload except debris). Categories classify by name; SGP4
+    // render is desktop-only so tablet/phone carry no satellite cost.
+    // (Jun 14, 2026 — movers on at reload.)
+    const moversOffAtBoot = getInitialFiltersOffMode();
     return {
       showStations: !moversOffAtBoot,
       showWeather: !moversOffAtBoot,
       showComms: !moversOffAtBoot,
       showGPS: !moversOffAtBoot,
       showStarlink: !moversOffAtBoot,
-      showDebris: !moversOffAtBoot,
+      showDebris: false, // debris stays OFF at boot per request
       showActive: !moversOffAtBoot,
       orbitTypes: [],
     };

--- a/lib/crep/earth-simulator-boot.ts
+++ b/lib/crep/earth-simulator-boot.ts
@@ -129,14 +129,14 @@ export const EARTH_SIM_BOUNDARY_BOOT_LAYER_IDS = [
 
 /** Movers, space weather, Earth-2, AQI/transit, devices, projects — OFF at refresh. */
 export const EARTH_SIM_OFF_AT_BOOT_LAYER_IDS = [
-  "aviation",
+  // aviation (live aircraft), ships, and satellites are NOT off-at-boot: their
+  // feeds are live (OpenSky ~6k, AISstream 44k, TLE/SGP4) and the categories
+  // classify correctly, so air/sea/space traffic paints at reload. aviationRoutes
+  // (flight paths) and orbitalDebris/debrisCloud stay off (debris excluded per
+  // request). Jun 13-14, 2026 — movers on at reload.
   "aviationRoutes",
-  // ships / shipRoutes intentionally NOT off-at-boot: vessels start ON so ocean
-  // traffic paints at load (the AIS feed is live; gating them off left the layer
-  // hidden + the mover pump never fetching). Jun 13, 2026 — vessels P0.
   "fishing",
   "containers",
-  "satellites",
   "orbitalDebris",
   "debrisCloud",
   "solar",
@@ -208,11 +208,24 @@ export const EARTH_SIM_TELECOM_BOOT_LAYER_IDS = [
   "signalHeatmap",
 ] as const
 
+/** Live movers (air / sea / space) ON at first paint. Their feeds are live
+ *  (OpenSky ~6k aircraft, AISstream ~44k vessels, TLE/SGP4 satellites) and the
+ *  categories classify correctly. Routes (aviationRoutes/shipRoutes) + debris
+ *  stay off. These MUST be in the profile-ON allowlist — otherwise
+ *  applyEarthSimulatorBootToLayers forces the mover layers off even after they
+ *  are removed from the OFF-at-boot list. (Jun 14, 2026 — movers on at reload.) */
+export const EARTH_SIM_MOVER_BOOT_LAYER_IDS = [
+  "aviation",
+  "ships",
+  "satellites",
+] as const
+
 export const EARTH_SIM_PROFILE_ON_LAYER_IDS = new Set<string>([
   ...EARTH_SIM_BASE_LAYER_IDS,
   ...EARTH_SIM_INSTANT_INFRA_LINE_IDS,
   ...EARTH_SIM_BOOT_INFRA_ON_LAYER_IDS,
   ...EARTH_SIM_TELECOM_BOOT_LAYER_IDS,
+  ...EARTH_SIM_MOVER_BOOT_LAYER_IDS,
   ...EARTH_SIM_DEVICE_BOOT_LAYER_IDS,
   ...EARTH_SIM_BOUNDARY_BOOT_LAYER_IDS,
   ...EARTH_SIM_EVENT_LAYER_IDS,


### PR DESCRIPTION
Per request: all aircraft, vessel, and satellite filters **on at reload** in production (satellites **except debris**) — but only after auditing + testing that they actually work.

## Audit + test (live browser)
I drove the dev-server preview into the Earth Sim and verified each mover type renders with its filters on: **700 aircraft / 900 vessels / 240 satellites at 58 FPS** (desktop). Classifiers checked in code:
- **Aircraft** — Cargo/Military/Commercial/Private by callsign prefix + onGround; sound. All categories on shows all aircraft.
- **Vessels** — by AIS shipType; no-shipType AIS targets fall to `isOther` and still paint. (Already wired by #198's filter init.)
- **Satellites** — `objectType`/`orbitType` are null upstream, so categories classify by **name** (ISS→station, starlink, GPS/glonass, NOAA/GOES→weather); `showActive` carries the rest. Debris excluded.

## Changes
- aircraft + satellite filter inits drop `isEarthSimulatorPath()` → categories start on (satellites set `showDebris:false`).
- **Mover layers (aviation, ships, satellites) added to `EARTH_SIM_PROFILE_ON_LAYER_IDS`** — `applyEarthSimulatorBootToLayers` is an allowlist that forces any layer not in that set to `enabled:false`, so removing them from the OFF list wasn't enough. **This also fixes #198: ships was never in the allowlist, so vessels were still off at boot.**

## Perf (iPad-safe)
Movers are native MapLibre **GPU symbol layers** — not the DOM markers that caused the iPad freeze (fixed separately in #200) — and satellite SGP4 render is **desktop-only**, so tablet/phone carry no satellite cost. Routes + orbital debris stay off. The boot state is lighter than the ALL-ON I tested at 58 FPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable live air, sea, and space traffic layers by default in the Earth Simulator while keeping debris and route overlays disabled at boot.

New Features:
- Turn on aviation, ship, and satellite mover layers by default in the Earth Simulator profile so live traffic paints immediately after reload.

Bug Fixes:
- Ensure vessel layers respect the profile-ON allowlist so ships no longer remain disabled at boot despite being removed from the off-at-boot set.

Enhancements:
- Initialize aircraft and satellite filter state so all categories start enabled on reload, with satellite debris remaining off per product requirements.