### PR TITLE
fix(deploy): blue-green cutover robust to malformed prod .env (unblocks deploy)

### DIFF
--- a/scripts/blue-green-deploy.sh
+++ b/scripts/blue-green-deploy.sh
@@ -56,8 +56,9 @@ load_deploy_env() {
   local f="${DEPLOY_ENV_FILE:-/opt/mycosoft/deploy.env}"
   if [[ -f "$f" ]]; then
     set -a
+    # Robust source — see load_production_env: ignore malformed (non-KEY=VALUE) lines.
     # shellcheck disable=SC1090
-    source "$f"
+    source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$f")
     set +a
   fi
   CF_ZONE_ID="${CF_ZONE_ID:-${CLOUDFLARE_ZONE_ID_PRODUCTION:-${CLOUDFLARE_ZONE_ID:-}}}"
@@ -70,8 +71,13 @@ load_production_env() {
   local env_file="${DEPLOY_DIR:-/opt/mycosoft/website}/.env"
   [[ -f "$env_file" ]] || { err "Missing production env: $env_file"; exit 8; }
   set -a
+  # Robust source: only well-formed KEY=VALUE assignment lines. A malformed line — e.g. a
+  # stray secret wrapped onto its own line without a KEY= prefix — would otherwise be run as
+  # a command under `source` and abort the whole deploy (exit 127) BEFORE any health/auth
+  # safety check, blocking every cutover. Filtering keeps all real vars, drops junk lines.
+  # (Jun 19 2026 — prod .env line-167 bare-token regression that blocked a deploy.)
   # shellcheck disable=SC1090
-  source "$env_file"
+  source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$env_file")
   set +a
   # Never allow dev PC values on production VM
   if [[ "${NEXT_PUBLIC_BASE_URL:-}" == *localhost* ]]; then


### PR DESCRIPTION
## Unblocks production deploys broken by a malformed prod .env line

The production VM's `/opt/mycosoft/website/.env` has a malformed **line 167** — a bare secret token wrapped onto its own line without a `KEY=` prefix (introduced during the recent `MINDEX_INTERNAL_TOKEN` ingestion work). The blue/green cutover sources that `.env` under `set -euo pipefail`, so the bare token executes as a command → exit 127 → **every cutover aborts before any health/auth check** (keep-blue, so the live site stayed safe). This has blocked the Earth Sim FPS deploy (run 27846695562 failed twice on it).

### Fix
Source only well-formed `KEY=VALUE` assignment lines (`scripts/blue-green-deploy.sh`, `load_production_env` + `load_deploy_env`). Malformed/junk lines are ignored; all real env vars **and** the required-key validation are preserved. `bash -n` verified. Keep-blue-on-failure behavior unchanged.

This makes deploys resilient regardless; the VM `.env` line should still be fixed properly (Cursor/infra) so the token actually takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden blue-green deploy environment loading to tolerate malformed lines in env files.

Bug Fixes:
- Prevent blue-green cutovers from aborting when production .env contains a malformed line without a KEY=VALUE assignment.

Enhancements:
- Filter deploy and production env files to source only well-formed KEY=VALUE lines while preserving existing variable export behavior.