### PR TITLE
fix(deploy): sanitize prod .env before cutover via GHA SSH [fast]

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -477,6 +477,38 @@ jobs:
             echo "Env vars injected"
           ENVSCRIPT2
 
+      - name: Sanitize production .env (fix bare-token lines)
+        run: |
+          ssh-retry production bash -s <<'SANITIZE'
+            set -euo pipefail
+            cd /opt/mycosoft/website
+            git fetch origin main
+            git checkout origin/main -- scripts/sanitize-production-env.sh 2>/dev/null || true
+            chmod +x scripts/sanitize-production-env.sh 2>/dev/null || true
+            if [[ -x scripts/sanitize-production-env.sh ]]; then
+              ./scripts/sanitize-production-env.sh .env
+            else
+              python3 -c "
+          from pathlib import Path
+          p=Path('.env'); lines=p.read_text().splitlines(); out=[]; i=0; ch=False
+          while i<len(lines):
+            ln,s=lines[i],lines[i].strip()
+            if s and not s.startswith('#') and '=' not in s:
+              if out and out[-1].rstrip().endswith('='): out[-1]=out[-1].rstrip()+s
+              else: out.append('MINDEX_INTERNAL_TOKEN='+s)
+              ch=True; i+=1; continue
+            if ln.rstrip().endswith('=') and i+1<len(lines):
+              nxt=lines[i+1].strip()
+              if nxt and '=' not in nxt and not nxt.startswith('#'):
+                out.append(ln.rstrip()+nxt); ch=True; i+=2; continue
+            out.append(ln); i+=1
+          if ch: t=p.read_text(); p.write_text(chr(10).join(out)+(chr(10) if t.endswith(chr(10)) else ''))
+          "
+              set -a; source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' .env); set +a
+              echo ENV_SOURCE_OK
+            fi
+          SANITIZE
+
       # Apr 23, 2026 — Morgan: "you need to prevent data from building up
       # in sandbox for builds that will kill resources especially in fixes
       # and deployments this needs to be cleaned autonomously when
@@ -925,6 +957,38 @@ jobs:
               echo 'DATABASE_URL=${{ secrets.DATABASE_URL }}' >> .env
             fi
           ENVSCRIPT2
+
+      - name: Sanitize production .env (fix bare-token lines)
+        run: |
+          ssh-retry production bash -s <<'SANITIZE'
+            set -euo pipefail
+            cd /opt/mycosoft/website
+            git fetch origin main
+            git checkout origin/main -- scripts/sanitize-production-env.sh 2>/dev/null || true
+            chmod +x scripts/sanitize-production-env.sh 2>/dev/null || true
+            if [[ -x scripts/sanitize-production-env.sh ]]; then
+              ./scripts/sanitize-production-env.sh .env
+            else
+              python3 -c "
+          from pathlib import Path
+          p=Path('.env'); lines=p.read_text().splitlines(); out=[]; i=0; ch=False
+          while i<len(lines):
+            ln,s=lines[i],lines[i].strip()
+            if s and not s.startswith('#') and '=' not in s:
+              if out and out[-1].rstrip().endswith('='): out[-1]=out[-1].rstrip()+s
+              else: out.append('MINDEX_INTERNAL_TOKEN='+s)
+              ch=True; i+=1; continue
+            if ln.rstrip().endswith('=') and i+1<len(lines):
+              nxt=lines[i+1].strip()
+              if nxt and '=' not in nxt and not nxt.startswith('#'):
+                out.append(ln.rstrip()+nxt); ch=True; i+=2; continue
+            out.append(ln); i+=1
+          if ch: t=p.read_text(); p.write_text(chr(10).join(out)+(chr(10) if t.endswith(chr(10)) else ''))
+          "
+              set -a; source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' .env); set +a
+              echo ENV_SOURCE_OK
+            fi
+          SANITIZE
 
       - name: Pull GHCR image + blue/green cutover (zero-downtime)
         env:

--- a/scripts/sanitize-production-env.sh
+++ b/scripts/sanitize-production-env.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Fix malformed production .env lines (bare secret on its own line without KEY=).
+# Jun 19 2026 — blocked blue/green cutover with exit 127.
+set -euo pipefail
+ENV_FILE="${1:-/opt/mycosoft/website/.env}"
+[[ -f "$ENV_FILE" ]] || { echo "Missing $ENV_FILE" >&2; exit 1; }
+cp "$ENV_FILE" "${ENV_FILE}.bak.sanitize"
+python3 - "$ENV_FILE" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1])
+lines = p.read_text().splitlines()
+out, i, changed = [], 0, False
+while i < len(lines):
+    ln, s = lines[i], lines[i].strip()
+    if s and not s.startswith("#") and "=" not in s:
+        if out and out[-1].rstrip().endswith("="):
+            out[-1] = out[-1].rstrip() + s
+        else:
+            out.append("MINDEX_INTERNAL_TOKEN=" + s)
+        changed = True
+        i += 1
+        continue
+    if ln.rstrip().endswith("=") and i + 1 < len(lines):
+        nxt = lines[i + 1].strip()
+        if nxt and "=" not in nxt and not nxt.startswith("#"):
+            out.append(ln.rstrip() + nxt)
+            changed = True
+            i += 2
+            continue
+    out.append(ln)
+    i += 1
+if changed:
+    orig = p.read_text()
+    p.write_text("\n".join(out) + ("\n" if orig.endswith("\n") else ""))
+    print(f"Sanitized {p}")
+else:
+    print(f"No changes needed for {p}")
+PY
+set -a
+# shellcheck disable=SC1090
+source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE")
+set +a
+echo "ENV_SOURCE_OK"


### PR DESCRIPTION
## Summary
- Add scripts/sanitize-production-env.sh
- Run sanitize over SSH in CI before blue/green cutover (regular + instant deploy)

## Test plan
- [ ] Fast deploy completes
- [ ] mycosoft.com stays 200

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Sanitize the production .env file during both standard and instant deployment workflows to prevent malformed bare-token lines from breaking blue/green cutovers.

Bug Fixes:
- Prevent deployment failures caused by malformed production .env entries where secret tokens appear without a KEY= prefix.

Enhancements:
- Introduce a reusable scripts/sanitize-production-env.sh helper to normalize and safely source production .env files during deploys.