### PR TITLE
fix(deploy): safe .env export — stop bash source of malformed lines [fast]

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -483,30 +483,9 @@ jobs:
             set -euo pipefail
             cd /opt/mycosoft/website
             git fetch origin main
-            git checkout origin/main -- scripts/sanitize-production-env.sh 2>/dev/null || true
+            git checkout origin/main -- scripts/sanitize-production-env.sh scripts/sanitize-production-env.py 2>/dev/null || true
             chmod +x scripts/sanitize-production-env.sh 2>/dev/null || true
-            if [[ -x scripts/sanitize-production-env.sh ]]; then
-              ./scripts/sanitize-production-env.sh .env
-            else
-              python3 -c "
-          from pathlib import Path
-          p=Path('.env'); lines=p.read_text().splitlines(); out=[]; i=0; ch=False
-          while i<len(lines):
-            ln,s=lines[i],lines[i].strip()
-            if s and not s.startswith('#') and '=' not in s:
-              if out and out[-1].rstrip().endswith('='): out[-1]=out[-1].rstrip()+s
-              else: out.append('MINDEX_INTERNAL_TOKEN='+s)
-              ch=True; i+=1; continue
-            if ln.rstrip().endswith('=') and i+1<len(lines):
-              nxt=lines[i+1].strip()
-              if nxt and '=' not in nxt and not nxt.startswith('#'):
-                out.append(ln.rstrip()+nxt); ch=True; i+=2; continue
-            out.append(ln); i+=1
-          if ch: t=p.read_text(); p.write_text(chr(10).join(out)+(chr(10) if t.endswith(chr(10)) else ''))
-          "
-              set -a; source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' .env); set +a
-              echo ENV_SOURCE_OK
-            fi
+            ./scripts/sanitize-production-env.sh .env
           SANITIZE
 
       # Apr 23, 2026 — Morgan: "you need to prevent data from building up
@@ -906,7 +885,9 @@ jobs:
               deploy/nginx/nginx.conf \
               deploy/nginx/conf.d/website.conf.template \
               scripts/blue-green-deploy.sh \
-              scripts/blue-green-bootstrap.sh 2>/dev/null || true
+              scripts/blue-green-bootstrap.sh \
+              scripts/sanitize-production-env.sh \
+              scripts/sanitize-production-env.py 2>/dev/null || true
             chmod +x scripts/blue-green-*.sh 2>/dev/null || true
             echo "Deploy scripts synced to $(git rev-parse --short origin/main)"
           SCRIPT
@@ -964,30 +945,9 @@ jobs:
             set -euo pipefail
             cd /opt/mycosoft/website
             git fetch origin main
-            git checkout origin/main -- scripts/sanitize-production-env.sh 2>/dev/null || true
+            git checkout origin/main -- scripts/sanitize-production-env.sh scripts/sanitize-production-env.py 2>/dev/null || true
             chmod +x scripts/sanitize-production-env.sh 2>/dev/null || true
-            if [[ -x scripts/sanitize-production-env.sh ]]; then
-              ./scripts/sanitize-production-env.sh .env
-            else
-              python3 -c "
-          from pathlib import Path
-          p=Path('.env'); lines=p.read_text().splitlines(); out=[]; i=0; ch=False
-          while i<len(lines):
-            ln,s=lines[i],lines[i].strip()
-            if s and not s.startswith('#') and '=' not in s:
-              if out and out[-1].rstrip().endswith('='): out[-1]=out[-1].rstrip()+s
-              else: out.append('MINDEX_INTERNAL_TOKEN='+s)
-              ch=True; i+=1; continue
-            if ln.rstrip().endswith('=') and i+1<len(lines):
-              nxt=lines[i+1].strip()
-              if nxt and '=' not in nxt and not nxt.startswith('#'):
-                out.append(ln.rstrip()+nxt); ch=True; i+=2; continue
-            out.append(ln); i+=1
-          if ch: t=p.read_text(); p.write_text(chr(10).join(out)+(chr(10) if t.endswith(chr(10)) else ''))
-          "
-              set -a; source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' .env); set +a
-              echo ENV_SOURCE_OK
-            fi
+            ./scripts/sanitize-production-env.sh .env
           SANITIZE
 
       - name: Pull GHCR image + blue/green cutover (zero-downtime)

--- a/scripts/blue-green-deploy.sh
+++ b/scripts/blue-green-deploy.sh
@@ -70,47 +70,20 @@ load_deploy_env() {
 load_production_env() {
   local env_file="${DEPLOY_DIR:-/opt/mycosoft/website}/.env"
   [[ -f "$env_file" ]] || { err "Missing production env: $env_file"; exit 8; }
-  # In-place sanitize: join KEY= + bare value line (Jun 19 2026 prod regression).
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - "$env_file" <<'PY' || true
-import sys
-from pathlib import Path
-p = Path(sys.argv[1])
-lines = p.read_text().splitlines()
-out, i, changed = [], 0, False
-while i < len(lines):
-    ln, s = lines[i], lines[i].strip()
-    if s and not s.startswith("#") and "=" not in s:
-        if out and out[-1].rstrip().endswith("="):
-            out[-1] = out[-1].rstrip() + s
-        else:
-            out.append("MINDEX_INTERNAL_TOKEN=" + s)
-        changed = True
-        i += 1
-        continue
-    if ln.rstrip().endswith("=") and i + 1 < len(lines):
-        nxt = lines[i + 1].strip()
-        if nxt and "=" not in nxt and not nxt.startswith("#"):
-            out.append(ln.rstrip() + nxt)
-            changed = True
-            i += 2
-            continue
-    out.append(ln)
-    i += 1
-if changed:
-    orig = p.read_text()
-    p.write_text("\n".join(out) + ("\n" if orig.endswith("\n") else ""))
-PY
+  local sanitizer="${DEPLOY_DIR}/scripts/sanitize-production-env.sh"
+  if [[ -x "$sanitizer" ]]; then
+    # shellcheck disable=SC1090
+    source "$sanitizer" "$env_file"
+  elif command -v python3 >/dev/null 2>&1 && [[ -f "${DEPLOY_DIR}/scripts/sanitize-production-env.py" ]]; then
+    python3 "${DEPLOY_DIR}/scripts/sanitize-production-env.py" "$env_file" || true
+    set -a
+    # shellcheck disable=SC1090
+    eval "$(python3 "${DEPLOY_DIR}/scripts/sanitize-production-env.py" --export "$env_file")"
+    set +a
+  else
+    err "Missing sanitize-production-env helper — cannot safely load $env_file"
+    exit 8
   fi
-  set -a
-  # Robust source: only well-formed KEY=VALUE assignment lines. A malformed line — e.g. a
-  # stray secret wrapped onto its own line without a KEY= prefix — would otherwise be run as
-  # a command under `source` and abort the whole deploy (exit 127) BEFORE any health/auth
-  # safety check, blocking every cutover. Filtering keeps all real vars, drops junk lines.
-  # (Jun 19 2026 — prod .env line-167 bare-token regression that blocked a deploy.)
-  # shellcheck disable=SC1090
-  source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$env_file")
-  set +a
   # Never allow dev PC values on production VM
   if [[ "${NEXT_PUBLIC_BASE_URL:-}" == *localhost* ]]; then
     err "NEXT_PUBLIC_BASE_URL must not be localhost on production (got $NEXT_PUBLIC_BASE_URL)"

--- a/scripts/sanitize-production-env.py
+++ b/scripts/sanitize-production-env.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Sanitize production .env and emit safe export statements (no bash source of raw file)."""
+from __future__ import annotations
+
+import re
+import shlex
+import sys
+from pathlib import Path
+
+KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Long alphanumeric lines without = are stray secrets (Jun 19 2026 regression).
+BARE_SECRET_RE = re.compile(r"^[A-Za-z0-9_-]{20,}$")
+
+
+def _normalize_value(val: str) -> str:
+    val = val.strip()
+    # Backticks or $(...) turn the token into a shell command when sourced.
+    if len(val) >= 2 and val[0] == "`" and val[-1] == "`":
+        val = val[1:-1]
+    if val.startswith("$(") and val.endswith(")"):
+        val = val[2:-1]
+    if ";" in val:
+        val = val.split(";", 1)[0].strip()
+    parts = val.split()
+    if len(parts) > 1 and BARE_SECRET_RE.match(parts[-1]):
+        val = parts[0]
+    return val
+
+
+def sanitize_lines(lines: list[str]) -> tuple[list[str], bool]:
+    out: list[str] = []
+    changed = False
+    i = 0
+    while i < len(lines):
+        raw = lines[i]
+        s = raw.strip().strip("\r")
+
+        if not s or s.startswith("#"):
+            out.append(raw.rstrip("\r"))
+            i += 1
+            continue
+
+        if "=" not in s:
+            if BARE_SECRET_RE.match(s) or (
+                len(s) > 30 and re.fullmatch(r"[A-Za-z0-9_-]+", s)
+            ):
+                if out and out[-1].rstrip().endswith("="):
+                    out[-1] = out[-1].rstrip() + s
+                else:
+                    out.append("MINDEX_INTERNAL_TOKEN=" + s)
+                changed = True
+                i += 1
+                continue
+            out.append(raw.rstrip("\r"))
+            i += 1
+            continue
+
+        key, _, val = s.partition("=")
+        key = key.strip()
+        val = val.strip()
+
+        if KEY_RE.match(key) and val == "" and i + 1 < len(lines):
+            nxt = lines[i + 1].strip().strip("\r")
+            if nxt and "=" not in nxt and not nxt.startswith("#"):
+                merged = f"{key}={nxt}"
+                if merged != s:
+                    changed = True
+                out.append(merged)
+                i += 2
+                continue
+
+        if KEY_RE.match(key):
+            new_val = _normalize_value(val)
+            merged = f"{key}={new_val}"
+            if merged != s:
+                changed = True
+            out.append(merged)
+            i += 1
+            continue
+
+        out.append(raw.rstrip("\r"))
+        i += 1
+
+    # Drop duplicate bare-secret lines that slipped through as KEY= duplicates.
+    seen_mindex = False
+    deduped: list[str] = []
+    for ln in out:
+        s = ln.strip()
+        if s.startswith("MINDEX_INTERNAL_TOKEN="):
+            if seen_mindex:
+                changed = True
+                continue
+            seen_mindex = True
+        deduped.append(ln)
+
+    return deduped, changed
+
+
+def sanitize_file(path: Path) -> bool:
+    text = path.read_text()
+    lines = text.splitlines()
+    cleaned, changed = sanitize_lines(lines)
+    if changed:
+        path.write_text("\n".join(cleaned) + ("\n" if text.endswith("\n") else ""))
+        print(f"Sanitized {path}")
+    else:
+        print(f"No changes needed for {path}")
+    return changed
+
+
+def export_statements(path: Path) -> str:
+    lines = path.read_text().splitlines()
+    exports: list[str] = []
+    for raw in lines:
+        s = raw.strip().strip("\r")
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        key, _, val = s.partition("=")
+        key = key.strip()
+        if not KEY_RE.match(key):
+            continue
+        val = _normalize_value(val)
+        exports.append(f"export {key}={shlex.quote(val)}")
+    return "\n".join(exports)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: sanitize-production-env.py <path> | --export <path>", file=sys.stderr)
+        return 2
+
+    if sys.argv[1] == "--export":
+        path = Path(sys.argv[2])
+        if not path.is_file():
+            print(f"Missing {path}", file=sys.stderr)
+            return 1
+        print(export_statements(path))
+        return 0
+
+    path = Path(sys.argv[1])
+    if not path.is_file():
+        print(f"Missing {path}", file=sys.stderr)
+        return 1
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    backup = path.with_suffix(path.suffix + ".bak.sanitize")
+    backup.write_text(path.read_text())
+    sanitize_file(path)
+    # Verify exports parse without shell execution of secret tokens.
+    try:
+        export_statements(path)
+    except Exception as exc:
+        print(f"ENV_VERIFY_FAILED: {exc}", file=sys.stderr)
+        return 1
+    print("ENV_VERIFY_OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sanitize-production-env.sh
+++ b/scripts/sanitize-production-env.sh
@@ -1,44 +1,19 @@
 #!/usr/bin/env bash
-# Fix malformed production .env lines (bare secret on its own line without KEY=).
-# Jun 19 2026 — blocked blue/green cutover with exit 127.
+# Sanitize production .env and load vars safely (no raw bash source of .env).
 set -euo pipefail
+
 ENV_FILE="${1:-/opt/mycosoft/website/.env}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${SCRIPT_DIR}/sanitize-production-env.py"
+
 [[ -f "$ENV_FILE" ]] || { echo "Missing $ENV_FILE" >&2; exit 1; }
-cp "$ENV_FILE" "${ENV_FILE}.bak.sanitize"
-python3 - "$ENV_FILE" <<'PY'
-import sys
-from pathlib import Path
-p = Path(sys.argv[1])
-lines = p.read_text().splitlines()
-out, i, changed = [], 0, False
-while i < len(lines):
-    ln, s = lines[i], lines[i].strip()
-    if s and not s.startswith("#") and "=" not in s:
-        if out and out[-1].rstrip().endswith("="):
-            out[-1] = out[-1].rstrip() + s
-        else:
-            out.append("MINDEX_INTERNAL_TOKEN=" + s)
-        changed = True
-        i += 1
-        continue
-    if ln.rstrip().endswith("=") and i + 1 < len(lines):
-        nxt = lines[i + 1].strip()
-        if nxt and "=" not in nxt and not nxt.startswith("#"):
-            out.append(ln.rstrip() + nxt)
-            changed = True
-            i += 2
-            continue
-    out.append(ln)
-    i += 1
-if changed:
-    orig = p.read_text()
-    p.write_text("\n".join(out) + ("\n" if orig.endswith("\n") else ""))
-    print(f"Sanitized {p}")
-else:
-    print(f"No changes needed for {p}")
-PY
+[[ -f "$PY" ]] || { echo "Missing $PY" >&2; exit 1; }
+
+python3 "$PY" "$ENV_FILE"
+
 set -a
 # shellcheck disable=SC1090
-source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE")
+eval "$(python3 "$PY" --export "$ENV_FILE")"
 set +a
+
 echo "ENV_SOURCE_OK"


### PR DESCRIPTION
Replaces grep+source with python shlex-quoted exports; strips backticks/semicolon injection on KEY= lines.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Introduce a dedicated Python-based sanitizer for production .env files and load environment variables via safe export statements instead of sourcing raw .env content.

Enhancements:
- Centralize .env sanitization and export logic into a reusable sanitize-production-env.py helper used by deploy and CI workflows.
- Update blue/green deploy script to prefer the shell sanitizer, fall back to the Python helper, and fail safely if neither is available.
- Simplify CI/CD workflow steps to always run the sanitizer script instead of inlined Python and grep-based sourcing of .env files.

Build:
- Ensure CI/CD workflows fetch and sync both the shell and Python sanitization helpers for deployment hosts.