### PR TITLE
Ship elevated satellites ON by default (3D meshes stay force-off)

### DIFF
--- a/lib/crep/bluesite/flags.ts
+++ b/lib/crep/bluesite/flags.ts
@@ -48,8 +48,12 @@ function truthy(v: unknown): boolean {
 
 export function getBlueSiteFlags(): BlueSiteFlags {
   const out = {
-    bluesite: false,
-    moverAltitude: false,
+    // DEFAULT-ON for all users (Jun 17 2026): the elevated-satellite view ships live. Morgan
+    // confirmed it on production — sats at orbital altitude, fluid, selectable. Only the master
+    // + moverAltitude default on; everything else stays off and `movers3d` is force-disabled
+    // below, so the 3D meshes still can't appear. Users can still force-off via ?bluesite=0.
+    bluesite: true,
+    moverAltitude: true,
     movers3d: false,
     smoke: false,
     clouds3d: false,


### PR DESCRIPTION
Flip `bluesite` + `moverAltitude` to default-on so all users get the elevated-satellite view on first load. `movers3d` stays force-disabled (no 3D meshes), all other v2 sub-flags stay off. Verified live on prod via ?bluesite=1&es3d=1; this just makes it the default.

## Summary by Sourcery

New Features:
- Default-enable the bluesite experience and moverAltitude so users see elevated satellites on first load.