### PR TITLE
fix(earth-sim): elevated satellites now actually have data (window-var feed)

### DIFF
--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -16627,8 +16627,13 @@ export default function CREPDashboardPage({
     const tierColor = (altKm: number): [number, number, number, number] =>
       altKm >= 20000 ? [251, 191, 36, 255] : altKm >= 2000 ? [168, 85, 247, 255] : [34, 211, 238, 255];
 
-    const satFeatures = () => ((map.getSource("crep-live-satellites") as any)?._data?.features ?? []) as any[];
-    const orbitFeatures = () => ((map.getSource("crep-live-satellite-orbits") as any)?._data?.features ?? []) as any[];
+    // Read the live SGP4 FeatureCollections from window vars published by the
+    // satellite-animation loop. maplibre v5 GeoJSONSource does NOT expose
+    // .features on ._data, so reading the source returned 0 satellites — the
+    // overlay mounted + Z worked (deltaY -36px) but had no data to elevate.
+    // (Jun 14, 2026 — elevation data feed fix.)
+    const satFeatures = () => (((window as any).__crep_sat_fc?.features) ?? []) as any[];
+    const orbitFeatures = () => (((window as any).__crep_sat_orbit_fc?.features) ?? []) as any[];
     const setNativeVisible = (vis: "visible" | "none") => {
       for (const id of ["crep-live-satellites-dot", "crep-live-satellites-glow", "crep-live-satellite-orbits-line"]) {
         try { if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", vis); } catch {}
@@ -16688,6 +16693,12 @@ export default function CREPDashboardPage({
         }
       };
       map.on("data", onData);
+      // Robustness: also rebuild on a timer aligned with the SGP4 tick. The
+      // window-var feed is independent of the maplibre 'data' event, so this
+      // guarantees the overlay refreshes even if that event is throttled/missed.
+      const rebuildTimer = window.setInterval(() => {
+        if (!rebuildQueued) { rebuildQueued = true; requestAnimationFrame(rebuild); }
+      }, 2500);
       // QA probe (no screenshots needed): __crep_deckSat.probe() returns the
       // screen-Y delta between a ground point and the same point at LEO altitude.
       // A clearly negative deltaY (elevated point higher on screen) under a tilted
@@ -16705,6 +16716,7 @@ export default function CREPDashboardPage({
       };
       return () => {
         disposed = true;
+        try { window.clearInterval(rebuildTimer); } catch {}
         try { map.off("data", onData); } catch {}
         try { setNativeVisible("visible"); } catch {}
         try { if (overlay) map.removeControl(overlay); } catch {}

--- a/lib/crep/satellite-animation.ts
+++ b/lib/crep/satellite-animation.ts
@@ -185,8 +185,14 @@ function tick(timestamp: number) {
         // coerce id field in case it changed.
         lastWorkerPositions = positions as unknown as SatellitePosition[]
         const satSource = map.getSource?.("crep-live-satellites") as any
+        // Publish the live SGP4 FeatureCollection (incl. altitude in the 3rd
+        // coord) to a window var so the elevated-satellite deck overlay can read
+        // it directly — maplibre v5 GeoJSONSource does not expose .features on
+        // ._data, so the overlay can't reliably read it from the source.
+        const fc = positionsToFeatureCollection(lastWorkerPositions)
+        if (typeof window !== "undefined") (window as any).__crep_sat_fc = fc
         if (satSource?.setData) {
-          satSource.setData(positionsToFeatureCollection(lastWorkerPositions))
+          satSource.setData(fc)
         }
       }).catch(() => { workerPropagationInFlight = false })
     }
@@ -199,8 +205,10 @@ function tick(timestamp: number) {
     }
     const positions = prop.propagateAll(now)
     const satSource = map.getSource?.("crep-live-satellites") as any
+    const fc = positionsToFeatureCollection(positions)
+    if (typeof window !== "undefined") (window as any).__crep_sat_fc = fc
     if (satSource?.setData) {
-      satSource.setData(positionsToFeatureCollection(positions))
+      satSource.setData(fc)
     }
   }
 
@@ -240,7 +248,9 @@ function updateOrbitPaths(prop: SGP4Propagator, now: Date, map: any) {
     }
   }
 
-  orbitSource.setData(orbitPathsToFeatureCollection(paths))
+  const ofc = orbitPathsToFeatureCollection(paths)
+  if (typeof window !== "undefined") (window as any).__crep_sat_orbit_fc = ofc
+  orbitSource.setData(ofc)
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
**The satellites weren't elevating because the overlay had zero data.** Step 2's deck overlay mounted fine and the Z elevation worked (verified `deltaY ~36px` on the tilted globe), but it read its data via `(map.getSource('crep-live-satellites'))._data.features` — and **maplibre-gl v5 GeoJSONSource does not expose `.features` on `._data`**, so the overlay was starved while SGP4 was happily producing 473+ positions.

## Fix
The `satellite-animation` loop now publishes its live FeatureCollection (positions with altitude in the 3rd coord + orbit paths) to `window.__crep_sat_fc` / `__crep_sat_orbit_fc` right before `setData`; the deck overlay reads those window vars instead of maplibre internals, plus a 2.5s timer-driven rebuild independent of the map `data` event.

## Verified live (dev server on main)
473 satellites with real altitudes (424 km LEO etc.) now flow into the overlay and **float above the globe surface** on the tilted view. Screenshot-confirmed.

Follow-ups (separate): atmospheric sphere shells (biosphere/stratosphere/exosphere) + raising the satellite/aircraft/vessel caps with viewport+LOD gating for thousands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure live satellite elevation data correctly feeds the 3D deck overlay in the Earth simulation dashboard.

Bug Fixes:
- Fix elevated satellite overlay receiving zero features by sourcing live FeatureCollections from window-published data instead of maplibre internal GeoJSONSource state.
- Ensure satellite orbit overlays update consistently by publishing orbit FeatureCollections to window and reusing them for rendering.
- Add a timer-based overlay rebuild aligned with the SGP4 tick to avoid missed updates when map data events are throttled or absent.