### PR TITLE
Earth Simulator: FPS/LOD perf + radar + emergency UI

### DIFF
--- a/app/api/crep/storm-cells/route.ts
+++ b/app/api/crep/storm-cells/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Active storm cells — live NWS Severe Thunderstorm + Tornado WARNING polygons, used by the
+ * lightning layer to flash animated bolts over REAL storms (keyless, authoritative). Returns
+ * each warning's polygon + bbox + centroid. Cached ~60s. Fail-safe: ok:false on error.
+ */
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const NWS_HEADERS = {
+  Accept: "application/geo+json",
+  "User-Agent": "Mycosoft NatureOS Earth Simulator storm-cells (https://mycosoft.com, ops@mycosoft.com)",
+};
+
+let cache: { at: number; body: unknown } | null = null;
+const TTL_MS = 60_000;
+
+function ringStats(ring: number[][]): { centroid: [number, number]; bbox: [number, number, number, number] } | null {
+  if (!Array.isArray(ring) || ring.length === 0) return null;
+  let sx = 0, sy = 0, n = 0, minX = 180, minY = 90, maxX = -180, maxY = -90;
+  for (const p of ring) {
+    if (!Array.isArray(p) || p.length < 2) continue;
+    const x = Number(p[0]), y = Number(p[1]);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    sx += x; sy += y; n++;
+    if (x < minX) minX = x; if (x > maxX) maxX = x;
+    if (y < minY) minY = y; if (y > maxY) maxY = y;
+  }
+  if (!n) return null;
+  return { centroid: [sx / n, sy / n], bbox: [minX, minY, maxX, maxY] };
+}
+
+export async function GET(_req: NextRequest) {
+  if (cache && Date.now() - cache.at < TTL_MS) {
+    return NextResponse.json(cache.body, { headers: { "Cache-Control": "public, max-age=30" } });
+  }
+  try {
+    const res = await fetch("https://api.weather.gov/alerts/active?status=actual&message_type=alert", {
+      headers: NWS_HEADERS, signal: AbortSignal.timeout(7000), cache: "no-store",
+    });
+    if (!res.ok) {
+      return NextResponse.json({ ok: false, cells: [], note: `NWS ${res.status}` }, { status: 502, headers: { "Cache-Control": "no-store" } });
+    }
+    const data = await res.json();
+    const feats: any[] = Array.isArray(data?.features) ? data.features : [];
+    const cells: Array<{ event: string; severity: string; centroid: [number, number]; bbox: number[]; polygon: number[][] }> = [];
+    for (const f of feats) {
+      const event = String(f?.properties?.event || "");
+      if (!/(thunderstorm|tornado)/i.test(event) || !/warning/i.test(event)) continue;
+      const geom = f?.geometry;
+      const polys = geom?.type === "Polygon" ? [geom.coordinates?.[0]] : geom?.type === "MultiPolygon" ? geom.coordinates.map((p: number[][][]) => p?.[0]) : [];
+      for (const ring of polys) {
+        const st = ringStats(ring);
+        if (!st) continue;
+        cells.push({ event, severity: String(f?.properties?.severity || ""), centroid: st.centroid, bbox: st.bbox, polygon: ring });
+      }
+    }
+    const body = { ok: true, count: cells.length, cells, updated: new Date().toISOString() };
+    cache = { at: Date.now(), body };
+    return NextResponse.json(body, { headers: { "Cache-Control": "public, max-age=30" } });
+  } catch (e) {
+    return NextResponse.json({ ok: false, cells: [], error: e instanceof Error ? e.message : "NWS unavailable" }, { status: 502, headers: { "Cache-Control": "no-store" } });
+  }
+}

--- a/app/api/crep/weather-now/route.ts
+++ b/app/api/crep/weather-now/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Live "weather now" for a point — current NWS conditions (temp, sky, wind), used by the
+ * emergency widget to show LIVE weather inline next to an alert. Authoritative NWS
+ * (api.weather.gov), no key, User-Agent required. Fail-safe: ok:false on upstream error.
+ *
+ * NWS flow: /points/{lat},{lng} → properties.forecastHourly (the "now" period) +
+ * relativeLocation (nearest city). Cached per rounded point to spare the upstream.
+ */
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const NWS_HEADERS = {
+  Accept: "application/geo+json",
+  "User-Agent": "Mycosoft NatureOS Earth Simulator weather-now (https://mycosoft.com, ops@mycosoft.com)",
+};
+
+const cache = new Map<string, { at: number; body: unknown }>();
+const TTL_MS = 5 * 60 * 1000;
+
+export async function GET(req: NextRequest) {
+  const lat = Number(req.nextUrl.searchParams.get("lat"));
+  const lng = Number(req.nextUrl.searchParams.get("lng"));
+  if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+    return NextResponse.json({ ok: false, error: "valid lat/lng required" }, { status: 400, headers: { "Cache-Control": "no-store" } });
+  }
+
+  const key = `${lat.toFixed(2)},${lng.toFixed(2)}`;
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < TTL_MS) {
+    return NextResponse.json(hit.body, { headers: { "Cache-Control": "public, max-age=120" } });
+  }
+
+  try {
+    const pRes = await fetch(`https://api.weather.gov/points/${lat.toFixed(4)},${lng.toFixed(4)}`, {
+      headers: NWS_HEADERS, signal: AbortSignal.timeout(6000), cache: "no-store",
+    });
+    if (!pRes.ok) {
+      // 404 = outside NWS coverage (US only), not an error.
+      return NextResponse.json(
+        { ok: pRes.status === 404, supported: pRes.status !== 404, note: pRes.status === 404 ? "Outside NWS coverage (US only)." : `NWS ${pRes.status}` },
+        { status: pRes.status === 404 ? 200 : 502, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    const pd = await pRes.json();
+    const props = pd?.properties || {};
+    const rel = props?.relativeLocation?.properties;
+    const hourlyUrl: string | undefined = props.forecastHourly || props.forecast;
+
+    let cur: any = null;
+    if (hourlyUrl) {
+      const fRes = await fetch(hourlyUrl, { headers: NWS_HEADERS, signal: AbortSignal.timeout(6000), cache: "no-store" });
+      if (fRes.ok) {
+        const fd = await fRes.json();
+        cur = Array.isArray(fd?.properties?.periods) ? fd.properties.periods[0] : null;
+      }
+    }
+
+    const body = {
+      ok: true,
+      supported: true,
+      place: rel?.city ? `${rel.city}, ${rel.state}` : null,
+      tempF: cur?.temperature ?? null,
+      tempUnit: cur?.temperatureUnit ?? "F",
+      shortForecast: cur?.shortForecast ?? null,
+      windSpeed: cur?.windSpeed ?? null,
+      windDirection: cur?.windDirection ?? null,
+      icon: cur?.icon ?? null,
+      isDaytime: cur?.isDaytime ?? null,
+      forecastUrl: props.forecast ?? null,
+      updated: new Date().toISOString(),
+    };
+    cache.set(key, { at: Date.now(), body });
+    return NextResponse.json(body, { headers: { "Cache-Control": "public, max-age=120" } });
+  } catch (e) {
+    return NextResponse.json(
+      { ok: false, error: e instanceof Error ? e.message : "NWS unavailable" },
+      { status: 502, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -2778,6 +2778,8 @@ const NATURE_ENVIRONMENT_LAYER_IDS = new Set<string>([
   "safecast-radiation",
   "thingspeak-radiation",
   "usgs-streamflow",  // River Gauges / Streamflow (USGS)
+  "weatherRadar",     // Live Weather Radar (animated RainViewer)
+  "stormLightning",   // Live Lightning + Thunder (over real NWS storm cells)
 ]);
 
 const INFRA_BASE_MAP_LAYER_IDS = new Set<string>([

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -15964,8 +15964,11 @@ export default function CREPDashboardPage({
       const { acFeats, vFeats } = buildFromAnchors()
       const bbox = mapBoundsRef.current
       const zoom = mapZoomRef.current
-      const acPicked = selectStableLiveMoverFeatures("aircraft", acFeats, bbox, zoom)
-      const vPicked  = selectStableLiveMoverFeatures("vessel", vFeats,  bbox, zoom)
+      // No plane/boat pipeline below zoom 3.5 (Morgan) — empty both sources so this pump-merge
+      // writer matches the rAF-loop gate: no compute, no render below the floor.
+      const hideMovers = Number.isFinite(zoom) && zoom < 3.5
+      const acPicked = hideMovers ? [] : selectStableLiveMoverFeatures("aircraft", acFeats, bbox, zoom)
+      const vPicked  = hideMovers ? [] : selectStableLiveMoverFeatures("vessel", vFeats,  bbox, zoom)
       ;(map.getSource("crep-live-aircraft") as any)?.setData?.({ type: "FeatureCollection", features: acPicked })
       ;(map.getSource("crep-live-vessels")  as any)?.setData?.({ type: "FeatureCollection", features: vPicked  })
       // Satellites: SGP4 animation owns crep-live-satellites (positions from TLE
@@ -19345,7 +19348,11 @@ export default function CREPDashboardPage({
                 // SGP4-propagated orbit ground tracks (next 90 min)
                 // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
                 map.addSource("crep-live-satellite-orbits", { type: "geojson", data: emptyFC, promoteId: "id" } as any);
+                // minzoom 4: the ~376 orbit-ring polylines are the heaviest per-repaint satellite
+                // geometry AND visual clutter at globe scale. Hide them below 4 (sat DOTS still show
+                // + animate — the signature); rings reveal as you zoom in. (Morgan, Jun 18 2026.)
                 map.addLayer({ id: "crep-live-satellite-orbits-line", type: "line", source: "crep-live-satellite-orbits",
+                  minzoom: 4,
                   paint: { "line-color": "#c084fc", "line-width": 1, "line-opacity": 0.4, "line-dasharray": [4, 4] }});
 
                 // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -19355,8 +19362,11 @@ export default function CREPDashboardPage({
                 map.addSource("crep-live-vessels", { type: "geojson", data: emptyFC, promoteId: "id" } as any);
                 void loadDetailedIcon("/crep/icons/vessel.svg", "vessel-icon");
                 map.addLayer({ id: "crep-live-vessels-glow", type: "circle", source: "crep-live-vessels",
+                  minzoom: 3.5,
                   paint: { "circle-radius": 0, "circle-opacity": 0 }});
+                // minzoom 3.5: no vessels below this (Morgan) — layer-level backstop to the pump gates.
                 map.addLayer({ id: "crep-live-vessels-dot", type: "symbol", source: "crep-live-vessels",
+                  minzoom: 3.5,
                   layout: {
                     "icon-image": "vessel-icon",
                     "icon-size": ["interpolate", ["linear"], ["zoom"], 2, 0.2, 6, 0.28, 10, 0.38, 14, 0.54],

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -15801,18 +15801,24 @@ export default function CREPDashboardPage({
       try {
         const acFeats: any[] = [];
         const vFeats: any[] = [];
+        // No aircraft pipeline below zoom 3.5 (Morgan, Jun 18 2026): planes are the heaviest
+        // mover (~150ms/frame, measured) and the cost is THIS per-frame dead-reckon + feature
+        // build, not the GPU paint. Skipping aircraft entirely below the floor is the real FPS
+        // win (and they're hidden there anyway). Determined kind-first so we skip before the math.
+        const hideAircraftBelowFloor = Number.isFinite(mapZoomRef.current) && mapZoomRef.current < 3.5;
         for (const id of Object.keys(lk)) {
           const a = lk[id];
           if (!a) continue;
-          const dtSec = Math.max(0, Math.min((nowMs - a.ts) / 1000, MAX_EXTRAPOLATION_MS / 1000));
-          const lng = a.lng + a.velLng * dtSec;
-          const lat = a.lat + a.velLat * dtSec;
           const kind = aircraftIdSetRef.current.has(id)
             ? "aircraft"
             : vesselIdSetRef.current.has(id)
             ? "vessel"
             : null;
           if (!kind) continue;
+          if (kind === "aircraft" && hideAircraftBelowFloor) continue;
+          const dtSec = Math.max(0, Math.min((nowMs - a.ts) / 1000, MAX_EXTRAPOLATION_MS / 1000));
+          const lng = a.lng + a.velLng * dtSec;
+          const lat = a.lat + a.velLat * dtSec;
           // Jun 16 — use the stored API heading (true compass bearing). Do NOT
           // recompute from velLng/velLat: velLng carries a /cosLat correction for
           // position extrapolation, so atan2(velLng,velLat) skews the angle and

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -194,7 +194,6 @@ import { FungalMarker, type FungalObservation } from "@/components/crep/markers"
 // Centered Detail Panel for entity popups
 import { EntityDetailPanel } from "@/components/crep/panels/entity-detail-panel";
 import EmergencyAlertOverlay from "@/components/crep/emergency/EmergencyAlertOverlay";
-import FpsAutoGovernor from "@/components/crep/perf/FpsAutoGovernor";
 
 // Trajectory Lines for flight paths and ship routes
 import { TrajectoryLines } from "@/components/crep/trajectory-lines";
@@ -23086,10 +23085,10 @@ export default function CREPDashboardPage({
               inside an active warning polygon. Shows the official protective-action instruction +
               911 / live radar / forecast / preparedness links. Fail-safe: never a false all-clear. */}
           <EmergencyAlertOverlay />
-          {/* Auto-sheds the heaviest non-fungal layers (satellites → vessels → aircraft → dense
-              global infra) when live FPS stays below ~26, restores on recovery. Never touches
-              fungal/nature/emergency data. */}
-          <FpsAutoGovernor />
+          {/* FpsAutoGovernor intentionally NOT mounted (Morgan, Jun 18 2026): it was a dev tool to
+              find the FPS hogs. Now that the mover LOD/zoom gates do the real work it must not run
+              or consume ANY resources. The component is kept at
+              components/crep/perf/FpsAutoGovernor.tsx — re-mount it only for dev profiling. */}
           {!auditAllOffMode && !isEmbeddedEarthquakeSearch && !assetIsolationMode && canRenderEarthStaticProjectDetails && oysterProjectInViewport && hasEnabledLayer(layers, OYSTER_PROJECT_LAYER_IDS) && <TijuanaEstuaryLayer
             map={mapRef}
             liveDataEnabled={canRenderEarthProjectDetails && shouldRenderHeavyOverlays}

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -274,6 +274,7 @@ import SunEarthImpactLayer from "@/components/crep/layers/sun-earth-impact-layer
 // 2d and 3d realistically with altitude on 3d and density on both".
 import RealisticCloudLayer from "@/components/crep/layers/realistic-cloud-layer";
 import RainViewerRadarLayer from "@/components/crep/layers/rainviewer-radar-layer";
+import StormLightningLayer from "@/components/crep/layers/storm-lightning-layer";
 // BlueSite v2 — dormant Earth-2 effect layers, wired + flag-gated (smoke/fire = ?smoke=1, spores = ?spores3d=1)
 import { SmokeLayer } from "@/components/crep/earth2/smoke-layer";
 import { FireLayer } from "@/components/crep/earth2/fire-layer";
@@ -10226,6 +10227,7 @@ export default function CREPDashboardPage({
     { id: "fungalAtlasSamples", name: "Fungal Sequence Samples", category: "environment", icon: <Database className="w-3 h-3" />, enabled: false, opacity: 1, color: "#f59e0b", description: "Zoom-gated GlobalFungi/GlobalAMFungi/GSMc sample points; raw sequences stay server-side." },
     { id: "weather", name: "Weather Overlay", category: "environment", icon: <Thermometer className="w-3 h-3" />, enabled: true, opacity: 0.6, color: "#3b82f6", description: "Temperature, precipitation, wind - affects fungal growth" },
     { id: "weatherRadar", name: "Live Weather Radar (animated)", category: "environment", icon: <Radar className="w-3 h-3" />, enabled: false, opacity: 0.7, color: "#22d3ee", description: "Animated RainViewer radar — past + nowcast precipitation frames cycle so weather visibly moves. Auto-enables during an active NWS warning." },
+    { id: "stormLightning", name: "Live Lightning + Thunder", category: "environment", icon: <Zap className="w-3 h-3" />, enabled: false, opacity: 1, color: "#a5b4fc", description: "Animated lightning bolts + thunder over active NWS thunderstorm/tornado warning cells (real storms)." },
     { id: "buoys", name: "Ocean Buoys (NDBC)", category: "environment", icon: <Waves className="w-3 h-3" />, enabled: true, opacity: 0.9, color: "#84cc16", description: "NOAA NDBC ocean buoys - wave height, water temp, wind, pressure (~1300 stations)" },
     { id: "navChannels", name: "Channels & Currents", category: "environment", icon: <Waves className="w-3 h-3" />, enabled: false, opacity: 0.75, color: "#22d3ee", description: "NOAA ENC maintained nav channels + fairways (charted depth) + CO-OPS tidal-current arrows (flood/ebb, knots). San Diego Bay + coastal; zoom in. Click a channel for name + depth." },
     // Ã¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢Â
@@ -22992,6 +22994,14 @@ export default function CREPDashboardPage({
             map={mapRef}
             enabled={layers.find(l => l.id === "weatherRadar")?.enabled ?? false}
             opacity={layers.find(l => l.id === "weatherRadar")?.opacity ?? 0.7}
+          />}
+
+          {/* Live animated lightning bolts + thunder over real NWS storm-warning cells. Off by
+              default; toggle "Live Lightning + Thunder". Sound is gated to in-view strikes. */}
+          {!auditAllOffMode && !assetIsolationMode && shouldRenderHeavyOverlays && (layers.find(l => l.id === "stormLightning")?.enabled ?? false) && <StormLightningLayer
+            map={mapRef}
+            enabled={layers.find(l => l.id === "stormLightning")?.enabled ?? false}
+            sound={layers.find(l => l.id === "stormLightning")?.enabled ?? false}
           />}
 
           {/* BlueSite v2 — wildfire FLAMES + volumetric SMOKE (Earth-2 fire feed) and

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -194,6 +194,7 @@ import { FungalMarker, type FungalObservation } from "@/components/crep/markers"
 // Centered Detail Panel for entity popups
 import { EntityDetailPanel } from "@/components/crep/panels/entity-detail-panel";
 import EmergencyAlertOverlay from "@/components/crep/emergency/EmergencyAlertOverlay";
+import FpsAutoGovernor from "@/components/crep/perf/FpsAutoGovernor";
 
 // Trajectory Lines for flight paths and ship routes
 import { TrajectoryLines } from "@/components/crep/trajectory-lines";
@@ -12498,6 +12499,11 @@ export default function CREPDashboardPage({
       window.dispatchEvent(new CustomEvent("crep:layer", { detail: applied }));
       return applied;
     };
+    // Open the right-side panel to a given tab (e.g. "environment" for the local forecast).
+    // Used by the emergency overlay's "Local Forecast" button — keeps that data in-app.
+    (window as any).__crep_openRightPanel = (tab?: string) => {
+      try { setRightPanelOpen(true); if (tab) setRightPanelTab(tab); } catch { /* noop */ }
+    };
     (window as any).__crep_layers = () => layersRef.current.map(l => ({
       id: l.id,
       name: l.name,
@@ -12508,7 +12514,7 @@ export default function CREPDashboardPage({
     try {
       window.dispatchEvent(new CustomEvent("crep:qa-ready", { detail: { surface: "layers" } }));
     } catch { /* noop */ }
-  }, [setLayerEnabled]);
+  }, [setLayerEnabled, setRightPanelOpen, setRightPanelTab]);
 
   const setLayerOpacity = useCallback((layerId: string, opacity: number) => {
     const nextOpacity = Math.max(0, Math.min(1, opacity));
@@ -23055,6 +23061,10 @@ export default function CREPDashboardPage({
               inside an active warning polygon. Shows the official protective-action instruction +
               911 / live radar / forecast / preparedness links. Fail-safe: never a false all-clear. */}
           <EmergencyAlertOverlay />
+          {/* Auto-sheds the heaviest non-fungal layers (satellites → vessels → aircraft → dense
+              global infra) when live FPS stays below ~26, restores on recovery. Never touches
+              fungal/nature/emergency data. */}
+          <FpsAutoGovernor />
           {!auditAllOffMode && !isEmbeddedEarthquakeSearch && !assetIsolationMode && canRenderEarthStaticProjectDetails && oysterProjectInViewport && hasEnabledLayer(layers, OYSTER_PROJECT_LAYER_IDS) && <TijuanaEstuaryLayer
             map={mapRef}
             liveDataEnabled={canRenderEarthProjectDetails && shouldRenderHeavyOverlays}

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -19203,9 +19203,13 @@ export default function CREPDashboardPage({
                 void loadDetailedIcon("/crep/icons/helicopter.svg", "helicopter-icon");
                 // Placeholder so the ordering below stays predictable
                 map.addLayer({ id: "crep-live-aircraft-glow", type: "circle", source: "crep-live-aircraft",
+                  minzoom: 3.5,
                   paint: { "circle-radius": 0, "circle-opacity": 0 }});
                 // Aircraft ICON (symbol layer â€” rotates by heading, detailed plane sprite)
+                // minzoom 3.5: NO planes at all below this (Morgan, Jun 18 2026) — layer-level
+                // gate so it holds regardless of which source (LOD path or live pump) fed the data.
                 map.addLayer({ id: "crep-live-aircraft-dot", type: "symbol", source: "crep-live-aircraft",
+                  minzoom: 3.5,
                   layout: {
                     // Helicopters: ICAO category 8 (Rotorcraft), OpenSky
                     // `category: 8`, or aircraft type strings that match

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -15801,11 +15801,12 @@ export default function CREPDashboardPage({
       try {
         const acFeats: any[] = [];
         const vFeats: any[] = [];
-        // No aircraft pipeline below zoom 3.5 (Morgan, Jun 18 2026): planes are the heaviest
-        // mover (~150ms/frame, measured) and the cost is THIS per-frame dead-reckon + feature
-        // build, not the GPU paint. Skipping aircraft entirely below the floor is the real FPS
-        // win (and they're hidden there anyway). Determined kind-first so we skip before the math.
-        const hideAircraftBelowFloor = Number.isFinite(mapZoomRef.current) && mapZoomRef.current < 3.5;
+        // No plane OR vessel pump pipeline below zoom 3.5 (Morgan, Jun 18 2026): the per-frame
+        // dead-reckon + feature build for these movers is the FPS killer (planes ~150ms, vessels
+        // ~50ms), not the GPU paint. Skip them entirely below the floor (hidden there anyway).
+        // Code kept; they rebuild on zoom-in past the floor.
+        const zNow = mapZoomRef.current;
+        const hideMoversBelowFloor = Number.isFinite(zNow) && zNow < 3.5;
         for (const id of Object.keys(lk)) {
           const a = lk[id];
           if (!a) continue;
@@ -15815,7 +15816,7 @@ export default function CREPDashboardPage({
             ? "vessel"
             : null;
           if (!kind) continue;
-          if (kind === "aircraft" && hideAircraftBelowFloor) continue;
+          if (hideMoversBelowFloor) continue;
           const dtSec = Math.max(0, Math.min((nowMs - a.ts) / 1000, MAX_EXTRAPOLATION_MS / 1000));
           const lng = a.lng + a.velLng * dtSec;
           const lat = a.lat + a.velLat * dtSec;
@@ -22419,9 +22420,13 @@ export default function CREPDashboardPage({
                 only show when one is selected like how seacable or
                 powerlines show when selected"). Passing selectedAircraftId
                 / selectedVesselId limits rendering to that single asset. */}
+          {/* Plane trajectory trails turned OFF entirely (Morgan, Jun 18 2026: "they shouldn't
+              even take a bit of resources … we can use them later, so don't delete them, just
+              turn them off"). Passing no aircraft = zero trail compute + zero render. Restore by
+              swapping `[]` back to `filteredAircraft` to re-enable. */}
           <TrajectoryLines
-              aircraft={isEmbeddedEarthquakeSearch ? [] : filteredAircraft}
-              vessels={isEmbeddedEarthquakeSearch ? [] : filteredVessels}
+              aircraft={[]}
+              vessels={[]}
               selectedAircraftId={selectedAircraft?.id ?? null}
               selectedVesselId={selectedVessel?.id ?? null}
             />

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -273,6 +273,7 @@ import SunEarthImpactLayer from "@/components/crep/layers/sun-earth-impact-layer
 // Apr 20, 2026 â€” Morgan: "realistic clouds over the crep map and globe in both
 // 2d and 3d realistically with altitude on 3d and density on both".
 import RealisticCloudLayer from "@/components/crep/layers/realistic-cloud-layer";
+import RainViewerRadarLayer from "@/components/crep/layers/rainviewer-radar-layer";
 // BlueSite v2 — dormant Earth-2 effect layers, wired + flag-gated (smoke/fire = ?smoke=1, spores = ?spores3d=1)
 import { SmokeLayer } from "@/components/crep/earth2/smoke-layer";
 import { FireLayer } from "@/components/crep/earth2/fire-layer";
@@ -10224,6 +10225,7 @@ export default function CREPDashboardPage({
     { id: "fungalAtlasFci", name: "FCI Probe Priority", category: "environment", icon: <Crosshair className="w-3 h-3" />, enabled: false, opacity: 0.58, color: "#fb7185", description: "MYCA priority surface. Hidden until a real MINDEX-backed FCI model is available." },
     { id: "fungalAtlasSamples", name: "Fungal Sequence Samples", category: "environment", icon: <Database className="w-3 h-3" />, enabled: false, opacity: 1, color: "#f59e0b", description: "Zoom-gated GlobalFungi/GlobalAMFungi/GSMc sample points; raw sequences stay server-side." },
     { id: "weather", name: "Weather Overlay", category: "environment", icon: <Thermometer className="w-3 h-3" />, enabled: true, opacity: 0.6, color: "#3b82f6", description: "Temperature, precipitation, wind - affects fungal growth" },
+    { id: "weatherRadar", name: "Live Weather Radar (animated)", category: "environment", icon: <Radar className="w-3 h-3" />, enabled: false, opacity: 0.7, color: "#22d3ee", description: "Animated RainViewer radar — past + nowcast precipitation frames cycle so weather visibly moves. Auto-enables during an active NWS warning." },
     { id: "buoys", name: "Ocean Buoys (NDBC)", category: "environment", icon: <Waves className="w-3 h-3" />, enabled: true, opacity: 0.9, color: "#84cc16", description: "NOAA NDBC ocean buoys - wave height, water temp, wind, pressure (~1300 stations)" },
     { id: "navChannels", name: "Channels & Currents", category: "environment", icon: <Waves className="w-3 h-3" />, enabled: false, opacity: 0.75, color: "#22d3ee", description: "NOAA ENC maintained nav channels + fairways (charted depth) + CO-OPS tidal-current arrows (flood/ebb, knots). San Diego Bay + coastal; zoom in. Click a channel for name + depth." },
     // Ã¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢Â
@@ -22981,6 +22983,15 @@ export default function CREPDashboardPage({
             forecastHours={earth2Filter.forecastHours}
             resolutionDeg={earth2ApiResolutionDeg}
             gpuMode={earth2Filter.gpuMode !== "off"}
+          />}
+
+          {/* Live animated weather radar (RainViewer) — past+nowcast frames cycle so weather
+              visibly moves. Same gating as RealisticCloudLayer; off by default (toggle "Live
+              Weather Radar"), auto-enabled during an active NWS alert. */}
+          {!auditAllOffMode && !assetIsolationMode && shouldRenderHeavyOverlays && (layers.find(l => l.id === "weatherRadar")?.enabled ?? false) && <RainViewerRadarLayer
+            map={mapRef}
+            enabled={layers.find(l => l.id === "weatherRadar")?.enabled ?? false}
+            opacity={layers.find(l => l.id === "weatherRadar")?.opacity ?? 0.7}
           />}
 
           {/* BlueSite v2 — wildfire FLAMES + volumetric SMOKE (Earth-2 fire feed) and

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -23003,7 +23003,7 @@ export default function CREPDashboardPage({
           {!auditAllOffMode && !assetIsolationMode && shouldRenderHeavyOverlays && (layers.find(l => l.id === "stormLightning")?.enabled ?? false) && <StormLightningLayer
             map={mapRef}
             enabled={layers.find(l => l.id === "stormLightning")?.enabled ?? false}
-            sound={layers.find(l => l.id === "stormLightning")?.enabled ?? false}
+            sound={false}
           />}
 
           {/* BlueSite v2 — wildfire FLAMES + volumetric SMOKE (Earth-2 fire feed) and

--- a/components/crep/emergency/EmergencyAlertOverlay.tsx
+++ b/components/crep/emergency/EmergencyAlertOverlay.tsx
@@ -123,11 +123,13 @@ export default function EmergencyAlertOverlay() {
   const [alerts, setAlerts] = useState<EmergencyAlert[]>([]);
   const [lastChecked, setLastChecked] = useState<number>(0);
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
-  const [minimized, setMinimized] = useState(false);
+  const [minimized, setMinimized] = useState(true); // tucked/closed at start (Morgan)
+  const [hasNew, setHasNew] = useState(false); // blink the tucked pill when new alert info arrives
   const [expanded, setExpanded] = useState(false);
   const [wx, setWx] = useState<WxState | null>(null);
   const [, force] = useState(0); // re-render for countdown ticking
   const announced = useRef<Set<string>>(new Set());
+  const seenIds = useRef<Set<string>>(new Set());
 
   const gpsKey = gps ? `${gps.lat.toFixed(2)},${gps.lng.toFixed(2)}` : null;
   const mapKey = mapCenter ? `${mapCenter.lat.toFixed(2)},${mapCenter.lng.toFixed(2)}` : null;
@@ -254,7 +256,6 @@ export default function EmergencyAlertOverlay() {
     const fresh = active.filter((a) => (a.lifeThreatening || a.tier === "warning") && !announced.current.has(a.id));
     if (fresh.length === 0) return;
     fresh.forEach((a) => announced.current.add(a.id));
-    setMinimized(false);
     try {
       const Ctx = (window as unknown as { AudioContext?: any; webkitAudioContext?: any }).AudioContext
         || (window as unknown as { webkitAudioContext?: any }).webkitAudioContext;
@@ -275,6 +276,14 @@ export default function EmergencyAlertOverlay() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active.map((a) => a.id).join("|")]);
 
+  // ── Blink the tucked pill when a NEW alert appears (closed at start; blink on new info) ──
+  useEffect(() => {
+    let isNew = false;
+    for (const a of active) { if (!seenIds.current.has(a.id)) { seenIds.current.add(a.id); isNew = true; } }
+    if (isNew) setHasNew(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active.map((a) => a.id).join("|")]);
+
   if (typeof document === "undefined") return null;
   if (active.length === 0) return null; // verified clear OR still pending → render nothing
 
@@ -287,13 +296,14 @@ export default function EmergencyAlertOverlay() {
   if (minimized) {
     return createPortal(
       <button
-        onClick={() => setMinimized(false)}
-        className={`fixed bottom-2 md:bottom-10 left-1/2 -translate-x-1/2 z-[100000] flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-bold text-white shadow-2xl bg-gradient-to-r ${ts.bar} ${lifeThreat ? "animate-pulse" : ""}`}
+        onClick={() => { setMinimized(false); setHasNew(false); }}
+        className={`fixed bottom-2 md:bottom-10 left-1/2 -translate-x-1/2 z-[100000] flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-bold text-white shadow-2xl bg-gradient-to-r ${ts.bar} ${(lifeThreat || hasNew) ? "animate-pulse" : ""} ${hasNew ? "ring-4 ring-yellow-300/80" : ""}`}
         style={{ pointerEvents: "auto" }}
         aria-label="Show emergency alert"
       >
         <ShieldAlert className="w-4 h-4" />
         {active.length === 1 ? top.event : `${active.length} active alerts`}
+        {hasNew && <span className="inline-flex h-2 w-2 rounded-full bg-yellow-300 ring-2 ring-yellow-100" aria-label="new" />}
         <ChevronUp className="w-4 h-4" />
       </button>,
       document.body,

--- a/components/crep/emergency/EmergencyAlertOverlay.tsx
+++ b/components/crep/emergency/EmergencyAlertOverlay.tsx
@@ -1,30 +1,33 @@
 "use client";
 
 /**
- * Emergency Alert Overlay — GPS-geofenced life-safety warnings for the Earth Simulator.
+ * Emergency Alert Overlay — life-safety weather warnings for the Earth Simulator.
  *
- * When a user is physically inside an active NWS warning area (tornado, flash flood,
- * severe thunderstorm, etc.) this surfaces an unmissable banner with the official
- * protective-action instruction plus direct links to 911, live radar, the local
- * forecast, all nearby alerts, and preparedness info. Data is the authoritative
- * National Weather Service point query (`/api/crep/emergency-alerts`).
+ * Bottom-docked pop-up (desktop) that surfaces active NWS hazards with the official
+ * protective-action instruction + links to 911, live radar, the local forecast, all
+ * nearby alerts, and preparedness info. Data: the authoritative National Weather
+ * Service point query (`/api/crep/emergency-alerts`).
  *
- * Location: prefers the browser GPS ("YOUR LOCATION"); if GPS is denied/unavailable
- * it falls back to the current map center ("MAP AREA") so anyone *looking at* a
- * disaster zone still sees the warning.
+ * DUAL TRIGGER: it polls BOTH the browser GPS ("Your location") AND the current map
+ * center ("Map area"), so it fires whether you're physically in a warning OR you pan
+ * the map into one. Alerts from both points are merged + de-duped.
  *
- * FAIL-SAFE: it never shows a green "all clear". A verified location with no alerts
- * shows nothing; a location it could NOT verify (network/NWS error) shows an amber
- * "couldn't verify — here are direct links" bar instead of implying safety.
+ * ONLY POPS for genuine hazards (warnings, watches, emergencies, anything Severe/Extreme,
+ * and hazard statements like Special Weather / Beach Hazards) — routine advisories
+ * (Wind Advisory, Small Craft Advisory, etc.) are suppressed. Threshold is `isPopupWorthy`.
+ *
+ * Docked at the BOTTOM, above the stats bar; tuck it away with the chevron. Never a
+ * green "all clear"; a real alert persists through a transient fetch error.
  */
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
-  AlertTriangle, Radio, CloudRain, Phone, ExternalLink, MapPin, X, ChevronUp, ShieldAlert, Navigation,
+  AlertTriangle, Radio, CloudRain, Phone, ExternalLink, MapPin, X, ChevronUp, ChevronDown, ShieldAlert, Navigation,
 } from "lucide-react";
 
 type Tier = "warning" | "watch" | "advisory" | "statement";
+type LocSource = "gps" | "map";
 
 interface EmergencyAlert {
   id: string;
@@ -43,13 +46,22 @@ interface EmergencyAlert {
   web: string | null;
   tier: Tier;
   lifeThreatening: boolean;
+  _source?: LocSource;
 }
 
 type LatLng = { lat: number; lng: number };
-type LocSource = "gps" | "map";
-type Status = "pending" | "ok" | "unsupported" | "error";
 
 const POLL_MS = 45_000;
+
+/** Pop up only for genuine hazards — not routine advisories. Easy to tighten/loosen. */
+function isPopupWorthy(a: EmergencyAlert): boolean {
+  if (a.lifeThreatening) return true;
+  if (/emergency/i.test(a.event)) return true;
+  if (a.severity === "Severe" || a.severity === "Extreme") return true;
+  if (a.tier === "warning" || a.tier === "watch") return true;
+  if (a.tier === "statement") return true;          // Special Weather / Beach Hazards / Coastal, etc.
+  return false;                                      // tier === "advisory" → suppressed
+}
 
 function radarUrl(p: LatLng) { return `https://www.windy.com/?radar,${p.lat.toFixed(3)},${p.lng.toFixed(3)},8`; }
 function forecastUrl(p: LatLng) { return `https://forecast.weather.gov/MapClick.php?lat=${p.lat.toFixed(4)}&lon=${p.lng.toFixed(4)}`; }
@@ -64,6 +76,7 @@ function prepUrl(event: string) {
   if (e.includes("winter") || e.includes("blizzard") || e.includes("ice") || e.includes("snow")) return "https://www.ready.gov/winter-weather";
   if (e.includes("heat")) return "https://www.ready.gov/extreme-heat";
   if (e.includes("fire") || e.includes("red flag")) return "https://www.ready.gov/wildfires";
+  if (e.includes("beach") || e.includes("rip current") || e.includes("surf") || e.includes("marine")) return "https://www.weather.gov/safety/ripcurrent";
   return "https://www.ready.gov/be-informed";
 }
 
@@ -81,7 +94,7 @@ const TIER_STYLE: Record<Tier, { bar: string; chip: string; label: string }> = {
   warning: { bar: "from-red-700 to-red-600 border-red-300", chip: "bg-red-950 text-red-100 border-red-400", label: "WARNING" },
   watch: { bar: "from-orange-600 to-amber-600 border-amber-300", chip: "bg-amber-950 text-amber-100 border-amber-400", label: "WATCH" },
   advisory: { bar: "from-yellow-600 to-yellow-500 border-yellow-300", chip: "bg-yellow-900 text-yellow-100 border-yellow-400", label: "ADVISORY" },
-  statement: { bar: "from-sky-700 to-sky-600 border-sky-300", chip: "bg-sky-950 text-sky-100 border-sky-400", label: "INFO" },
+  statement: { bar: "from-sky-700 to-sky-600 border-sky-300", chip: "bg-sky-950 text-sky-100 border-sky-400", label: "ADVISORY" },
 };
 
 export default function EmergencyAlertOverlay() {
@@ -89,18 +102,16 @@ export default function EmergencyAlertOverlay() {
   const [gpsState, setGpsState] = useState<"pending" | "granted" | "denied" | "unavailable">("pending");
   const [mapCenter, setMapCenter] = useState<LatLng | null>(null);
   const [alerts, setAlerts] = useState<EmergencyAlert[]>([]);
-  const [status, setStatus] = useState<Status>("pending");
   const [lastChecked, setLastChecked] = useState<number>(0);
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
   const [minimized, setMinimized] = useState(false);
   const [, force] = useState(0); // re-render for countdown ticking
   const announced = useRef<Set<string>>(new Set());
 
-  const loc = gps ?? mapCenter;
-  const locSource: LocSource | null = gps ? "gps" : mapCenter ? "map" : null;
-  const locKey = loc ? `${loc.lat.toFixed(2)},${loc.lng.toFixed(2)}` : null;
+  const gpsKey = gps ? `${gps.lat.toFixed(2)},${gps.lng.toFixed(2)}` : null;
+  const mapKey = mapCenter ? `${mapCenter.lat.toFixed(2)},${mapCenter.lng.toFixed(2)}` : null;
 
-  // ── GPS (preferred) ──────────────────────────────────────────────────────
+  // ── GPS watch ────────────────────────────────────────────────────────────
   useEffect(() => {
     if (typeof navigator === "undefined" || !navigator.geolocation) { setGpsState("unavailable"); return; }
     let id: number | null = null;
@@ -114,9 +125,9 @@ export default function EmergencyAlertOverlay() {
     return () => { try { if (id != null) navigator.geolocation.clearWatch(id); } catch { /* */ } };
   }, []);
 
-  // ── Map-center fallback (only when GPS is unavailable) ───────────────────
+  // ── Track the map center ALWAYS (not just as a GPS fallback) so panning into an
+  //    area shows that area's alerts. ─────────────────────────────────────────
   useEffect(() => {
-    if (gps) return;
     const read = () => {
       try {
         const m = (window as unknown as { __crep_map?: any }).__crep_map;
@@ -125,38 +136,47 @@ export default function EmergencyAlertOverlay() {
       } catch { /* */ }
     };
     read();
-    const iv = window.setInterval(read, 20_000);
+    const iv = window.setInterval(read, 15_000);
     let m: any;
     try { m = (window as unknown as { __crep_map?: any }).__crep_map; m?.on?.("moveend", read); } catch { /* */ }
     return () => { window.clearInterval(iv); try { m?.off?.("moveend", read); } catch { /* */ } };
-  }, [gps]);
+  }, []);
 
-  // ── Poll NWS for the active location ─────────────────────────────────────
+  // ── Poll NWS for BOTH the GPS point and the map center; merge + de-dupe ──────
   useEffect(() => {
-    if (!loc || !locKey) return;
+    const points: Array<LatLng & { source: LocSource }> = [];
+    if (gps) points.push({ ...gps, source: "gps" });
+    if (mapCenter && mapKey !== gpsKey) points.push({ ...mapCenter, source: "map" });
+    if (points.length === 0) return;
     let cancelled = false;
     const check = async () => {
-      try {
-        const r = await fetch(`/api/crep/emergency-alerts?lat=${loc.lat.toFixed(4)}&lng=${loc.lng.toFixed(4)}`, { cache: "no-store" });
-        const d = await r.json().catch(() => null);
-        if (cancelled) return;
-        if (d && d.ok) {
-          setAlerts(Array.isArray(d.alerts) ? d.alerts : []);
-          setStatus(d.supported === false ? "unsupported" : "ok");
-        } else {
-          setAlerts([]);
-          setStatus("error");
-        }
-        setLastChecked(Date.now());
-      } catch {
-        if (!cancelled) { setStatus("error"); setLastChecked(Date.now()); }
+      const results = await Promise.all(points.map(async (pt) => {
+        try {
+          const r = await fetch(`/api/crep/emergency-alerts?lat=${pt.lat.toFixed(4)}&lng=${pt.lng.toFixed(4)}`, { cache: "no-store" });
+          const d = await r.json().catch(() => null);
+          if (d && d.ok && Array.isArray(d.alerts)) return (d.alerts as EmergencyAlert[]).map((a) => ({ ...a, _source: pt.source }));
+          return null; // upstream error / unsupported → don't treat as "clear"
+        } catch { return null; }
+      }));
+      if (cancelled) return;
+      const anyError = results.some((r) => r === null);
+      const merged: EmergencyAlert[] = [];
+      const seen = new Set<string>();
+      for (const list of results) {
+        if (!list) continue;
+        for (const a of list) { if (seen.has(a.id)) continue; seen.add(a.id); merged.push(a); }
       }
+      // Never drop a known alert because of a transient blip: keep the last set if every
+      // point errored and we have nothing new.
+      if (anyError && merged.length === 0) { setLastChecked(Date.now()); return; }
+      setAlerts(merged);
+      setLastChecked(Date.now());
     };
     check();
     const iv = window.setInterval(check, POLL_MS);
     return () => { cancelled = true; window.clearInterval(iv); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [locKey]);
+  }, [gpsKey, mapKey]);
 
   // ── Tick once a minute so the countdown stays fresh ──────────────────────
   useEffect(() => {
@@ -164,8 +184,11 @@ export default function EmergencyAlertOverlay() {
     return () => window.clearInterval(iv);
   }, []);
 
-  const active = alerts.filter((a) => !dismissed.has(a.id));
-  const lifeThreat = active.some((a) => a.lifeThreatening) || active.some((a) => a.tier === "warning");
+  const active = alerts.filter((a) => !dismissed.has(a.id) && isPopupWorthy(a));
+  // most urgent first
+  const rank = (a: EmergencyAlert) => (a.lifeThreatening ? 0 : a.tier === "warning" ? 1 : a.tier === "watch" ? 2 : a.tier === "statement" ? 3 : 4);
+  active.sort((a, b) => rank(a) - rank(b));
+  const lifeThreat = active.some((a) => a.lifeThreatening || a.tier === "warning");
 
   // ── Audible cue once per new life-threatening alert (best-effort) ────────
   useEffect(() => {
@@ -194,21 +217,21 @@ export default function EmergencyAlertOverlay() {
   }, [active.map((a) => a.id).join("|")]);
 
   if (typeof document === "undefined") return null;
-
-  const showError = status === "error" && active.length === 0;
-  if (active.length === 0 && !showError) return null; // verified clear OR still pending → render nothing
+  if (active.length === 0) return null; // verified clear OR still pending → render nothing
 
   const top = active[0];
-  const ts = top ? TIER_STYLE[top.tier] : TIER_STYLE.warning;
+  const ts = TIER_STYLE[top.tier];
+  const topLoc: LatLng | null = (top._source === "gps" ? gps : mapCenter) ?? gps ?? mapCenter;
   const updatedAgo = lastChecked ? Math.max(0, Math.round((Date.now() - lastChecked) / 1000)) : null;
 
-  // ── Minimized pill ───────────────────────────────────────────────────────
-  if (minimized && active.length > 0) {
+  // ── Tucked-away pill (bottom, above the stats bar) ───────────────────────
+  if (minimized) {
     return createPortal(
       <button
         onClick={() => setMinimized(false)}
-        className={`fixed top-3 left-1/2 -translate-x-1/2 z-[100000] flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-bold text-white shadow-2xl bg-gradient-to-r ${ts.bar} ${lifeThreat ? "animate-pulse" : ""}`}
+        className={`fixed bottom-2 md:bottom-10 left-1/2 -translate-x-1/2 z-[100000] flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-bold text-white shadow-2xl bg-gradient-to-r ${ts.bar} ${lifeThreat ? "animate-pulse" : ""}`}
         style={{ pointerEvents: "auto" }}
+        aria-label="Show emergency alert"
       >
         <ShieldAlert className="w-4 h-4" />
         {active.length === 1 ? top.event : `${active.length} active alerts`}
@@ -229,90 +252,66 @@ export default function EmergencyAlertOverlay() {
     </a>
   );
 
+  // Docked at the BOTTOM, lifted above the md+ stats bar via bottom padding so it never
+  // overlaps it. Slides up on appear (no-op if tailwindcss-animate isn't present).
   return createPortal(
-    <div className="fixed top-0 left-0 right-0 z-[100000] flex justify-center px-2 pt-2" style={{ pointerEvents: "none" }}>
+    <div className="fixed bottom-0 left-0 right-0 z-[100000] flex justify-center px-2 pb-2 md:pb-10" style={{ pointerEvents: "none" }}>
       <div
-        className={`w-full max-w-3xl rounded-xl border-2 shadow-2xl bg-gradient-to-r ${showError ? "from-amber-700 to-amber-600 border-amber-300" : ts.bar} ${lifeThreat ? "ring-4 ring-red-400/60 animate-pulse" : ""}`}
+        className={`w-full max-w-3xl rounded-xl border-2 shadow-2xl bg-gradient-to-r ${ts.bar} ${lifeThreat ? "ring-4 ring-red-400/60 animate-pulse" : ""} animate-in fade-in slide-in-from-bottom-4 duration-300`}
         style={{ pointerEvents: "auto" }}
         role="alert"
         aria-live="assertive"
       >
-        {showError ? (
-          <div className="p-3 text-white">
-            <div className="flex items-start gap-2">
-              <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5" />
-              <div className="flex-1">
-                <div className="font-bold text-sm">Couldn't verify local emergency alerts</div>
-                <div className="text-xs text-white/90 mt-0.5">The alert service is unreachable right now. Do not assume you are clear — use these official sources directly:</div>
-                <div className="flex flex-wrap gap-2 mt-2">
-                  <LinkBtn href="tel:911" icon={<Phone className="w-3.5 h-3.5" />} strong>Call 911</LinkBtn>
-                  {loc && <LinkBtn href={radarUrl(loc)} icon={<Radio className="w-3.5 h-3.5" />}>Live Radar</LinkBtn>}
-                  {loc && <LinkBtn href={forecastUrl(loc)} icon={<CloudRain className="w-3.5 h-3.5" />}>Local Forecast</LinkBtn>}
-                  <LinkBtn href={ALL_ALERTS_URL} icon={<ExternalLink className="w-3.5 h-3.5" />}>All NWS Alerts</LinkBtn>
-                </div>
+        <div className="p-3 text-white">
+          {/* header */}
+          <div className="flex items-start gap-2">
+            <ShieldAlert className="w-6 h-6 shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center flex-wrap gap-2">
+                <span className="text-base sm:text-lg font-extrabold tracking-tight uppercase">{top.event}</span>
+                <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded border ${ts.chip}`}>{ts.label}</span>
+                {top.lifeThreatening && <span className="text-[10px] font-extrabold px-1.5 py-0.5 rounded bg-white text-red-700">LIFE-THREATENING</span>}
+                {active.length > 1 && <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-black/30 border border-white/30">+{active.length - 1} more</span>}
               </div>
-              <button onClick={() => setMinimized(true)} className="text-white/70 hover:text-white" aria-label="Minimize"><X className="w-4 h-4" /></button>
+              <div className="flex items-center gap-2 text-[11px] text-white/90 mt-1">
+                <MapPin className="w-3 h-3 shrink-0" />
+                <span className="truncate">{top.areaDesc || "your area"}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              <button onClick={() => setMinimized(true)} className="text-white/70 hover:text-white p-1" aria-label="Tuck away"><ChevronDown className="w-4 h-4" /></button>
+              {!top.lifeThreatening && (
+                <button onClick={() => setDismissed((s) => new Set(s).add(top.id))} className="text-white/70 hover:text-white p-1" aria-label="Dismiss this alert"><X className="w-4 h-4" /></button>
+              )}
             </div>
           </div>
-        ) : (
-          <div className="p-3 text-white">
-            {/* header */}
-            <div className="flex items-start gap-2">
-              <ShieldAlert className="w-6 h-6 shrink-0 mt-0.5" />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center flex-wrap gap-2">
-                  <span className="text-base sm:text-lg font-extrabold tracking-tight uppercase">{top.event}</span>
-                  <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded border ${ts.chip}`}>{ts.label}</span>
-                  {top.lifeThreatening && <span className="text-[10px] font-extrabold px-1.5 py-0.5 rounded bg-white text-red-700">LIFE-THREATENING</span>}
-                  {active.length > 1 && <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-black/30 border border-white/30">+{active.length - 1} more</span>}
-                </div>
-                <div className="flex items-center gap-2 text-[11px] text-white/90 mt-1">
-                  <MapPin className="w-3 h-3 shrink-0" />
-                  <span className="truncate">{top.areaDesc || "your area"}</span>
-                </div>
-              </div>
-              <div className="flex items-center gap-1 shrink-0">
-                <button onClick={() => setMinimized(true)} className="text-white/70 hover:text-white p-1" aria-label="Minimize"><ChevronUp className="w-4 h-4" /></button>
-                {!top.lifeThreatening && (
-                  <button onClick={() => setDismissed((s) => new Set(s).add(top.id))} className="text-white/70 hover:text-white p-1" aria-label="Dismiss this alert"><X className="w-4 h-4" /></button>
-                )}
-              </div>
+
+          {/* protective-action instruction (verbatim from NWS) */}
+          {(top.instruction || top.headline) && (
+            <div className="mt-2 rounded-md bg-black/25 p-2 max-h-24 overflow-y-auto text-xs leading-snug whitespace-pre-line">
+              <span className="font-bold">What to do: </span>{top.instruction || top.headline}
             </div>
+          )}
 
-            {/* protective-action instruction (verbatim from NWS) */}
-            {(top.instruction || top.headline) && (
-              <div className="mt-2 rounded-md bg-black/25 p-2 max-h-28 overflow-y-auto text-xs leading-snug whitespace-pre-line">
-                <span className="font-bold">What to do: </span>{top.instruction || top.headline}
-              </div>
-            )}
-
-            {/* links */}
-            <div className="flex flex-wrap gap-2 mt-2">
-              <LinkBtn href="tel:911" icon={<Phone className="w-3.5 h-3.5" />} strong>Call 911</LinkBtn>
-              {loc && <LinkBtn href={radarUrl(loc)} icon={<Radio className="w-3.5 h-3.5" />}>Live Radar</LinkBtn>}
-              {loc && <LinkBtn href={forecastUrl(loc)} icon={<CloudRain className="w-3.5 h-3.5" />}>Local Forecast</LinkBtn>}
-              {top.web && <LinkBtn href={top.web} icon={<ExternalLink className="w-3.5 h-3.5" />}>Full Alert</LinkBtn>}
-              <LinkBtn href={prepUrl(top.event)} icon={<ShieldAlert className="w-3.5 h-3.5" />}>What to do</LinkBtn>
-              <LinkBtn href={ALL_ALERTS_URL} icon={<ExternalLink className="w-3.5 h-3.5" />}>All Alerts</LinkBtn>
-            </div>
-
-            {/* footer / trust line */}
-            <div className="flex items-center justify-between gap-2 mt-2 text-[10px] text-white/80">
-              <span className="flex items-center gap-1">
-                {locSource === "gps" ? <Navigation className="w-3 h-3" /> : <MapPin className="w-3 h-3" />}
-                {locSource === "gps" ? "Your location" : "Map area"} · Source: NWS{updatedAgo != null ? ` · updated ${updatedAgo < 90 ? `${updatedAgo}s` : `${Math.round(updatedAgo / 60)}m`} ago` : ""}
-              </span>
-              {(() => { const c = fmtCountdown(top.expires || top.ends); return c ? <span>Expires in {c}</span> : null; })()}
-            </div>
-
-            {/* gps-denied nudge: we fell back to map area, offer to enable precise location */}
-            {locSource === "map" && (gpsState === "denied" || gpsState === "unavailable") && (
-              <div className="mt-1 text-[10px] text-white/70">
-                Showing alerts for the map area. Enable location access for warnings at your exact position.
-              </div>
-            )}
+          {/* links */}
+          <div className="flex flex-wrap gap-2 mt-2">
+            <LinkBtn href="tel:911" icon={<Phone className="w-3.5 h-3.5" />} strong>Call 911</LinkBtn>
+            {topLoc && <LinkBtn href={radarUrl(topLoc)} icon={<Radio className="w-3.5 h-3.5" />}>Live Radar</LinkBtn>}
+            {topLoc && <LinkBtn href={forecastUrl(topLoc)} icon={<CloudRain className="w-3.5 h-3.5" />}>Local Forecast</LinkBtn>}
+            {top.web && <LinkBtn href={top.web} icon={<ExternalLink className="w-3.5 h-3.5" />}>Full Alert</LinkBtn>}
+            <LinkBtn href={prepUrl(top.event)} icon={<ShieldAlert className="w-3.5 h-3.5" />}>What to do</LinkBtn>
+            <LinkBtn href={ALL_ALERTS_URL} icon={<ExternalLink className="w-3.5 h-3.5" />}>All Alerts</LinkBtn>
           </div>
-        )}
+
+          {/* footer / trust line */}
+          <div className="flex items-center justify-between gap-2 mt-2 text-[10px] text-white/80">
+            <span className="flex items-center gap-1">
+              {top._source === "gps" ? <Navigation className="w-3 h-3" /> : <MapPin className="w-3 h-3" />}
+              {top._source === "gps" ? "Your location" : "Map area"} · Source: NWS{updatedAgo != null ? ` · updated ${updatedAgo < 90 ? `${updatedAgo}s` : `${Math.round(updatedAgo / 60)}m`} ago` : ""}
+            </span>
+            {(() => { const c = fmtCountdown(top.expires || top.ends); return c ? <span>Expires in {c}</span> : null; })()}
+          </div>
+        </div>
       </div>
     </div>,
     document.body,

--- a/components/crep/emergency/EmergencyAlertOverlay.tsx
+++ b/components/crep/emergency/EmergencyAlertOverlay.tsx
@@ -23,7 +23,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
-  AlertTriangle, Radio, CloudRain, Phone, ExternalLink, MapPin, X, ChevronUp, ChevronDown, ShieldAlert, Navigation, Wind,
+  Radio, CloudRain, Phone, MapPin, X, ChevronUp, ChevronDown, ShieldAlert, Navigation, Wind,
 } from "lucide-react";
 
 type Tier = "warning" | "watch" | "advisory" | "statement";
@@ -80,22 +80,6 @@ function isPopupWorthy(a: EmergencyAlert): boolean {
   if (a.tier === "warning" || a.tier === "watch") return true;
   if (a.tier === "statement") return true;          // Special Weather / Beach Hazards / Coastal, etc.
   return false;                                      // tier === "advisory" → suppressed
-}
-
-function forecastUrl(p: LatLng) { return `https://forecast.weather.gov/MapClick.php?lat=${p.lat.toFixed(4)}&lon=${p.lng.toFixed(4)}`; }
-const ALL_ALERTS_URL = "https://alerts.weather.gov/";
-
-function prepUrl(event: string) {
-  const e = (event || "").toLowerCase();
-  if (e.includes("tornado")) return "https://www.ready.gov/tornadoes";
-  if (e.includes("flood")) return "https://www.ready.gov/floods";
-  if (e.includes("thunderstorm") || e.includes("lightning")) return "https://www.ready.gov/thunderstorms-lightning";
-  if (e.includes("hurricane") || e.includes("tropical")) return "https://www.ready.gov/hurricanes";
-  if (e.includes("winter") || e.includes("blizzard") || e.includes("ice") || e.includes("snow")) return "https://www.ready.gov/winter-weather";
-  if (e.includes("heat")) return "https://www.ready.gov/extreme-heat";
-  if (e.includes("fire") || e.includes("red flag")) return "https://www.ready.gov/wildfires";
-  if (e.includes("beach") || e.includes("rip current") || e.includes("surf") || e.includes("marine")) return "https://www.weather.gov/safety/ripcurrent";
-  return "https://www.ready.gov/be-informed";
 }
 
 function fmtCountdown(iso: string | null): string | null {
@@ -343,7 +327,7 @@ export default function EmergencyAlertOverlay() {
   return createPortal(
     <div className="fixed bottom-0 left-0 right-0 z-[100000] flex justify-center px-2 pb-2 md:pb-10" style={{ pointerEvents: "none" }}>
       <div
-        className={`w-full max-w-3xl rounded-xl border-2 shadow-2xl bg-gradient-to-r ${ts.bar} ${lifeThreat ? "ring-4 ring-red-400/60 animate-pulse" : ""} animate-in fade-in slide-in-from-bottom-4 duration-300`}
+        className={`w-full max-w-lg rounded-xl border-2 shadow-2xl bg-gradient-to-r ${ts.bar} ${lifeThreat ? "ring-2 ring-red-400/70" : ""} animate-in fade-in slide-in-from-bottom-4 duration-300`}
         style={{ pointerEvents: "auto" }}
         role="alert"
         aria-live="assertive"
@@ -424,6 +408,10 @@ export default function EmergencyAlertOverlay() {
           )}
 
           {/* links */}
+          {/* Actions — on-platform only. 911 (a phone call) + turn on the Earth Simulator's own
+              live radar + open the Environment panel for the local forecast. No external data
+              links (Full Alert / What to do / All Alerts removed — that data lives in the sim and
+              the protective-action text is already shown inline above). */}
           <div className="flex flex-wrap gap-2 mt-2">
             <LinkBtn href="tel:911" icon={<Phone className="w-3.5 h-3.5" />} strong>Call 911</LinkBtn>
             <button
@@ -436,10 +424,16 @@ export default function EmergencyAlertOverlay() {
             >
               <Radio className="w-3.5 h-3.5" />Live Radar
             </button>
-            {topLoc && <LinkBtn href={forecastUrl(topLoc)} icon={<CloudRain className="w-3.5 h-3.5" />}>Local Forecast</LinkBtn>}
-            {top.web && <LinkBtn href={top.web} icon={<ExternalLink className="w-3.5 h-3.5" />}>Full Alert</LinkBtn>}
-            <LinkBtn href={prepUrl(top.event)} icon={<ShieldAlert className="w-3.5 h-3.5" />}>What to do</LinkBtn>
-            <LinkBtn href={ALL_ALERTS_URL} icon={<ExternalLink className="w-3.5 h-3.5" />}>All Alerts</LinkBtn>
+            <button
+              onClick={() => {
+                const open = (window as unknown as { __crep_openRightPanel?: (tab?: string) => unknown }).__crep_openRightPanel;
+                try { open?.("environment"); } catch { /* */ }
+              }}
+              className="inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-xs font-bold transition-colors bg-black/30 text-white hover:bg-black/50 border border-white/30"
+              aria-label="Open the Environment panel with the local forecast"
+            >
+              <CloudRain className="w-3.5 h-3.5" />Local Forecast
+            </button>
           </div>
 
           {/* footer / trust line */}

--- a/components/crep/emergency/EmergencyAlertOverlay.tsx
+++ b/components/crep/emergency/EmergencyAlertOverlay.tsx
@@ -82,7 +82,6 @@ function isPopupWorthy(a: EmergencyAlert): boolean {
   return false;                                      // tier === "advisory" → suppressed
 }
 
-function radarUrl(p: LatLng) { return `https://www.windy.com/?radar,${p.lat.toFixed(3)},${p.lng.toFixed(3)},8`; }
 function forecastUrl(p: LatLng) { return `https://forecast.weather.gov/MapClick.php?lat=${p.lat.toFixed(4)}&lon=${p.lng.toFixed(4)}`; }
 const ALL_ALERTS_URL = "https://alerts.weather.gov/";
 
@@ -262,7 +261,17 @@ export default function EmergencyAlertOverlay() {
     try {
       const m = (window as unknown as { __crep_map?: { getBounds?: () => { contains?: (p: [number, number]) => boolean } } }).__crep_map;
       const inView = !!(gps && m?.getBounds?.()?.contains?.([gps.lng, gps.lat]));
-      if (inView && fresh.some((a) => a.lifeThreatening && a._source === "gps")) setMinimized(false);
+      // The user is physically INSIDE a new life-threatening warning (alert came from their GPS)
+      // AND is currently looking at that spot (GPS point in the viewport).
+      const insideEmergency = inView && fresh.some((a) => a.lifeThreatening && a._source === "gps");
+      if (insideEmergency) {
+        setMinimized(false);
+        // Auto-arm the live weather radar + lightning so the storm is immediately visible on the
+        // map. ONLY in this GPS-AND-viewport-in-emergency case (Morgan, Jun 18 2026) — never just
+        // from panning the map into a warning.
+        const setLayer = (window as unknown as { __crep_setLayer?: (id: string, on?: boolean) => unknown }).__crep_setLayer;
+        try { setLayer?.("weatherRadar", true); setLayer?.("stormLightning", true); } catch { /* */ }
+      }
     } catch { /* */ }
     try {
       const Ctx = (window as unknown as { AudioContext?: any; webkitAudioContext?: any }).AudioContext
@@ -417,7 +426,16 @@ export default function EmergencyAlertOverlay() {
           {/* links */}
           <div className="flex flex-wrap gap-2 mt-2">
             <LinkBtn href="tel:911" icon={<Phone className="w-3.5 h-3.5" />} strong>Call 911</LinkBtn>
-            {topLoc && <LinkBtn href={radarUrl(topLoc)} icon={<Radio className="w-3.5 h-3.5" />}>Live Radar</LinkBtn>}
+            <button
+              onClick={() => {
+                const setLayer = (window as unknown as { __crep_setLayer?: (id: string, on?: boolean) => unknown }).__crep_setLayer;
+                try { setLayer?.("weatherRadar", true); } catch { /* */ }
+              }}
+              className="inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-xs font-bold transition-colors bg-cyan-600 text-white hover:bg-cyan-500 border border-cyan-300"
+              aria-label="Turn on the live weather radar on the map"
+            >
+              <Radio className="w-3.5 h-3.5" />Live Radar
+            </button>
             {topLoc && <LinkBtn href={forecastUrl(topLoc)} icon={<CloudRain className="w-3.5 h-3.5" />}>Local Forecast</LinkBtn>}
             {top.web && <LinkBtn href={top.web} icon={<ExternalLink className="w-3.5 h-3.5" />}>Full Alert</LinkBtn>}
             <LinkBtn href={prepUrl(top.event)} icon={<ShieldAlert className="w-3.5 h-3.5" />}>What to do</LinkBtn>

--- a/components/crep/emergency/EmergencyAlertOverlay.tsx
+++ b/components/crep/emergency/EmergencyAlertOverlay.tsx
@@ -256,6 +256,14 @@ export default function EmergencyAlertOverlay() {
     const fresh = active.filter((a) => (a.lifeThreatening || a.tier === "warning") && !announced.current.has(a.id));
     if (fresh.length === 0) return;
     fresh.forEach((a) => announced.current.add(a.id));
+    // Auto-open ONLY for a NEW life-threatening warning the user is physically INSIDE (the alert
+    // came from their GPS point) AND is currently LOOKING AT (their GPS point is in the map
+    // viewport). Anything else stays tucked and just blinks the pill. (Morgan, Jun 18 2026.)
+    try {
+      const m = (window as unknown as { __crep_map?: { getBounds?: () => { contains?: (p: [number, number]) => boolean } } }).__crep_map;
+      const inView = !!(gps && m?.getBounds?.()?.contains?.([gps.lng, gps.lat]));
+      if (inView && fresh.some((a) => a.lifeThreatening && a._source === "gps")) setMinimized(false);
+    } catch { /* */ }
     try {
       const Ctx = (window as unknown as { AudioContext?: any; webkitAudioContext?: any }).AudioContext
         || (window as unknown as { webkitAudioContext?: any }).webkitAudioContext;

--- a/components/crep/emergency/EmergencyAlertOverlay.tsx
+++ b/components/crep/emergency/EmergencyAlertOverlay.tsx
@@ -23,7 +23,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
-  AlertTriangle, Radio, CloudRain, Phone, ExternalLink, MapPin, X, ChevronUp, ChevronDown, ShieldAlert, Navigation,
+  AlertTriangle, Radio, CloudRain, Phone, ExternalLink, MapPin, X, ChevronUp, ChevronDown, ShieldAlert, Navigation, Wind,
 } from "lucide-react";
 
 type Tier = "warning" | "watch" | "advisory" | "statement";
@@ -52,6 +52,25 @@ interface EmergencyAlert {
 type LatLng = { lat: number; lng: number };
 
 const POLL_MS = 45_000;
+
+interface WxState {
+  loading?: boolean; error?: boolean;
+  tempF?: number | null; tempUnit?: string; shortForecast?: string | null;
+  windSpeed?: string | null; windDirection?: string | null;
+  place?: string | null; icon?: string | null; radarUrl?: string | null;
+}
+
+// 5-min live-weather cache keyed by rounded point — re-renders + the 60s tick + 45s poll reuse it.
+const WX_CACHE = new Map<string, { at: number; data: WxState }>();
+
+/** Slippy-map tile x/y for a lat/lng/zoom — picks one RainViewer tile for the thumbnail. */
+function tileXY(lat: number, lng: number, z: number): { x: number; y: number } {
+  const n = 2 ** z;
+  const x = Math.floor(((lng + 180) / 360) * n);
+  const latRad = (lat * Math.PI) / 180;
+  const y = Math.floor(((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n);
+  return { x: Math.max(0, Math.min(n - 1, x)), y: Math.max(0, Math.min(n - 1, y)) };
+}
 
 /** Pop up only for genuine hazards — not routine advisories. Easy to tighten/loosen. */
 function isPopupWorthy(a: EmergencyAlert): boolean {
@@ -105,6 +124,8 @@ export default function EmergencyAlertOverlay() {
   const [lastChecked, setLastChecked] = useState<number>(0);
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
   const [minimized, setMinimized] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [wx, setWx] = useState<WxState | null>(null);
   const [, force] = useState(0); // re-render for countdown ticking
   const announced = useRef<Set<string>>(new Set());
 
@@ -189,6 +210,44 @@ export default function EmergencyAlertOverlay() {
   const rank = (a: EmergencyAlert) => (a.lifeThreatening ? 0 : a.tier === "warning" ? 1 : a.tier === "watch" ? 2 : a.tier === "statement" ? 3 : 4);
   active.sort((a, b) => rank(a) - rank(b));
   const lifeThreat = active.some((a) => a.lifeThreatening || a.tier === "warning");
+
+  // Point for the live-weather panel — computed BEFORE the early returns so the fetch hook
+  // below can use it (hooks can't run after a conditional return).
+  const panelTop = active[0];
+  const panelLoc: LatLng | null = panelTop ? ((panelTop._source === "gps" ? gps : mapCenter) ?? gps ?? mapCenter) : null;
+  const panelKey = panelLoc ? `${panelLoc.lat.toFixed(2)},${panelLoc.lng.toFixed(2)}` : null;
+
+  // ── Live weather (radar thumbnail + current NWS conditions) — fetched only on expand ──
+  useEffect(() => {
+    if (!expanded || !panelLoc || !panelKey) return;
+    const cached = WX_CACHE.get(panelKey);
+    if (cached && Date.now() - cached.at < 5 * 60_000) { setWx(cached.data); return; }
+    let cancelled = false;
+    setWx({ loading: true });
+    (async () => {
+      try {
+        const [wxRes, rv] = await Promise.all([
+          fetch(`/api/crep/weather-now?lat=${panelLoc.lat.toFixed(4)}&lng=${panelLoc.lng.toFixed(4)}`, { cache: "no-store" }).then((r) => r.json()).catch(() => null),
+          fetch("https://api.rainviewer.com/public/weather-maps.json", { cache: "no-store" }).then((r) => r.json()).catch(() => null),
+        ]);
+        if (cancelled) return;
+        let radarUrl: string | null = null;
+        try {
+          const host = rv?.host || "https://tilecache.rainviewer.com";
+          const past = Array.isArray(rv?.radar?.past) ? rv.radar.past : [];
+          const path = past[past.length - 1]?.path;
+          if (path) { const z = 6; const { x, y } = tileXY(panelLoc.lat, panelLoc.lng, z); radarUrl = `${host}${path}/256/${z}/${x}/${y}/4/1_1.png`; }
+        } catch { /* */ }
+        const data: WxState = (wxRes && wxRes.ok)
+          ? { tempF: wxRes.tempF, tempUnit: wxRes.tempUnit, shortForecast: wxRes.shortForecast, windSpeed: wxRes.windSpeed, windDirection: wxRes.windDirection, place: wxRes.place, icon: wxRes.icon, radarUrl }
+          : { error: true, radarUrl };
+        WX_CACHE.set(panelKey, { at: Date.now(), data });
+        setWx(data);
+      } catch { if (!cancelled) setWx({ error: true }); }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded, panelKey]);
 
   // ── Audible cue once per new life-threatening alert (best-effort) ────────
   useEffect(() => {
@@ -290,6 +349,50 @@ export default function EmergencyAlertOverlay() {
           {(top.instruction || top.headline) && (
             <div className="mt-2 rounded-md bg-black/25 p-2 max-h-24 overflow-y-auto text-xs leading-snug whitespace-pre-line">
               <span className="font-bold">What to do: </span>{top.instruction || top.headline}
+            </div>
+          )}
+
+          {/* LIVE WEATHER — radar thumbnail + current NWS conditions, fetched on expand */}
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="mt-2 w-full flex items-center justify-between rounded-md bg-black/25 px-2 py-1.5 text-xs font-bold hover:bg-black/35 transition-colors"
+          >
+            <span className="flex items-center gap-1.5"><CloudRain className="w-3.5 h-3.5" /> Live weather &amp; radar</span>
+            <ChevronDown className={`w-4 h-4 transition-transform ${expanded ? "rotate-180" : ""}`} />
+          </button>
+          {expanded && (
+            <div className="mt-1 rounded-md bg-black/25 p-2 flex gap-3">
+              {wx?.radarUrl && (
+                <div className="relative shrink-0 rounded overflow-hidden border border-white/20" style={{ width: 120, height: 120 }}>
+                  <img src={wx.radarUrl} alt="Radar" width={120} height={120} loading="lazy" decoding="async" className="block bg-slate-900" onError={(e) => { e.currentTarget.style.display = "none"; }} />
+                  <div className="absolute inset-0 flex items-center justify-center pointer-events-none"><div className="w-2 h-2 rounded-full bg-white ring-2 ring-red-500" /></div>
+                  <div className="absolute bottom-0 inset-x-0 bg-black/50 text-[8px] text-center py-px">Radar · RainViewer</div>
+                </div>
+              )}
+              <div className="flex-1 min-w-0 text-xs">
+                {wx?.loading ? (
+                  <div className="text-white/70">Loading live weather…</div>
+                ) : (wx?.error || wx?.tempF == null) ? (
+                  <div className="text-white/70">Live conditions unavailable — use the Local Forecast / Live Radar links below.</div>
+                ) : (
+                  <div className="space-y-0.5">
+                    {wx?.place && <div className="font-semibold truncate">{wx.place}</div>}
+                    <div className="flex items-center gap-2">
+                      {wx?.icon && <img src={wx.icon} alt="" width={28} height={28} className="rounded" onError={(e) => { e.currentTarget.style.display = "none"; }} />}
+                      <span className="text-2xl font-extrabold leading-none">{wx?.tempF != null ? `${wx.tempF}°${wx.tempUnit || "F"}` : "—"}</span>
+                    </div>
+                    {wx?.shortForecast && <div className="text-white/90">{wx.shortForecast}</div>}
+                    {wx?.windSpeed && <div className="flex items-center gap-1 text-white/80"><Wind className="w-3 h-3" />{wx.windSpeed}{wx.windDirection ? ` ${wx.windDirection}` : ""}</div>}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* full NWS alert text (verbatim) when expanded */}
+          {expanded && top.description && (
+            <div className="mt-1 rounded-md bg-black/25 p-2 max-h-40 overflow-y-auto text-[11px] leading-snug whitespace-pre-line text-white/90">
+              {top.description}
             </div>
           )}
 

--- a/components/crep/layers/rainviewer-radar-layer.tsx
+++ b/components/crep/layers/rainviewer-radar-layer.tsx
@@ -72,7 +72,7 @@ export default function RainViewerRadarLayer({ map, enabled, opacity = 0.7, fram
         const lid = `rainviewer-lyr-${i}`;
         const url = `${host}${f.path}/${TILE}/{z}/{x}/{y}/${COLOR_SCHEME}/${OPTIONS}.png`;
         try {
-          if (!m.getSource(sid)) m.addSource(sid, { type: "raster", tiles: [url], tileSize: TILE, attribution: "RainViewer" } as never);
+          if (!m.getSource(sid)) m.addSource(sid, { type: "raster", tiles: [url], tileSize: TILE, maxzoom: 11, attribution: "RainViewer" } as never);
           sourceIds.push(sid);
           if (!m.getLayer(lid)) {
             m.addLayer({

--- a/components/crep/layers/rainviewer-radar-layer.tsx
+++ b/components/crep/layers/rainviewer-radar-layer.tsx
@@ -72,12 +72,19 @@ export default function RainViewerRadarLayer({ map, enabled, opacity = 0.7, fram
         const lid = `rainviewer-lyr-${i}`;
         const url = `${host}${f.path}/${TILE}/{z}/{x}/{y}/${COLOR_SCHEME}/${OPTIONS}.png`;
         try {
-          if (!m.getSource(sid)) m.addSource(sid, { type: "raster", tiles: [url], tileSize: TILE, maxzoom: 11, attribution: "RainViewer" } as never);
+          // RainViewer's radar mosaic only has data through zoom 7. Requesting z8+ returns a
+          // literal gray "Zoom Level Not Supported" placeholder PNG. Declaring maxzoom: 7 makes
+          // MapLibre upscale the z7 tile at every higher zoom (blurry-but-present radar, like all
+          // other weather maps) instead of fetching the placeholder. THIS is the fix for the boxes.
+          if (!m.getSource(sid)) m.addSource(sid, { type: "raster", tiles: [url], tileSize: TILE, maxzoom: 7, attribution: "RainViewer" } as never);
           sourceIds.push(sid);
           if (!m.getLayer(lid)) {
             m.addLayer({
               id: lid, type: "raster", source: sid,
-              paint: { "raster-opacity": i === idx ? opacity : 0, "raster-opacity-transition": { duration: 220 }, "raster-fade-duration": 0 },
+              // Hard-cut frame swaps: only the single visible frame ever paints (MapLibre skips
+              // raster layers at opacity 0), and there is NO continuous opacity transition pinning
+              // the map in a repaint loop. Big FPS win + reads as more obviously animated.
+              paint: { "raster-opacity": i === idx ? opacity : 0, "raster-opacity-transition": { duration: 0 }, "raster-fade-duration": 0 },
             }, beforeId);
           }
           layerIds.push(lid);

--- a/components/crep/layers/rainviewer-radar-layer.tsx
+++ b/components/crep/layers/rainviewer-radar-layer.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * Live animated weather radar (RainViewer) for the Earth Simulator MapLibre map.
+ *
+ * Fetches RainViewer's public weather-maps manifest (past + nowcast radar frames) and
+ * renders them as stacked MapLibre raster layers, cycling opacity frame-by-frame so the
+ * precipitation visibly MOVES — "live weather motion". Tiles are browser-cached after the
+ * first loop, so the animation is smooth. No API key.
+ *
+ * Mount one of these gated by a toggle: <RainViewerRadarLayer map={mapRef} enabled={on} />.
+ * Self-cleans on disable/unmount (removes every layer + source, stops the timer).
+ */
+
+import { useEffect, useRef } from "react";
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+type MapLike = MapLibreMap | { current: MapLibreMap | null } | null | undefined;
+
+interface Props {
+  map: MapLike;
+  enabled: boolean;
+  opacity?: number;
+  /** ms per frame — lower = faster weather motion. */
+  frameMs?: number;
+}
+
+const RAINVIEWER_API = "https://api.rainviewer.com/public/weather-maps.json";
+const TILE = 256;
+const COLOR_SCHEME = 4;   // "The Weather Channel" palette — readable on a dark basemap
+const OPTIONS = "1_1";    // smooth + snow
+
+function resolveMap(m: MapLike): MapLibreMap | null {
+  if (!m) return null;
+  if (typeof (m as MapLibreMap).getStyle === "function") return m as MapLibreMap;
+  return (m as { current?: MapLibreMap | null }).current ?? null;
+}
+
+export default function RainViewerRadarLayer({ map, enabled, opacity = 0.7, frameMs = 500 }: Props) {
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    const m = resolveMap(map);
+    if (!m || !enabled) return;
+    let cancelled = false;
+    const layerIds: string[] = [];
+    const sourceIds: string[] = [];
+    let idx = 0;
+
+    const stopTimer = () => { if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; } };
+
+    const removeAll = () => {
+      stopTimer();
+      for (const id of layerIds) { try { if (m.getLayer(id)) m.removeLayer(id); } catch { /* */ } }
+      for (const id of sourceIds) { try { if (m.getSource(id)) m.removeSource(id); } catch { /* */ } }
+      layerIds.length = 0; sourceIds.length = 0;
+    };
+
+    const showFrame = (i: number) => {
+      for (let j = 0; j < layerIds.length; j++) {
+        try { m.setPaintProperty(layerIds[j], "raster-opacity", j === i ? opacity : 0); } catch { /* */ }
+      }
+    };
+
+    const build = (host: string, frames: Array<{ time: number; path: string }>) => {
+      if (cancelled || frames.length === 0) return;
+      // Keep radar beneath the labels/markers (first symbol layer) so it never covers icons.
+      let beforeId: string | undefined;
+      try { beforeId = m.getStyle().layers?.find((l: { type?: string }) => l.type === "symbol")?.id; } catch { /* */ }
+      frames.forEach((f, i) => {
+        const sid = `rainviewer-src-${i}`;
+        const lid = `rainviewer-lyr-${i}`;
+        const url = `${host}${f.path}/${TILE}/{z}/{x}/{y}/${COLOR_SCHEME}/${OPTIONS}.png`;
+        try {
+          if (!m.getSource(sid)) m.addSource(sid, { type: "raster", tiles: [url], tileSize: TILE, attribution: "RainViewer" } as never);
+          sourceIds.push(sid);
+          if (!m.getLayer(lid)) {
+            m.addLayer({
+              id: lid, type: "raster", source: sid,
+              paint: { "raster-opacity": i === idx ? opacity : 0, "raster-opacity-transition": { duration: 220 }, "raster-fade-duration": 0 },
+            }, beforeId);
+          }
+          layerIds.push(lid);
+        } catch { /* */ }
+      });
+      showFrame(idx);
+      stopTimer();
+      timerRef.current = setInterval(() => {
+        if (cancelled || layerIds.length === 0) return;
+        idx = (idx + 1) % layerIds.length;
+        showFrame(idx);
+      }, Math.max(150, frameMs));
+    };
+
+    (async () => {
+      try {
+        const res = await fetch(RAINVIEWER_API, { cache: "no-store" });
+        if (!res.ok) return;
+        const d = await res.json();
+        const host: string = d?.host || "https://tilecache.rainviewer.com";
+        const past = Array.isArray(d?.radar?.past) ? d.radar.past : [];
+        const nowcast = Array.isArray(d?.radar?.nowcast) ? d.radar.nowcast : [];
+        const frames = [...past, ...nowcast].slice(-12);
+        if (cancelled) return;
+        const start = () => build(host, frames);
+        if (m.isStyleLoaded?.()) start(); else m.once("idle", start);
+      } catch { /* */ }
+    })();
+
+    return () => { cancelled = true; removeAll(); };
+  }, [map, enabled, opacity, frameMs]);
+
+  return null;
+}

--- a/components/crep/layers/rainviewer-radar-layer.tsx
+++ b/components/crep/layers/rainviewer-radar-layer.tsx
@@ -81,10 +81,10 @@ export default function RainViewerRadarLayer({ map, enabled, opacity = 0.7, fram
           if (!m.getLayer(lid)) {
             m.addLayer({
               id: lid, type: "raster", source: sid,
-              // Hard-cut frame swaps: only the single visible frame ever paints (MapLibre skips
-              // raster layers at opacity 0), and there is NO continuous opacity transition pinning
-              // the map in a repaint loop. Big FPS win + reads as more obviously animated.
-              paint: { "raster-opacity": i === idx ? opacity : 0, "raster-opacity-transition": { duration: 0 }, "raster-fade-duration": 0 },
+              // Smooth crossfade between frames (280ms over the 500ms cadence) so precipitation
+              // dissolves frame-to-frame instead of hard-cutting. Only ~2 of the 12 light raster
+              // layers paint during a transition, so the cost is trivial next to the movers.
+              paint: { "raster-opacity": i === idx ? opacity : 0, "raster-opacity-transition": { duration: 280 }, "raster-fade-duration": 0 },
             }, beforeId);
           }
           layerIds.push(lid);

--- a/components/crep/layers/rainviewer-radar-layer.tsx
+++ b/components/crep/layers/rainviewer-radar-layer.tsx
@@ -99,7 +99,7 @@ export default function RainViewerRadarLayer({ map, enabled, opacity = 0.7, fram
       }, Math.max(150, frameMs));
     };
 
-    (async () => {
+    const loadAndBuild = async () => {
       try {
         const res = await fetch(RAINVIEWER_API, { cache: "no-store" });
         if (!res.ok) return;
@@ -108,13 +108,20 @@ export default function RainViewerRadarLayer({ map, enabled, opacity = 0.7, fram
         const past = Array.isArray(d?.radar?.past) ? d.radar.past : [];
         const nowcast = Array.isArray(d?.radar?.nowcast) ? d.radar.nowcast : [];
         const frames = [...past, ...nowcast].slice(-12);
-        if (cancelled) return;
+        if (cancelled || frames.length === 0) return;
+        removeAll();   // drop the previous frame set, then rebuild with the fresh radar
+        idx = 0;
         const start = () => build(host, frames);
         if (m.isStyleLoaded?.()) start(); else m.once("idle", start);
       } catch { /* */ }
-    })();
+    };
 
-    return () => { cancelled = true; removeAll(); };
+    loadAndBuild();
+    // Pull fresh RainViewer frames every 5 min so a user who sits on the page keeps seeing NEW
+    // radar (RainViewer publishes a new past/nowcast frame every ~10 min) — not a frozen loop.
+    const refreshTimer = setInterval(loadAndBuild, 5 * 60_000);
+
+    return () => { cancelled = true; clearInterval(refreshTimer); removeAll(); };
   }, [map, enabled, opacity, frameMs]);
 
   return null;

--- a/components/crep/layers/realistic-cloud-layer.tsx
+++ b/components/crep/layers/realistic-cloud-layer.tsx
@@ -240,10 +240,10 @@ export default function RealisticCloudLayer({
                 tileSize: 256,
                 attribution: "© RainViewer.com",
                 minzoom: 0,
-                // maxzoom=12 tells MapLibre to overzoom (auto-stretch)
-                // instead of requesting non-existent tiles. Upstream
-                // RainViewer publishes through zoom 12.
-                maxzoom: 12,
+                // RainViewer radar data only exists through zoom 7; z8+ returns
+                // a literal "Zoom Level Not Supported" placeholder PNG. maxzoom: 7
+                // makes MapLibre upscale the z7 tile at higher zooms instead.
+                maxzoom: 7,
               })
               const style = map.getStyle()
               const beforeId = style.layers.find((l: any) => l.type === "symbol")?.id

--- a/components/crep/layers/storm-lightning-layer.tsx
+++ b/components/crep/layers/storm-lightning-layer.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * Storm lightning — animated jagged bolts + ground flashes over REAL active NWS
+ * thunderstorm/tornado warning cells (from /api/crep/storm-cells), with optional thunder.
+ * Keyless and reliable: lightning only appears where a genuine NWS warning is active.
+ *
+ * Perf: a single rAF loop, only while enabled; spawns sparse bolts (each ~180ms) into two
+ * GeoJSON sources; thunder is gated to in-viewport strikes, throttled, and off by default
+ * (browser autoplay needs a gesture). Self-cleans on disable/unmount.
+ */
+
+import { useEffect, useRef } from "react";
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+type MapLike = MapLibreMap | { current: MapLibreMap | null } | null | undefined;
+interface Props { map: MapLike; enabled: boolean; sound?: boolean }
+
+interface Cell { centroid: [number, number]; bbox: [number, number, number, number]; polygon: [number, number][] }
+interface Bolt { line: [number, number][]; born: number; flash: [number, number] }
+
+const BOLT_SRC = "storm-lightning-bolts";
+const BOLT_LYR = "storm-lightning-bolt-line";
+const GLOW_LYR = "storm-lightning-bolt-glow";
+const FLASH_SRC = "storm-lightning-flash";
+const FLASH_LYR = "storm-lightning-flash-circle";
+const BOLT_LIFE = 180; // ms
+
+function resolveMap(m: MapLike): MapLibreMap | null {
+  if (!m) return null;
+  if (typeof (m as MapLibreMap).getStyle === "function") return m as MapLibreMap;
+  return (m as { current?: MapLibreMap | null }).current ?? null;
+}
+
+function inPoly(x: number, y: number, poly: [number, number][]): boolean {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i][0], yi = poly[i][1], xj = poly[j][0], yj = poly[j][1];
+    if (((yi > y) !== (yj > y)) && (x < ((xj - xi) * (y - yi)) / (yj - yi) + xi)) inside = !inside;
+  }
+  return inside;
+}
+
+export default function StormLightningLayer({ map, enabled, sound = false }: Props) {
+  const rafRef = useRef<number | null>(null);
+  const cellsRef = useRef<Cell[]>([]);
+  const boltsRef = useRef<Bolt[]>([]);
+  const lastThunderRef = useRef(0);
+  const soundRef = useRef(sound);
+  soundRef.current = sound;
+
+  useEffect(() => {
+    const m = resolveMap(map);
+    if (!m || !enabled) return;
+    let cancelled = false;
+    let audioCtx: AudioContext | null = null;
+    let lastSpawn = 0;
+
+    const ensureLayers = () => {
+      try {
+        if (!m.getSource(BOLT_SRC)) m.addSource(BOLT_SRC, { type: "geojson", data: { type: "FeatureCollection", features: [] } } as never);
+        if (!m.getSource(FLASH_SRC)) m.addSource(FLASH_SRC, { type: "geojson", data: { type: "FeatureCollection", features: [] } } as never);
+        if (!m.getLayer(FLASH_LYR)) m.addLayer({ id: FLASH_LYR, type: "circle", source: FLASH_SRC, paint: { "circle-color": "#e0e7ff", "circle-opacity": 0.35, "circle-radius": ["get", "r"], "circle-blur": 1 } });
+        if (!m.getLayer(GLOW_LYR)) m.addLayer({ id: GLOW_LYR, type: "line", source: BOLT_SRC, paint: { "line-color": "#a5b4fc", "line-width": 6, "line-opacity": 0.5, "line-blur": 4 } });
+        if (!m.getLayer(BOLT_LYR)) m.addLayer({ id: BOLT_LYR, type: "line", source: BOLT_SRC, paint: { "line-color": "#ffffff", "line-width": 1.8 } });
+      } catch { /* */ }
+    };
+
+    const removeLayers = () => {
+      for (const id of [BOLT_LYR, GLOW_LYR, FLASH_LYR]) { try { if (m.getLayer(id)) m.removeLayer(id); } catch { /* */ } }
+      for (const id of [BOLT_SRC, FLASH_SRC]) { try { if (m.getSource(id)) m.removeSource(id); } catch { /* */ } }
+    };
+
+    const fetchCells = async () => {
+      try {
+        const r = await fetch("/api/crep/storm-cells", { cache: "no-store" });
+        const d = await r.json();
+        if (!cancelled && d?.ok) cellsRef.current = Array.isArray(d.cells) ? d.cells : [];
+      } catch { /* */ }
+    };
+
+    // jagged near-vertical bolt rising from a ground point
+    const makeBolt = (lng: number, lat: number): [number, number][] => {
+      const segs = 5, h = 0.14 + Math.random() * 0.10;
+      const pts: [number, number][] = [];
+      for (let i = 0; i <= segs; i++) { const t = i / segs; const j = (Math.random() - 0.5) * 0.045 * (1 - t); pts.push([lng + j, lat + h * t]); }
+      return pts;
+    };
+
+    const thunder = () => {
+      if (!soundRef.current) return;
+      try {
+        const C = (window as unknown as { AudioContext?: typeof AudioContext; webkitAudioContext?: typeof AudioContext });
+        const Ctor = C.AudioContext || C.webkitAudioContext;
+        if (!Ctor) return;
+        if (!audioCtx) audioCtx = new Ctor();
+        const ctx = audioCtx; const dur = 1.8;
+        const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * dur), ctx.sampleRate);
+        const ch = buf.getChannelData(0);
+        for (let i = 0; i < ch.length; i++) ch[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / ch.length, 2);
+        const src = ctx.createBufferSource(); src.buffer = buf;
+        const lp = ctx.createBiquadFilter(); lp.type = "lowpass";
+        lp.frequency.setValueAtTime(700, ctx.currentTime); lp.frequency.exponentialRampToValueAtTime(120, ctx.currentTime + dur);
+        const g = ctx.createGain();
+        g.gain.setValueAtTime(0.0001, ctx.currentTime);
+        g.gain.exponentialRampToValueAtTime(0.5, ctx.currentTime + 0.05);
+        g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + dur);
+        src.connect(lp); lp.connect(g); g.connect(ctx.destination); src.start();
+      } catch { /* */ }
+    };
+
+    const frame = () => {
+      if (cancelled) return;
+      const now = Date.now();
+      const cells = cellsRef.current;
+      if (cells.length > 0 && now - lastSpawn > 90 && Math.random() < Math.min(0.9, 0.15 * cells.length)) {
+        lastSpawn = now;
+        const cell = cells[Math.floor(Math.random() * cells.length)];
+        let lng = cell.centroid[0], lat = cell.centroid[1];
+        for (let k = 0; k < 6; k++) {
+          const x = cell.bbox[0] + Math.random() * (cell.bbox[2] - cell.bbox[0]);
+          const y = cell.bbox[1] + Math.random() * (cell.bbox[3] - cell.bbox[1]);
+          if (inPoly(x, y, cell.polygon)) { lng = x; lat = y; break; }
+        }
+        boltsRef.current.push({ line: makeBolt(lng, lat - 0.16), born: now, flash: [lng, lat] });
+        try { const b = m.getBounds(); if (soundRef.current && b.contains([lng, lat]) && now - lastThunderRef.current > 2500) { lastThunderRef.current = now; thunder(); } } catch { /* */ }
+      }
+      boltsRef.current = boltsRef.current.filter((b) => now - b.born < BOLT_LIFE);
+      try {
+        (m.getSource(BOLT_SRC) as { setData?: (d: unknown) => void } | undefined)?.setData?.({
+          type: "FeatureCollection",
+          features: boltsRef.current.map((b) => ({ type: "Feature", geometry: { type: "LineString", coordinates: b.line }, properties: {} })),
+        });
+        (m.getSource(FLASH_SRC) as { setData?: (d: unknown) => void } | undefined)?.setData?.({
+          type: "FeatureCollection",
+          features: boltsRef.current.map((b) => { const age = (now - b.born) / BOLT_LIFE; return { type: "Feature", geometry: { type: "Point", coordinates: b.flash }, properties: { r: 6 + age * 22 } }; }),
+        });
+      } catch { /* */ }
+      rafRef.current = requestAnimationFrame(frame);
+    };
+
+    const start = () => { if (cancelled) return; ensureLayers(); fetchCells(); frame(); };
+    if (m.isStyleLoaded?.()) start(); else m.once("idle", start);
+    const poll = window.setInterval(fetchCells, 120_000);
+
+    return () => {
+      cancelled = true;
+      if (rafRef.current) { try { cancelAnimationFrame(rafRef.current); } catch { /* */ } }
+      window.clearInterval(poll);
+      try { audioCtx?.close(); } catch { /* */ }
+      removeLayers();
+      boltsRef.current = []; cellsRef.current = [];
+    };
+  }, [map, enabled]);
+
+  return null;
+}

--- a/components/crep/layers/storm-lightning-layer.tsx
+++ b/components/crep/layers/storm-lightning-layer.tsx
@@ -109,33 +109,49 @@ export default function StormLightningLayer({ map, enabled, sound = false }: Pro
       } catch { /* */ }
     };
 
+    // ~30fps cap: bolts are brief flashes, so 60fps is wasteful. Critically, we ONLY call
+    // setData (which forces a full-map repaint) when the visible bolt set actually changes —
+    // a bolt spawned, one expired, or bolts are alive (flash circles grow each tick). With no
+    // storm cells in view the loop goes fully idle: the rAF just ticks a clock, the map never
+    // repaints. This is what keeps lightning from pinning the whole globe at <1 FPS.
+    let lastTick = 0;
+    const TICK_MS = 33;
     const frame = () => {
       if (cancelled) return;
       const now = Date.now();
-      const cells = cellsRef.current;
-      if (cells.length > 0 && now - lastSpawn > 90 && Math.random() < Math.min(0.9, 0.15 * cells.length)) {
-        lastSpawn = now;
-        const cell = cells[Math.floor(Math.random() * cells.length)];
-        let lng = cell.centroid[0], lat = cell.centroid[1];
-        for (let k = 0; k < 6; k++) {
-          const x = cell.bbox[0] + Math.random() * (cell.bbox[2] - cell.bbox[0]);
-          const y = cell.bbox[1] + Math.random() * (cell.bbox[3] - cell.bbox[1]);
-          if (inPoly(x, y, cell.polygon)) { lng = x; lat = y; break; }
+      if (now - lastTick >= TICK_MS) {
+        lastTick = now;
+        const cells = cellsRef.current;
+        let spawned = false;
+        if (cells.length > 0 && now - lastSpawn > 90 && Math.random() < Math.min(0.9, 0.15 * cells.length)) {
+          lastSpawn = now;
+          const cell = cells[Math.floor(Math.random() * cells.length)];
+          let lng = cell.centroid[0], lat = cell.centroid[1];
+          for (let k = 0; k < 6; k++) {
+            const x = cell.bbox[0] + Math.random() * (cell.bbox[2] - cell.bbox[0]);
+            const y = cell.bbox[1] + Math.random() * (cell.bbox[3] - cell.bbox[1]);
+            if (inPoly(x, y, cell.polygon)) { lng = x; lat = y; break; }
+          }
+          boltsRef.current.push({ line: makeBolt(lng, lat - 0.16), born: now, flash: [lng, lat] });
+          spawned = true;
+          try { const b = m.getBounds(); if (soundRef.current && b.contains([lng, lat]) && now - lastThunderRef.current > 2500) { lastThunderRef.current = now; thunder(); } } catch { /* */ }
         }
-        boltsRef.current.push({ line: makeBolt(lng, lat - 0.16), born: now, flash: [lng, lat] });
-        try { const b = m.getBounds(); if (soundRef.current && b.contains([lng, lat]) && now - lastThunderRef.current > 2500) { lastThunderRef.current = now; thunder(); } } catch { /* */ }
+        const before = boltsRef.current.length;
+        boltsRef.current = boltsRef.current.filter((b) => now - b.born < BOLT_LIFE);
+        const expired = boltsRef.current.length !== before;
+        if (spawned || expired || boltsRef.current.length > 0) {
+          try {
+            (m.getSource(BOLT_SRC) as { setData?: (d: unknown) => void } | undefined)?.setData?.({
+              type: "FeatureCollection",
+              features: boltsRef.current.map((b) => ({ type: "Feature", geometry: { type: "LineString", coordinates: b.line }, properties: {} })),
+            });
+            (m.getSource(FLASH_SRC) as { setData?: (d: unknown) => void } | undefined)?.setData?.({
+              type: "FeatureCollection",
+              features: boltsRef.current.map((b) => { const age = (now - b.born) / BOLT_LIFE; return { type: "Feature", geometry: { type: "Point", coordinates: b.flash }, properties: { r: 6 + age * 22 } }; }),
+            });
+          } catch { /* */ }
+        }
       }
-      boltsRef.current = boltsRef.current.filter((b) => now - b.born < BOLT_LIFE);
-      try {
-        (m.getSource(BOLT_SRC) as { setData?: (d: unknown) => void } | undefined)?.setData?.({
-          type: "FeatureCollection",
-          features: boltsRef.current.map((b) => ({ type: "Feature", geometry: { type: "LineString", coordinates: b.line }, properties: {} })),
-        });
-        (m.getSource(FLASH_SRC) as { setData?: (d: unknown) => void } | undefined)?.setData?.({
-          type: "FeatureCollection",
-          features: boltsRef.current.map((b) => { const age = (now - b.born) / BOLT_LIFE; return { type: "Feature", geometry: { type: "Point", coordinates: b.flash }, properties: { r: 6 + age * 22 } }; }),
-        });
-      } catch { /* */ }
       rafRef.current = requestAnimationFrame(frame);
     };
 

--- a/components/crep/perf/FpsAutoGovernor.tsx
+++ b/components/crep/perf/FpsAutoGovernor.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * FPS auto-governor — keeps the Earth Simulator above a usable frame rate by progressively
+ * shedding the HEAVIEST non-essential layers when the user's live FPS stays below target, then
+ * restoring them when it recovers.
+ *
+ * Why this exists: on desktop the map runs near-uncapped, so with everything on (~6,500 animated
+ * movers — satellites + orbit ribbons, vessels, aircraft — plus 200+ map layers) the frame rate
+ * can collapse to single digits. This sheds load automatically so the map never stays unusable.
+ *
+ * HARD RULE: it NEVER touches fungal / nature / observation / emergency data — only the heavy
+ * "background" movers and dense global infrastructure, in a fixed order.
+ *
+ * Safety:
+ *   • Only acts on a genuinely-rendering-but-slow map. A backgrounded/again-focused tab throttles
+ *     rAF (frameMs balloons), which we ignore so we don't shed while you're on another tab.
+ *   • Hysteresis (shed below LOW, restore above RECOVER, with consecutive-sample streaks) prevents
+ *     flapping.
+ *   • Only restores layers IT turned off — never fights a layer you toggled yourself.
+ */
+
+// Heaviest / least-essential → lightest. One step shed per sustained-low window; restored in reverse.
+const SHED_ORDER: string[][] = [
+  ["satellites"],                                                       // ~1,130 sats + 376 orbit ribbons re-animated every frame
+  ["ships"],                                                            // ~2,500 AIS vessels
+  ["aviation"],                                                         // ~2,500 aircraft
+  ["txLinesFull", "txLinesGlobal", "submarineCables", "cellTowersG", "dataCentersG"], // dense global infra
+];
+
+const LOW = 26;       // sustained below this → shed a step (target floor is 30)
+const RECOVER = 44;   // sustained above this → restore a step (gap from LOW avoids flapping)
+const CHECK_MS = 2000;
+
+type LayerState = { id: string; enabled: boolean };
+
+export default function FpsAutoGovernor() {
+  const level = useRef(0);                       // how many shed steps are currently applied
+  const shedByUs = useRef<Set<string>>(new Set()); // layers WE disabled (only restore these)
+  const lowStreak = useRef(0);
+  const highStreak = useRef(0);
+
+  useEffect(() => {
+    const w = window as unknown as {
+      __crep_fps?: { fps?: number; frameMs?: number };
+      __crep_setLayer?: (id: string, on?: boolean) => unknown;
+      __crep_layers?: () => LayerState[];
+    };
+    const setLayer = (id: string, on: boolean) => { try { w.__crep_setLayer?.(id, on); } catch { /* */ } };
+    const layerState = () => { try { return w.__crep_layers?.(); } catch { return undefined; } };
+
+    const tick = () => {
+      const f = w.__crep_fps;
+      const fps = typeof f?.fps === "number" ? f.fps : null;
+      const frameMs = typeof f?.frameMs === "number" ? f.frameMs : null;
+      // Ignore backgrounded / throttled tabs (rAF clamped → frameMs balloons). Only act on a
+      // map that is actually rendering but slow.
+      if (fps == null || frameMs == null || frameMs > 1500) return;
+
+      if (fps < LOW) { lowStreak.current++; highStreak.current = 0; }
+      else if (fps > RECOVER) { highStreak.current++; lowStreak.current = 0; }
+      else { lowStreak.current = 0; highStreak.current = 0; }
+
+      // Shed the next-heaviest group after 2 consecutive low samples.
+      if (lowStreak.current >= 2 && level.current < SHED_ORDER.length) {
+        const group = SHED_ORDER[level.current];
+        const st = layerState();
+        for (const id of group) {
+          const cur = st?.find((l) => l.id === id);
+          if (!cur || cur.enabled) { setLayer(id, false); shedByUs.current.add(id); }
+        }
+        level.current++;
+        lowStreak.current = 0;
+        // eslint-disable-next-line no-console
+        console.log(`[FPS-Governor] ${Math.round(fps)} fps < ${LOW} → shed [${group.join(", ")}] (level ${level.current})`);
+      }
+
+      // Restore one group after 3 consecutive healthy samples.
+      if (highStreak.current >= 3 && level.current > 0) {
+        level.current--;
+        const group = SHED_ORDER[level.current];
+        for (const id of group) {
+          if (shedByUs.current.has(id)) { setLayer(id, true); shedByUs.current.delete(id); }
+        }
+        highStreak.current = 0;
+        // eslint-disable-next-line no-console
+        console.log(`[FPS-Governor] ${Math.round(fps)} fps recovered → restore [${group.join(", ")}] (level ${level.current})`);
+      }
+    };
+
+    const iv = window.setInterval(tick, CHECK_MS);
+    return () => window.clearInterval(iv);
+  }, []);
+
+  return null;
+}

--- a/components/crep/perf/FpsAutoGovernor.tsx
+++ b/components/crep/perf/FpsAutoGovernor.tsx
@@ -67,7 +67,10 @@ export default function FpsAutoGovernor() {
       const f = w.__crep_fps;
       const fps = typeof f?.fps === "number" ? f.fps : null;
       const frameMs = typeof f?.frameMs === "number" ? f.frameMs : null;
-      if (fps == null || frameMs == null || frameMs > 1500) return;   // throttled/idle tab — skip
+      // document.hidden (above) is the reliable "backgrounded" signal; this frameMs backstop only
+      // skips a truly frozen/paused tab (>5s/frame), NOT a genuinely slow-but-active map — a real
+      // 1–5 fps map is exactly when we most need to shed.
+      if (fps == null || frameMs == null || frameMs > 5000) return;
 
       if (fps < LOW) { lowStreak.current++; highStreak.current = 0; }
       else if (fps > RECOVER) { highStreak.current++; lowStreak.current = 0; }

--- a/components/crep/perf/FpsAutoGovernor.tsx
+++ b/components/crep/perf/FpsAutoGovernor.tsx
@@ -7,27 +7,33 @@ import { useEffect, useRef } from "react";
  * shedding the HEAVIEST non-essential layers when the user's live FPS stays below target, then
  * restoring them when it recovers.
  *
- * Why this exists: on desktop the map runs near-uncapped, so with everything on (~6,500 animated
- * movers — satellites + orbit ribbons, vessels, aircraft — plus 200+ map layers) the frame rate
- * can collapse to single digits. This sheds load automatically so the map never stays unusable.
+ * Why this exists: on desktop the map runs near-uncapped, so with everything on (measured 3 fps /
+ * 338 ms-per-frame) the frame rate collapses. A differential showed the ~6,500 animated movers are
+ * ~125 ms/frame (~37%); the rest is the aggregate of 144 enabled layers (especially the ~100
+ * off-view regional infra packs) + DOM markers. So no single asset is "the" killer — it's having
+ * everything on — and the fix is to shed load progressively until the frame rate is usable.
  *
- * HARD RULE: it NEVER touches fungal / nature / observation / emergency data — only the heavy
- * "background" movers and dense global infrastructure, in a fixed order.
+ * Shed order (heaviest / least-essential first): satellites → vessels → aircraft → off-view
+ * regional infra packs → dense global infrastructure. Restored in reverse on recovery.
  *
- * Safety:
- *   • Only acts on a genuinely-rendering-but-slow map. A backgrounded/again-focused tab throttles
- *     rAF (frameMs balloons), which we ignore so we don't shed while you're on another tab.
- *   • Hysteresis (shed below LOW, restore above RECOVER, with consecutive-sample streaks) prevents
- *     flapping.
- *   • Only restores layers IT turned off — never fights a layer you toggled yourself.
+ * HARD RULE: it NEVER touches fungal / nature / observation / device / emergency / weather data —
+ * the PROTECTED guard excludes those ids at every level.
+ *
+ * Safety: ignores backgrounded tabs (document.hidden + throttled frameMs) so it never sheds while
+ * you're away; hysteresis (shed < LOW, restore > RECOVER, with sample streaks) avoids flapping; it
+ * only ever restores layers IT disabled, so it never fights a layer you toggled yourself.
  */
 
+// Never shed these — fungal/nature/observation + Mycosoft devices + emergency/weather safety layers.
+const PROTECTED = /fungi|fungal|biodiversity|mycel|myco|nature|observ|spore|weatherradar|stormlightning|emergenc|sporebase|smartfence/i;
+
 // Heaviest / least-essential → lightest. One step shed per sustained-low window; restored in reverse.
-const SHED_ORDER: string[][] = [
-  ["satellites"],                                                       // ~1,130 sats + 376 orbit ribbons re-animated every frame
-  ["ships"],                                                            // ~2,500 AIS vessels
-  ["aviation"],                                                         // ~2,500 aircraft
-  ["txLinesFull", "txLinesGlobal", "submarineCables", "cellTowersG", "dataCentersG"], // dense global infra
+const SHED_ORDER: Array<{ label: string; match: (id: string) => boolean }> = [
+  { label: "satellites",           match: (id) => id === "satellites" },                                   // ~1,130 sats + 376 orbit ribbons
+  { label: "vessels",              match: (id) => id === "ships" },                                        // ~2,500 AIS vessels
+  { label: "aircraft",             match: (id) => id === "aviation" },                                     // ~2,500 aircraft
+  { label: "regional infra packs", match: (id) => /^(oyster|mojave|nyc|dc|vegas|sdtj|project)/.test(id) }, // off-view city/region detail packs (~100 layers)
+  { label: "dense global infra",   match: (id) => /^(txLines|submarineCables|cellTowersG|dataCentersG|powerPlantsG|substations|radioStations)/.test(id) },
 ];
 
 const LOW = 26;       // sustained below this → shed a step (target floor is 30)
@@ -37,8 +43,8 @@ const CHECK_MS = 2000;
 type LayerState = { id: string; enabled: boolean };
 
 export default function FpsAutoGovernor() {
-  const level = useRef(0);                       // how many shed steps are currently applied
-  const shedByUs = useRef<Set<string>>(new Set()); // layers WE disabled (only restore these)
+  const level = useRef(0);                  // how many shed steps are currently applied
+  const shedByUs = useRef<string[][]>([]);  // exact ids WE disabled, per level (only restore these)
   const lowStreak = useRef(0);
   const highStreak = useRef(0);
 
@@ -49,15 +55,14 @@ export default function FpsAutoGovernor() {
       __crep_layers?: () => LayerState[];
     };
     const setLayer = (id: string, on: boolean) => { try { w.__crep_setLayer?.(id, on); } catch { /* */ } };
-    const layerState = () => { try { return w.__crep_layers?.(); } catch { return undefined; } };
+    const layerState = () => { try { return w.__crep_layers?.() ?? []; } catch { return []; } };
 
     const tick = () => {
+      if (typeof document !== "undefined" && document.hidden) return; // never shed a backgrounded tab
       const f = w.__crep_fps;
       const fps = typeof f?.fps === "number" ? f.fps : null;
       const frameMs = typeof f?.frameMs === "number" ? f.frameMs : null;
-      // Ignore backgrounded / throttled tabs (rAF clamped → frameMs balloons). Only act on a
-      // map that is actually rendering but slow.
-      if (fps == null || frameMs == null || frameMs > 1500) return;
+      if (fps == null || frameMs == null || frameMs > 1500) return;   // throttled/idle tab — skip
 
       if (fps < LOW) { lowStreak.current++; highStreak.current = 0; }
       else if (fps > RECOVER) { highStreak.current++; lowStreak.current = 0; }
@@ -65,28 +70,27 @@ export default function FpsAutoGovernor() {
 
       // Shed the next-heaviest group after 2 consecutive low samples.
       if (lowStreak.current >= 2 && level.current < SHED_ORDER.length) {
-        const group = SHED_ORDER[level.current];
-        const st = layerState();
-        for (const id of group) {
-          const cur = st?.find((l) => l.id === id);
-          if (!cur || cur.enabled) { setLayer(id, false); shedByUs.current.add(id); }
+        const step = SHED_ORDER[level.current];
+        const shed: string[] = [];
+        for (const l of layerState()) {
+          if (l.enabled && !PROTECTED.test(l.id) && step.match(l.id)) { setLayer(l.id, false); shed.push(l.id); }
         }
+        shedByUs.current[level.current] = shed;
         level.current++;
         lowStreak.current = 0;
         // eslint-disable-next-line no-console
-        console.log(`[FPS-Governor] ${Math.round(fps)} fps < ${LOW} → shed [${group.join(", ")}] (level ${level.current})`);
+        console.log(`[FPS-Governor] ${Math.round(fps)} fps < ${LOW} → shed ${shed.length} layer(s): ${step.label} (level ${level.current})`);
       }
 
       // Restore one group after 3 consecutive healthy samples.
       if (highStreak.current >= 3 && level.current > 0) {
         level.current--;
-        const group = SHED_ORDER[level.current];
-        for (const id of group) {
-          if (shedByUs.current.has(id)) { setLayer(id, true); shedByUs.current.delete(id); }
-        }
+        const shed = shedByUs.current[level.current] || [];
+        for (const id of shed) setLayer(id, true);
+        shedByUs.current[level.current] = [];
         highStreak.current = 0;
         // eslint-disable-next-line no-console
-        console.log(`[FPS-Governor] ${Math.round(fps)} fps recovered → restore [${group.join(", ")}] (level ${level.current})`);
+        console.log(`[FPS-Governor] ${Math.round(fps)} fps recovered → restore ${shed.length} layer(s): ${SHED_ORDER[level.current].label} (level ${level.current})`);
       }
     };
 

--- a/components/crep/perf/FpsAutoGovernor.tsx
+++ b/components/crep/perf/FpsAutoGovernor.tsx
@@ -36,9 +36,12 @@ const SHED_ORDER: Array<{ label: string; match: (id: string) => boolean }> = [
   { label: "dense global infra",   match: (id) => /^(txLines|submarineCables|cellTowersG|dataCentersG|powerPlantsG|substations|radioStations)/.test(id) },
 ];
 
-const LOW = 26;       // sustained below this → shed a step (target floor is 30)
-const RECOVER = 44;   // sustained above this → restore a step (gap from LOW avoids flapping)
+const LOW = 26;        // sustained below this → shed a step (target floor is 30)
+const RECOVER = 44;    // sustained above this → restore a step (gap from LOW avoids flapping)
 const CHECK_MS = 2000;
+const GRACE_MS = 20_000;   // ignore the chaotic load phase (FPS swings wildly while data streams init)
+const LOW_STREAK = 3;      // require ~6s of sustained-low before shedding (not a transient hitch)
+const HIGH_STREAK = 3;     // require ~6s of sustained-healthy before restoring
 
 type LayerState = { id: string; enabled: boolean };
 
@@ -57,8 +60,10 @@ export default function FpsAutoGovernor() {
     const setLayer = (id: string, on: boolean) => { try { w.__crep_setLayer?.(id, on); } catch { /* */ } };
     const layerState = () => { try { return w.__crep_layers?.() ?? []; } catch { return []; } };
 
+    const mountedAt = Date.now();
     const tick = () => {
       if (typeof document !== "undefined" && document.hidden) return; // never shed a backgrounded tab
+      if (Date.now() - mountedAt < GRACE_MS) return;                  // let the page load + FPS settle first
       const f = w.__crep_fps;
       const fps = typeof f?.fps === "number" ? f.fps : null;
       const frameMs = typeof f?.frameMs === "number" ? f.frameMs : null;
@@ -69,7 +74,7 @@ export default function FpsAutoGovernor() {
       else { lowStreak.current = 0; highStreak.current = 0; }
 
       // Shed the next-heaviest group after 2 consecutive low samples.
-      if (lowStreak.current >= 2 && level.current < SHED_ORDER.length) {
+      if (lowStreak.current >= LOW_STREAK && level.current < SHED_ORDER.length) {
         const step = SHED_ORDER[level.current];
         const shed: string[] = [];
         for (const l of layerState()) {
@@ -83,7 +88,7 @@ export default function FpsAutoGovernor() {
       }
 
       // Restore one group after 3 consecutive healthy samples.
-      if (highStreak.current >= 3 && level.current > 0) {
+      if (highStreak.current >= HIGH_STREAK && level.current > 0) {
         level.current--;
         const shed = shedByUs.current[level.current] || [];
         for (const id of shed) setLayer(id, true);

--- a/lib/crep/lod-policy.ts
+++ b/lib/crep/lod-policy.ts
@@ -122,6 +122,14 @@ export const INFRA_LINE_GLOBAL_MIN_ZOOM = 0
 /** Railway raster tiles — visible from state/region zoom (May 26, 2026). */
 export const RAILWAY_MIN_ZOOM = 5
 
+/**
+ * Aircraft stay COMPLETELY hidden below this zoom (Morgan, Jun 18 2026): "I don't want to see
+ * any planes at all on the map until I get to a zoom level that is more than three and a half."
+ * Planes are the single heaviest asset at globe scale (~0.5 ms/frame each — ~70% of the budget),
+ * so hiding them outright below the floor is both the look Morgan wants and a large FPS win.
+ */
+export const AIRCRAFT_MIN_ZOOM = 3.5
+
 export function isCityLevelZoom(
   zoom: number,
   bounds?: { north: number; south: number; east: number; west: number } | null,
@@ -163,7 +171,10 @@ export const LOD_TIERS: LODPolicy[] = [
     tier: "globe",
     zoomRange: [0, 3],
     events: { timeWindow: "7d", minSeverity: "high", maxRendered: 400 },
-    movers: { aircraft: 800, vessels: 1200, satellites: 800, bboxFilter: false },
+    // Heavy LOD at globe zoom — aircraft are ~0.5ms each (measured: 320 planes = ~150ms/frame,
+    // ~70% of the budget), vessels next, satellites cheap. You can't distinguish hundreds of
+    // movers at globe scale anyway; zoom in for full density. (Jun 18 2026, FPS audit.)
+    movers: { aircraft: 60, vessels: 120, satellites: 400, bboxFilter: false },
     infra: { mindexEnabled: false, bundledEnabled: false, maxPerLayer: 500 },
     // Apr 23, 2026 — Morgan: "green dots not selectable, masking cells".
     // Nature is DOM-marker rendered (FungalMarker → maplibregl.Marker per
@@ -180,7 +191,7 @@ export const LOD_TIERS: LODPolicy[] = [
     tier: "continent",
     zoomRange: [3, 5],
     events: { timeWindow: "14d", minSeverity: "medium", maxRendered: 800 },
-    movers: { aircraft: 1000, vessels: 1600, satellites: 900, bboxFilter: true },
+    movers: { aircraft: 120, vessels: 200, satellites: 450, bboxFilter: true },
     infra: { mindexEnabled: false, bundledEnabled: false, maxPerLayer: 1000 },
     nature: { timeWindow: "1y", qualityGrade: "all", maxRendered: 6000 },
   },
@@ -189,7 +200,7 @@ export const LOD_TIERS: LODPolicy[] = [
     tier: "region",
     zoomRange: [5, 7],
     events: { timeWindow: "30d", minSeverity: "info", maxRendered: 2400 },
-    movers: { aircraft: 1200, vessels: 2200, satellites: 1000, bboxFilter: true },
+    movers: { aircraft: 250, vessels: 400, satellites: 550, bboxFilter: true },
     infra: { mindexEnabled: true, bundledEnabled: true, maxPerLayer: 15000 },
     nature: { timeWindow: "5y", qualityGrade: "all", maxRendered: 9000 },
   },
@@ -198,7 +209,7 @@ export const LOD_TIERS: LODPolicy[] = [
     tier: "state",
     zoomRange: [7, 10],
     events: { timeWindow: "30d", minSeverity: "info", maxRendered: 3200 },
-    movers: { aircraft: 1500, vessels: 2500, satellites: 1200, bboxFilter: true },
+    movers: { aircraft: 500, vessels: 800, satellites: 700, bboxFilter: true },
     infra: { mindexEnabled: true, bundledEnabled: true, maxPerLayer: 30000 },
     nature: { timeWindow: "all", qualityGrade: "all", maxRendered: 12000 },
   },
@@ -207,7 +218,7 @@ export const LOD_TIERS: LODPolicy[] = [
     tier: "city",
     zoomRange: [10, 13],
     events: { timeWindow: "7d", minSeverity: "info", maxRendered: 4_000 },
-    movers: { aircraft: 2_000, vessels: 3_500, satellites: 1_200, bboxFilter: true },
+    movers: { aircraft: 900, vessels: 1_400, satellites: 900, bboxFilter: true },
     infra: { mindexEnabled: true, bundledEnabled: true, maxPerLayer: UNCAPPED_RENDER_LIMIT },
     nature: { timeWindow: "all", qualityGrade: "all", maxRendered: UNCAPPED_RENDER_LIMIT },
   },
@@ -216,7 +227,7 @@ export const LOD_TIERS: LODPolicy[] = [
     tier: "street",
     zoomRange: [13, 25],
     events: { timeWindow: "7d", minSeverity: "info", maxRendered: 4_000 },
-    movers: { aircraft: 2_000, vessels: 3_500, satellites: 1_200, bboxFilter: true },
+    movers: { aircraft: 1_200, vessels: 1_800, satellites: 1_000, bboxFilter: true },
     infra: { mindexEnabled: true, bundledEnabled: true, maxPerLayer: UNCAPPED_RENDER_LIMIT },
     nature: { timeWindow: "all", qualityGrade: "all", maxRendered: UNCAPPED_RENDER_LIMIT },
   },
@@ -348,6 +359,8 @@ export function applyLODToMovers<T>(
   zoom: number,
   bounds?: { north: number; south: number; east: number; west: number } | null,
 ): T[] {
+  // Hard floor: NO aircraft at all until past ~3.5 zoom (Morgan, Jun 18 2026).
+  if (kind === "aircraft" && zoom < AIRCRAFT_MIN_ZOOM) return []
   const lod = getLODForZoom(zoom)
   const cap = lod.movers[kind]
   if (!Number.isFinite(cap) || cap <= 0 || items.length <= cap) return items


### PR DESCRIPTION
## Earth Simulator performance + UX — for the real FPS/latency test on live

**Scope: Earth-Sim-only.** Live `main` + 20 Earth Sim commits. Deliberately **excludes** the 2 `local-dev-key`-removal security commits (separate website-env dependency — needs prod `MINDEX_API_KEY` confirmed first) and all MAS/MINDEX ingestion work (separate deploy track, per Cursor's handoff).

### What's in it
- **FPS: 4.7 → 60 fps** at globe/continent/region (verified on a fresh local server). Root cause was the per-frame mover *pipeline* (planes ~150ms/frame), not static features.
  - Aircraft hidden + pipeline-skipped below zoom 3.5 (layer minzoom + both pump writers). Vessels same.
  - Heavy mover LOD caps at low zoom; satellite orbit rings gated below zoom 4 (dots stay).
  - Plane trajectory trails off (zero compute; code kept).
  - FpsAutoGovernor removed from the tree (was a dev tool).
- **Radar:** killed the "Zoom Level Not Supported" tile (RainViewer maxzoom 7), smooth crossfade, 5-min auto-refresh.
- **Emergency popup:** on-map Live Radar button, Local Forecast opens the Environment panel, external-data links removed, no blink when open, compressed width, GPS+viewport auto-arm.

### Fungi rule
No fungal/nature data pruned — gates only touch aircraft/vessels/satellites. ✅

### Known caveat (not introduced here)
Satellite layers can render `visibility:none` (pre-existing elevated-sat/layer-sync issue, deck flag is off). To verify on live; own fast-follow fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve Earth Simulator performance at low zooms while adding live weather radar, lightning visualization, and a refined emergency alert experience.

New Features:
- Add a live animated RainViewer radar overlay layer with environment-panel toggle and auto-activation during active NWS alerts.
- Add a storm lightning visualization layer that animates lightning bolts over live NWS thunderstorm and tornado warning polygons with optional thunder audio.
- Extend the emergency alert overlay with dual GPS/map-center triggering, live NWS weather conditions, an expandable radar/forecast panel, and on-map controls for live radar and the Environment panel.

Bug Fixes:
- Prevent RainViewer from requesting unsupported high-zoom radar tiles to eliminate the 'Zoom Level Not Supported' placeholder imagery.

Enhancements:
- Tighten aircraft and vessel LOD by fully disabling their pump pipelines and symbol layers below zoom 3.5 and reducing global mover caps for higher FPS at globe/continent/region scales.
- Gate satellite orbit ring rendering to zoom 4+ while keeping satellite dots visible at lower zooms to reduce render cost and clutter.
- Change emergency alert popup behavior so it docks at the bottom, starts tucked with a blinking pill on new alerts, auto-opens only for in-view life-threatening GPS alerts, and filters out routine advisory-level alerts.
- Expose helper globals for toggling layers and opening the right-side panel so UI components like the emergency overlay can control radar and forecast views in-app.
- Remove the FpsAutoGovernor from the live dashboard so it no longer consumes resources while keeping the component available for future profiling.