### PR TITLE
Earth Simulator P0-P2 fixes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -483,30 +483,9 @@ jobs:
             set -euo pipefail
             cd /opt/mycosoft/website
             git fetch origin main
-            git checkout origin/main -- scripts/sanitize-production-env.sh 2>/dev/null || true
+            git checkout origin/main -- scripts/sanitize-production-env.sh scripts/sanitize-production-env.py 2>/dev/null || true
             chmod +x scripts/sanitize-production-env.sh 2>/dev/null || true
-            if [[ -x scripts/sanitize-production-env.sh ]]; then
-              ./scripts/sanitize-production-env.sh .env
-            else
-              python3 -c "
-          from pathlib import Path
-          p=Path('.env'); lines=p.read_text().splitlines(); out=[]; i=0; ch=False
-          while i<len(lines):
-            ln,s=lines[i],lines[i].strip()
-            if s and not s.startswith('#') and '=' not in s:
-              if out and out[-1].rstrip().endswith('='): out[-1]=out[-1].rstrip()+s
-              else: out.append('MINDEX_INTERNAL_TOKEN='+s)
-              ch=True; i+=1; continue
-            if ln.rstrip().endswith('=') and i+1<len(lines):
-              nxt=lines[i+1].strip()
-              if nxt and '=' not in nxt and not nxt.startswith('#'):
-                out.append(ln.rstrip()+nxt); ch=True; i+=2; continue
-            out.append(ln); i+=1
-          if ch: t=p.read_text(); p.write_text(chr(10).join(out)+(chr(10) if t.endswith(chr(10)) else ''))
-          "
-              set -a; source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' .env); set +a
-              echo ENV_SOURCE_OK
-            fi
+            ./scripts/sanitize-production-env.sh .env
           SANITIZE
 
       # Apr 23, 2026 — Morgan: "you need to prevent data from building up
@@ -906,7 +885,9 @@ jobs:
               deploy/nginx/nginx.conf \
               deploy/nginx/conf.d/website.conf.template \
               scripts/blue-green-deploy.sh \
-              scripts/blue-green-bootstrap.sh 2>/dev/null || true
+              scripts/blue-green-bootstrap.sh \
+              scripts/sanitize-production-env.sh \
+              scripts/sanitize-production-env.py 2>/dev/null || true
             chmod +x scripts/blue-green-*.sh 2>/dev/null || true
             echo "Deploy scripts synced to $(git rev-parse --short origin/main)"
           SCRIPT
@@ -964,30 +945,9 @@ jobs:
             set -euo pipefail
             cd /opt/mycosoft/website
             git fetch origin main
-            git checkout origin/main -- scripts/sanitize-production-env.sh 2>/dev/null || true
+            git checkout origin/main -- scripts/sanitize-production-env.sh scripts/sanitize-production-env.py 2>/dev/null || true
             chmod +x scripts/sanitize-production-env.sh 2>/dev/null || true
-            if [[ -x scripts/sanitize-production-env.sh ]]; then
-              ./scripts/sanitize-production-env.sh .env
-            else
-              python3 -c "
-          from pathlib import Path
-          p=Path('.env'); lines=p.read_text().splitlines(); out=[]; i=0; ch=False
-          while i<len(lines):
-            ln,s=lines[i],lines[i].strip()
-            if s and not s.startswith('#') and '=' not in s:
-              if out and out[-1].rstrip().endswith('='): out[-1]=out[-1].rstrip()+s
-              else: out.append('MINDEX_INTERNAL_TOKEN='+s)
-              ch=True; i+=1; continue
-            if ln.rstrip().endswith('=') and i+1<len(lines):
-              nxt=lines[i+1].strip()
-              if nxt and '=' not in nxt and not nxt.startswith('#'):
-                out.append(ln.rstrip()+nxt); ch=True; i+=2; continue
-            out.append(ln); i+=1
-          if ch: t=p.read_text(); p.write_text(chr(10).join(out)+(chr(10) if t.endswith(chr(10)) else ''))
-          "
-              set -a; source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' .env); set +a
-              echo ENV_SOURCE_OK
-            fi
+            ./scripts/sanitize-production-env.sh .env
           SANITIZE
 
       - name: Pull GHCR image + blue/green cutover (zero-downtime)

--- a/.github/workflows/instant-deploy.yml
+++ b/.github/workflows/instant-deploy.yml
@@ -52,6 +52,14 @@ on:
         options:
           - 'false'
           - 'true'
+      no_cache:
+        description: 'Force full Docker rebuild (disables GHA BuildKit cache — use when prod serves stale routes)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 concurrency:
   # Same group name as ci-cd.yml's instant-deploy job — so a manual
@@ -132,11 +140,12 @@ jobs:
           file: ./Dockerfile.production
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          no-cache: ${{ inputs.no_cache == 'true' }}
           # Share the GHA cache with ci-cd.yml's instant-build so a
           # push-triggered deploy followed by an instant-deploy hits
-          # warm cache on the second run.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # warm cache on the second run. no_cache=true skips cache entirely.
+          cache-from: ${{ inputs.no_cache != 'true' && 'type=gha' || '' }}
+          cache-to: ${{ inputs.no_cache != 'true' && 'type=gha,mode=max' || '' }}
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             GIT_SHA=${{ steps.sha.outputs.sha }}
@@ -317,6 +326,28 @@ jobs:
               -d '{"purge_everything":true}'
             echo "Cache purged"
           fi
+
+      - name: Verify Earth Simulator routes on public origin
+        run: |
+          set -euo pipefail
+          echo "=== Entity stream BFF (mode=entities) ==="
+          stream_head=$(curl -sS --max-time 8 "https://mycosoft.com/api/stream/crep?mode=entities" | head -c 400 || true)
+          echo "$stream_head"
+          echo "$stream_head" | grep -q "Entity stream BFF connected" || {
+            echo "::error::Prod still serving old CREP stream handler — rebuild with no_cache=true"
+            exit 1
+          }
+          echo "=== Capped unified bundle size ==="
+          unified_bytes=$(curl -sS --max-time 120 -o /tmp/unified.json -w '%{size_download}' \
+            "https://mycosoft.com/api/crep/unified?refresh=true")
+          echo "unified bytes=$unified_bytes"
+          if [ "$unified_bytes" -gt 1200000 ]; then
+            echo "::error::Unified payload still oversized (${unified_bytes}B > 1.2MB) — slim caps not live"
+            exit 1
+          fi
+          echo "=== Earth Simulator page ==="
+          curl -fsS --max-time 20 -o /dev/null -w "earth-simulator HTTP %{http_code}\n" \
+            "https://mycosoft.com/natureos/earth-simulator"
 
       - name: Append deploy log
         continue-on-error: true

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -80,7 +80,8 @@ ENV NEXT_PRIVATE_DISABLE_WORKER_THREADS=1
 # Increase memory for large builds
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
-RUN npm run build
+# Cache-bust token MUST change when routes must register on prod (BuildKit GHA cache).
+RUN echo "DEPLOY_CACHE_BUST=earth-sim-p0p2-jun20-r5 commit=${SOURCE_COMMIT}" && npm run build
 
 # Production image
 FROM base AS runner

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -20,6 +20,8 @@
 # Jun 20, 2026 (r5): bust BuildKit cache — /api/stream/entities + capped
 # /api/crep/unified compiled locally but 404 / 3MB on prod after instant-deploy.
 # Force clean `npm run build` layer so manual-SHA image registers new routes.
+# Jun 20, 2026 (r7): instant-deploy no_cache=true — GHA cache still served stale
+# npm run build output despite r5/r6 bust strings; full rebuild required.
 
 FROM node:20-bookworm-slim AS base
 # SECURITY: no default — NEXTAUTH_SECRET must be supplied at build/runtime (docker-compose
@@ -81,7 +83,7 @@ ENV NEXT_PRIVATE_DISABLE_WORKER_THREADS=1
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # Cache-bust token MUST change when routes must register on prod (BuildKit GHA cache).
-RUN echo "DEPLOY_CACHE_BUST=earth-sim-entities-via-crep-jun20-r6 commit=${SOURCE_COMMIT}" && npm run build
+RUN echo "DEPLOY_CACHE_BUST=earth-sim-entities-via-crep-jun20-r7 commit=${SOURCE_COMMIT}" && npm run build
 
 # Production image
 FROM base AS runner

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -17,6 +17,10 @@
 # tag race with Cursor's docker compose --force-recreate). Comment edit
 # invalidates every downstream layer.
 
+# Jun 20, 2026 (r5): bust BuildKit cache — /api/stream/entities + capped
+# /api/crep/unified compiled locally but 404 / 3MB on prod after instant-deploy.
+# Force clean `npm run build` layer so manual-SHA image registers new routes.
+
 FROM node:20-bookworm-slim AS base
 # SECURITY: no default — NEXTAUTH_SECRET must be supplied at build/runtime (docker-compose
 # .env). Baking a known default ("change-me-before-prod") would let anyone forge sessions.

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -81,7 +81,7 @@ ENV NEXT_PRIVATE_DISABLE_WORKER_THREADS=1
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # Cache-bust token MUST change when routes must register on prod (BuildKit GHA cache).
-RUN echo "DEPLOY_CACHE_BUST=earth-sim-p0p2-jun20-r5 commit=${SOURCE_COMMIT}" && npm run build
+RUN echo "DEPLOY_CACHE_BUST=earth-sim-entities-via-crep-jun20-r6 commit=${SOURCE_COMMIT}" && npm run build
 
 # Production image
 FROM base AS runner

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Continuous environmental and infrastructure context layer. AVANI works alongside
 ### Defense — OEI & FUSARIUM
 Operational Environmental Intelligence (OEI) and FUSARIUM provide integrated defense and biosecurity capabilities, including threat assessment and global situational awareness through the CREP Dashboard.
 
+### Earth Simulator (NatureOS)
+Live environmental intelligence globe at **`/natureos/earth-simulator`**. Layers include aircraft (zoom ≥ 3.5), vessels, satellites, fungal/nature observations, infrastructure PMTiles, weather overlays, and MYCA LIVE chat (MAS LLM + fast local map commands). Key BFF routes: `/api/crep/unified` (capped bundle), `/api/stream/entities` (SSE), `/api/earth2/health`. See [Earth Simulator capabilities](https://github.com/MycosoftLabs/website/blob/main/docs/EARTH_SIMULATOR_REFERENCE.md) and MAS doc `EARTH_SIMULATOR_PUBLIC_CAPABILITIES_JUN20_2026.md`.
+
 ---
 
 ## Key Features

--- a/app/api/crep/services/route.ts
+++ b/app/api/crep/services/route.ts
@@ -59,7 +59,7 @@ const SERVICES = [
   { name: "iNaturalist", url: "https://api.inaturalist.org", healthPath: "/v1/observations?per_page=1&quality_grade=research", external: true },
   { name: "NASA GIBS", url: "https://gibs.earthdata.nasa.gov", healthPath: "/wmts/epsg3857/best/1.0.0/WMTSCapabilities.xml", external: true, method: "HEAD", accept: "text/xml", timeoutMs: 10000 },
   { name: "Overpass API", url: "https://overpass-api.de", healthPath: "/api/status", external: true, accept: "text/plain", timeoutMs: 10000 },
-  { name: "CelesTrak", url: "https://celestrak.org", healthPath: "/NORAD/elements/gp.php?GROUP=stations&FORMAT=2-line", external: true, timeoutMs: 15000 },
+  { name: "CelesTrak", url: "https://celestrak.org", healthPath: "/NORAD/elements/gp.php?GROUP=stations&FORMAT=2-line", external: true, timeoutMs: 8000 },
 ] satisfies ServiceProbe[];
 
 function tcpProbe(url: string, timeoutMs = 3000): Promise<ServiceStatus> {
@@ -154,17 +154,7 @@ async function pingServiceOnce(
 async function pingService(
   svc: ServiceProbe,
 ): Promise<ServiceStatus> {
-  const primary = await pingServiceOnce(svc);
-  if (primary.status !== "offline" || svc.name !== "CelesTrak") {
-    return primary;
-  }
-
-  return pingServiceOnce({
-    ...svc,
-    url: "https://celestrak.com",
-    healthPath: "/NORAD/elements/stations.txt",
-    timeoutMs: 15_000,
-  });
+  return pingServiceOnce(svc);
 }
 
 // Cache for 30 seconds

--- a/app/api/crep/unified/route.ts
+++ b/app/api/crep/unified/route.ts
@@ -1,23 +1,8 @@
 /**
  * Unified CREP Data API
- * 
+ *
  * Single endpoint for fetching all CREP data with caching.
- * This prevents the dashboard from making 10+ separate API calls
- * and overwhelming the dev server.
- * 
- * GET /api/crep/unified
- *   - Returns all cached CREP data
- *   - Uses stale-while-revalidate pattern
- *   - Much less load than individual endpoints
- * 
- * GET /api/crep/unified?type=aircraft
- *   - Returns specific data type only
- *   
- * GET /api/crep/unified?refresh=true
- *   - Forces cache refresh
- *   
- * GET /api/crep/unified?stats=true
- *   - Returns cache statistics
+ * Default bundle is capped (Jun 20 2026) to avoid multi-MB payloads.
  */
 
 import { NextRequest, NextResponse } from "next/server"
@@ -31,22 +16,61 @@ import {
   getDevices,
   getDataSummary,
   getServiceStats,
-  fetchAllData,
   fetchAllEarthData,
   getEarthStats,
+  getEarthDataByBbox,
+  UNIFIED_DEFAULT_LIMITS,
+  type UnifiedLimits,
 } from "@/lib/crep/crep-data-service"
 
 export const dynamic = "force-dynamic"
-export const maxDuration = 60 // Allow up to 60 seconds for full data fetch
+export const maxDuration = 60
+
+const UNIFIED_CACHE_TTL_MS = 45_000
+let unifiedCache: {
+  key: string
+  at: number
+  body: Record<string, unknown>
+} | null = null
+
+function parseBbox(raw: string | null): {
+  north: number
+  south: number
+  east: number
+  west: number
+} | null {
+  if (!raw) return null
+  const parts = raw.split(",").map((p) => Number(p.trim()))
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) return null
+  const [north, south, east, west] = parts
+  return { north, south, east, west }
+}
+
+function resolveLimits(searchParams: URLSearchParams): UnifiedLimits {
+  const limitParam = searchParams.get("limit")
+  if (!limitParam) return UNIFIED_DEFAULT_LIMITS
+  const n = Number(limitParam)
+  if (!Number.isFinite(n) || n <= 0) return UNIFIED_DEFAULT_LIMITS
+  const cap = Math.min(n, 5000)
+  return {
+    aircraft: cap,
+    vessels: cap,
+    satellites: cap,
+    fungal: cap,
+    events: cap,
+  }
+}
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams
   const type = searchParams.get("type")
   const refresh = searchParams.get("refresh") === "true"
   const stats = searchParams.get("stats") === "true"
+  const countsOnly = searchParams.get("countsOnly") === "true"
+  const bbox = parseBbox(searchParams.get("bbox"))
+  const limits = resolveLimits(searchParams)
 
   try {
-    // Return cache stats
     if (stats) {
       return NextResponse.json({
         success: true,
@@ -54,48 +78,57 @@ export async function GET(request: NextRequest) {
       })
     }
 
-    // Fetch specific data type
+    if (countsOnly) {
+      const earthStats = await getEarthStats()
+      const summary = await getDataSummary(undefined, limits)
+      return NextResponse.json({
+        success: true,
+        counts: {
+          ...earthStats,
+          aircraft: summary.aircraft,
+          vessels: summary.vessels,
+          satellites: summary.satellites,
+          fungalObservations: summary.fungalObservations,
+          globalEvents: summary.globalEvents,
+          devices: summary.devices,
+        },
+        timestamp: new Date().toISOString(),
+      })
+    }
+
     if (type) {
       const forceRefresh = refresh
       let data: unknown = null
 
+      const typeLimits: UnifiedLimits = limits
+
       switch (type) {
         case "aircraft":
-          data = await getAircraft({ forceRefresh })
+          data = await getAircraft({ forceRefresh, limit: typeLimits.aircraft })
           break
         case "vessels":
-          data = await getVessels({ forceRefresh })
+          data = await getVessels({ forceRefresh, limit: typeLimits.vessels })
           break
         case "satellites":
-          data = await getSatellites({ forceRefresh })
+          data = await getSatellites({ forceRefresh, limit: typeLimits.satellites })
           break
         case "spaceWeather":
           data = await getSpaceWeather({ forceRefresh })
           break
         case "globalEvents":
-          data = await getGlobalEvents({ forceRefresh })
+          data = await getGlobalEvents({ forceRefresh, limit: typeLimits.events })
           break
         case "fungalObservations":
-          data = await getFungalObservations({ forceRefresh })
+          data = await getFungalObservations({ forceRefresh, limit: typeLimits.fungal })
           break
         case "devices":
           data = await getDevices({ forceRefresh })
-          break
-        case "weather":
-          // Fetch weather from MINDEX earth sync
-          { const earth = await fetchAllEarthData(); data = earth.weather }
-          break
-        case "emissions":
-          { const earth2 = await fetchAllEarthData(); data = earth2.emissions }
-          break
-        case "infrastructure":
-          { const earth3 = await fetchAllEarthData(); data = earth3.infrastructure }
           break
         case "earthStats":
           data = await getEarthStats()
           break
         case "summary":
-          data = await getDataSummary()
+          data = await getDataSummary(undefined, typeLimits)
           break
         default:
           return NextResponse.json(
@@ -113,16 +146,38 @@ export async function GET(request: NextRequest) {
       })
     }
 
-    // Fetch all data (including new earth domains via MINDEX)
-    console.log("[CREP Unified] Fetching all earth data...")
+    const cacheKey = bbox
+      ? `bbox:${bbox.north},${bbox.south},${bbox.east},${bbox.west}:${limits.aircraft}`
+      : `global:${limits.aircraft}`
+
+    if (!refresh && unifiedCache && unifiedCache.key === cacheKey) {
+      const age = Date.now() - unifiedCache.at
+      if (age < UNIFIED_CACHE_TTL_MS) {
+        return NextResponse.json({
+          ...unifiedCache.body,
+          cached: true,
+          cacheAgeMs: age,
+        })
+      }
+    }
+
+    console.log("[CREP Unified] Fetching earth data...", bbox ? "bbox" : "global capped")
     const startTime = Date.now()
 
-    const allData = await fetchAllEarthData()
+    const allData = bbox
+      ? await getEarthDataByBbox({
+          north: bbox.north,
+          south: bbox.south,
+          east: bbox.east,
+          west: bbox.west,
+          limit: limits.aircraft,
+        })
+      : await fetchAllEarthData(undefined, undefined, limits)
 
     const elapsed = Date.now() - startTime
-    console.log(`[CREP Unified] All data fetched in ${elapsed}ms`)
+    console.log(`[CREP Unified] Fetched in ${elapsed}ms`)
 
-    return NextResponse.json({
+    const body = {
       success: true,
       data: allData,
       counts: {
@@ -139,6 +194,15 @@ export async function GET(request: NextRequest) {
       },
       elapsed,
       timestamp: new Date().toISOString(),
+      cached: false,
+    }
+
+    unifiedCache = { key: cacheKey, at: Date.now(), body }
+
+    return NextResponse.json(body, {
+      headers: {
+        "Cache-Control": "s-maxage=30, stale-while-revalidate=120",
+      },
     })
   } catch (error) {
     console.error("[CREP Unified] Error:", error)
@@ -153,6 +217,10 @@ export async function GET(request: NextRequest) {
           fungalObservations: [],
           globalEvents: [],
           devices: [],
+          weather: [],
+          emissions: [],
+          infrastructure: [],
+          spaceWeather: [],
         },
         counts: {
           aircraft: 0,
@@ -161,6 +229,10 @@ export async function GET(request: NextRequest) {
           fungalObservations: 0,
           globalEvents: 0,
           devices: 0,
+          weather: 0,
+          emissions: 0,
+          infrastructure: 0,
+          spaceWeather: 0,
         },
         timestamp: new Date().toISOString(),
       },

--- a/app/api/stream/crep/route.ts
+++ b/app/api/stream/crep/route.ts
@@ -28,7 +28,114 @@ export const dynamic = "force-dynamic"
 export async function GET(request: NextRequest) {
   const encoder = new TextEncoder()
   const { searchParams } = new URL(request.url)
+  const mode = searchParams.get("mode")
   const category = searchParams.get("category")
+
+  // Entity stream (Earth Simulator) — same BFF path as CREP for prod route registration
+  if (mode === "entities") {
+    const cells = searchParams.get("cells")
+    const types = searchParams.get("types")
+    const timeFrom = searchParams.get("time_from")
+    const wsParams = new URLSearchParams()
+    if (cells) wsParams.set("cells", cells)
+    if (types) wsParams.set("types", types)
+    if (timeFrom) wsParams.set("time_from", timeFrom)
+    const qs = wsParams.toString()
+    const wsUrl = `${MAS_WS_URL}/api/entities/stream${qs ? `?${qs}` : ""}`
+
+    const customReadable = new ReadableStream({
+      async start(controller) {
+        let heartbeatInterval: NodeJS.Timeout | null = null
+        let wsInstance: InstanceType<typeof import("ws").default> | null = null
+
+        const sendEvent = (eventType: string, payload: Record<string, unknown>) => {
+          controller.enqueue(
+            encoder.encode(`event: ${eventType}\ndata: ${JSON.stringify(payload)}\n\n`)
+          )
+        }
+
+        const cleanup = () => {
+          if (heartbeatInterval) {
+            clearInterval(heartbeatInterval)
+            heartbeatInterval = null
+          }
+          if (wsInstance && wsInstance.readyState === 1) {
+            wsInstance.close()
+          }
+          try {
+            controller.close()
+          } catch {
+            // already closed
+          }
+        }
+
+        try {
+          const WebSocketModule = await import("ws")
+          const WS = WebSocketModule.default
+          wsInstance = new WS(wsUrl)
+
+          sendEvent("connected", {
+            message: "Entity stream BFF connected",
+            masUrl: MAS_API_URL,
+            timestamp: new Date().toISOString(),
+          })
+
+          wsInstance.on("open", () => {
+            heartbeatInterval = setInterval(() => {
+              if (wsInstance && wsInstance.readyState === WS.OPEN) {
+                wsInstance.ping()
+              }
+            }, 30000)
+          })
+
+          wsInstance.on("message", (data: Buffer) => {
+            try {
+              const message = JSON.parse(data.toString())
+              sendEvent(message.type || "entity", message)
+            } catch (error) {
+              console.error("[Entity Stream] Message parse error:", error)
+            }
+          })
+
+          wsInstance.on("error", (error: Error) => {
+            sendEvent("error", {
+              error: "WebSocket error",
+              message: error.message || "Unknown error",
+              timestamp: new Date().toISOString(),
+            })
+          })
+
+          wsInstance.on("close", (code: number, reason: Buffer) => {
+            sendEvent("disconnected", {
+              message: "Entity stream disconnected",
+              code,
+              timestamp: new Date().toISOString(),
+            })
+            cleanup()
+          })
+
+          request.signal.addEventListener("abort", cleanup)
+        } catch (error) {
+          sendEvent("error", {
+            error: "Connection setup failed",
+            message: error instanceof Error ? error.message : "Unknown error",
+            masUrl: MAS_API_URL,
+            timestamp: new Date().toISOString(),
+          })
+          cleanup()
+        }
+      },
+    })
+
+    return new Response(customReadable, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    })
+  }
 
   const customReadable = new ReadableStream({
     async start(controller) {

--- a/app/api/stream/entities/route.ts
+++ b/app/api/stream/entities/route.ts
@@ -1,0 +1,142 @@
+/**
+ * Unified Entity Stream SSE BFF
+ *
+ * Proxies MAS WebSocket /api/entities/stream to Server-Sent Events for browsers
+ * on public origins (cannot connect ws:// to private MAS LAN IP).
+ */
+
+import { NextRequest } from "next/server"
+import { API_URLS } from "@/lib/config/api-urls"
+
+const MAS_API_URL = API_URLS.MAS
+const MAS_WS_URL = MAS_API_URL.replace("http://", "ws://").replace("https://", "wss://")
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * GET /api/stream/entities
+ *
+ * Query params (forwarded to MAS):
+ * - cells: comma-separated S2 cell IDs
+ * - types: comma-separated entity types
+ * - time_from: ISO8601 lower time bound
+ */
+export async function GET(request: NextRequest) {
+  const encoder = new TextEncoder()
+  const { searchParams } = new URL(request.url)
+
+  const cells = searchParams.get("cells")
+  const types = searchParams.get("types")
+  const timeFrom = searchParams.get("time_from")
+
+  const wsParams = new URLSearchParams()
+  if (cells) wsParams.set("cells", cells)
+  if (types) wsParams.set("types", types)
+  if (timeFrom) wsParams.set("time_from", timeFrom)
+  const qs = wsParams.toString()
+  const wsUrl = `${MAS_WS_URL}/api/entities/stream${qs ? `?${qs}` : ""}`
+
+  const customReadable = new ReadableStream({
+    async start(controller) {
+      let heartbeatInterval: NodeJS.Timeout | null = null
+      let wsInstance: InstanceType<typeof import("ws").default> | null = null
+
+      const sendEvent = (eventType: string, payload: Record<string, unknown>) => {
+        controller.enqueue(
+          encoder.encode(`event: ${eventType}\ndata: ${JSON.stringify(payload)}\n\n`)
+        )
+      }
+
+      const cleanup = () => {
+        if (heartbeatInterval) {
+          clearInterval(heartbeatInterval)
+          heartbeatInterval = null
+        }
+        if (wsInstance && wsInstance.readyState === 1) {
+          wsInstance.close()
+        }
+        try {
+          controller.close()
+        } catch {
+          // Stream may already be closed
+        }
+      }
+
+      try {
+        const WebSocketModule = await import("ws")
+        const WS = WebSocketModule.default
+        wsInstance = new WS(wsUrl)
+
+        sendEvent("connected", {
+          message: "Entity stream BFF connected",
+          masUrl: MAS_API_URL,
+          timestamp: new Date().toISOString(),
+        })
+
+        wsInstance.on("open", () => {
+          console.log("[Entity Stream] WebSocket connected to MAS")
+          heartbeatInterval = setInterval(() => {
+            if (wsInstance && wsInstance.readyState === WS.OPEN) {
+              wsInstance.ping()
+            }
+          }, 30000)
+        })
+
+        wsInstance.on("message", (data: Buffer) => {
+          try {
+            const message = JSON.parse(data.toString())
+            const eventType = message.type || "entity"
+            sendEvent(eventType, message)
+          } catch (error) {
+            console.error("[Entity Stream] Message parse error:", error)
+          }
+        })
+
+        wsInstance.on("error", (error: Error) => {
+          console.error("[Entity Stream] WebSocket error:", error.message)
+          sendEvent("error", {
+            error: "WebSocket error",
+            message: error.message || "Unknown error",
+            timestamp: new Date().toISOString(),
+          })
+        })
+
+        wsInstance.on("close", (code: number, reason: Buffer) => {
+          console.log(
+            `[Entity Stream] WebSocket closed (code: ${code}, reason: ${reason.toString() || "none"})`
+          )
+          sendEvent("disconnected", {
+            message: "Entity stream disconnected",
+            code,
+            timestamp: new Date().toISOString(),
+          })
+          cleanup()
+        })
+
+        request.signal.addEventListener("abort", () => {
+          console.log("[Entity Stream] Client disconnected")
+          cleanup()
+        })
+      } catch (error) {
+        console.error("[Entity Stream] Setup error:", error)
+        sendEvent("error", {
+          error: "Connection setup failed",
+          message: error instanceof Error ? error.message : "Unknown error",
+          masUrl: MAS_API_URL,
+          timestamp: new Date().toISOString(),
+        })
+        cleanup()
+      }
+    },
+  })
+
+  return new Response(customReadable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  })
+}

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -19,6 +19,7 @@
  */
 
 import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, memo, startTransition, type ReactNode, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import { useCrepPollScheduler } from "@/hooks/use-crep-poll-scheduler";
 import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
 import { Map as MapComponent, MapControls, MapMarker, MarkerContent, MarkerPopup, freezeNativeMarkerUpdates, thawNativeMarkerUpdates } from "@/components/ui/map";
@@ -7500,9 +7501,10 @@ const CREPMycaPanel = memo(function CREPMycaPanel({
         showHeader={true}
         getContextText={getContextText}
         context={getStructuredContext}
-        enableFastIntent={false}
-        localOnly={true}
+        enableFastIntent={true}
+        localOnly={false}
         onLocalCommand={handleEarthSimulatorMycaCommand}
+        emptyMessage="Ask MYCA to fly the map, toggle layers, or query Earth intelligence. Full LLM replies route through MAS when online."
       />
     </div>
   );
@@ -8030,6 +8032,33 @@ export default function CREPDashboardPage({
     assetIsolationMode,
   ]);
   const fpsOverlayRef = useRef<HTMLElement>(null);
+  type FooterServiceState = "connected" | "degraded" | "offline" | "checking";
+  interface FooterServiceHealth {
+    system: FooterServiceState;
+    mycobrain: FooterServiceState;
+    mindex: FooterServiceState;
+    myca: FooterServiceState;
+    earth2: FooterServiceState;
+  }
+  const [footerServiceHealth, setFooterServiceHealth] = useState<FooterServiceHealth>({
+    system: "checking",
+    mycobrain: "checking",
+    mindex: "checking",
+    myca: "checking",
+    earth2: "checking",
+  });
+  const footerStatusClass = useCallback((state: FooterServiceState) => {
+    if (state === "connected") return "text-green-400";
+    if (state === "degraded") return "text-amber-400";
+    if (state === "checking") return "text-gray-400";
+    return "text-red-400";
+  }, []);
+  const footerStatusText = useCallback((state: FooterServiceState, labels: { connected: string; degraded: string; offline: string }) => {
+    if (state === "connected") return labels.connected;
+    if (state === "degraded") return labels.degraded;
+    if (state === "checking") return "CHECKING...";
+    return labels.offline;
+  }, []);
   const isSearchEmbedded = embedded || enabledLayerIds.length > 0;
   const isEmbeddedEarthquakeSearch = isSearchEmbedded && EARTHQUAKE_QUERY_RE.test(initialQuery);
   const embeddedLayerIdKey = enabledLayerIds.slice().sort().join("|");
@@ -9085,6 +9114,23 @@ export default function CREPDashboardPage({
     if (mapInteractionActiveRef.current) return true;
     return Date.now() < navigationPauseUntilRef.current;
   }, [assetIsolationMode, auditAllOffMode, isEarthSimulatorRoute, isMapAnimationActive]);
+
+  useCrepPollScheduler(
+    useMemo(
+      () => [
+        {
+          id: "crep-services-warm",
+          intervalMs: 120_000,
+          enabled: isEarthSimulatorRoute && !auditAllOffMode && !assetIsolationMode,
+          run: () => {
+            fetch("/api/crep/services", { signal: AbortSignal.timeout(45_000) }).catch(() => {})
+          },
+        },
+      ],
+      [assetIsolationMode, auditAllOffMode, isEarthSimulatorRoute],
+    ),
+    { shouldPause: shouldPauseLiveWork },
+  );
 
   useEffect(() => {
     if (!isEarthSimulatorPath()) return;
@@ -10770,15 +10816,112 @@ export default function CREPDashboardPage({
     [earth2Filter.resolution, earth2Filter.gpuMode],
   );
 
+  const [earth2Available, setEarth2Available] = useState(false);
   const [, setEarth2Alerts] = useState<unknown[]>([]);
   const [, setEarth2Loading] = useState(false);
-  const [, setEarth2Available] = useState(false);
+
+  // Earth-2 + platform health for status bar and cloud layer degrade
+  useEffect(() => {
+    if (shouldPauseLiveWork()) return;
+    let cancelled = false;
+
+    const mapServiceStatus = (name: string, status?: string): FooterServiceState => {
+      if (status === "up") return "connected";
+      if (status === "degraded") return "degraded";
+      if (status === "down") return "offline";
+      return "offline";
+    };
+
+    const pollFooterHealth = async () => {
+      const next: FooterServiceHealth = {
+        system: "checking",
+        mycobrain: "checking",
+        mindex: "checking",
+        myca: "checking",
+        earth2: "checking",
+      };
+
+      try {
+        const [healthRes, earth2Res, mycoRes] = await Promise.all([
+          fetch("/api/health", { cache: "no-store", signal: AbortSignal.timeout(8_000) }).catch(() => null),
+          fetch("/api/earth2/health", { cache: "no-store", signal: AbortSignal.timeout(8_000) }).catch(() => null),
+          fetch("/api/mycobrain/health", { cache: "no-store", signal: AbortSignal.timeout(8_000) }).catch(() => null),
+        ]);
+
+        if (healthRes?.ok) {
+          const health = await healthRes.json().catch(() => null);
+          const services: { name: string; status?: string }[] = Array.isArray(health?.services) ? health.services : [];
+          const mas = services.find((s) => s.name === "mas-api");
+          const mindex = services.find((s) => s.name === "mindex-api");
+          const overall = String(health?.status ?? "");
+          next.system = overall === "healthy" ? "connected" : overall === "degraded" ? "degraded" : "offline";
+          next.myca = mapServiceStatus("mas-api", mas?.status);
+          next.mindex = mapServiceStatus("mindex-api", mindex?.status);
+        } else {
+          next.system = "offline";
+          next.myca = "offline";
+          next.mindex = "offline";
+        }
+
+        if (earth2Res?.ok) {
+          const earth2 = await earth2Res.json().catch(() => null);
+          const available = earth2?.available === true || earth2?.ok === true;
+          next.earth2 = available ? "connected" : "offline";
+          if (!cancelled) setEarth2Available(available);
+        } else {
+          next.earth2 = "offline";
+          if (!cancelled) setEarth2Available(false);
+        }
+
+        if (mycoRes?.ok) {
+          const myco = await mycoRes.json().catch(() => null);
+          const healthy = String(myco?.status ?? "").toLowerCase() === "healthy" || myco?.connected === true;
+          next.mycobrain = healthy ? "connected" : "degraded";
+        } else {
+          next.mycobrain = "offline";
+        }
+      } catch {
+        next.system = "offline";
+        next.myca = "offline";
+        next.mindex = "offline";
+        next.mycobrain = "offline";
+        next.earth2 = "offline";
+        if (!cancelled) setEarth2Available(false);
+      }
+
+      if (!cancelled) setFooterServiceHealth(next);
+    };
+
+    pollFooterHealth();
+    const interval = window.setInterval(() => {
+      if (!shouldPauseLiveWork()) pollFooterHealth();
+    }, 30_000);
+    const onVisibility = () => {
+      if (!document.hidden) pollFooterHealth();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [shouldPauseLiveWork]);
+
+  useEffect(() => {
+    if (earth2Available) return;
+    setLayers((prev) =>
+      prev.map((layer) =>
+        layer.id === "realisticClouds" && layer.enabled
+          ? { ...layer, enabled: false, description: `${layer.description ?? ""} Earth-2 offline — layer auto-disabled.`.trim() }
+          : layer,
+      ),
+    );
+  }, [earth2Available]);
 
   // Ã¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢Â
   // EARTH-2 STATUS CHECK - Fetch status on mount
   // Ã¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢ÂÃ¢â€¢Â
   useEffect(() => {
-    return;
     if (!EARTH2_BACKEND_ENABLED) {
       setEarth2Available(false);
       setEarth2Loading(false);
@@ -17813,6 +17956,19 @@ export default function CREPDashboardPage({
             <span className={cn("text-[9px] font-mono", filteredAircraft.length === 0 ? "text-amber-400" : "text-sky-400")}>
               Planes: {filteredAircraft.length}
             </span>
+            {mapZoom < 3.5 &&
+              (layers.find((layer) => layer.id === "aviation")?.enabled ||
+                layers.find((layer) => layer.id === "aviationRoutes")?.enabled) && (
+              <>
+                <span className="text-gray-600">|</span>
+                <span
+                  className="text-[8px] font-mono text-amber-300/90"
+                  title="Live aircraft markers render at zoom 3.5 and above"
+                >
+                  Zoom in for aircraft
+                </span>
+              </>
+            )}
             <span className="text-gray-600">|</span>
             <span className={cn("text-[9px] font-mono", filteredVessels.length === 0 ? "text-amber-400" : "text-teal-400")}>
               Boats: {filteredVessels.length}
@@ -18296,7 +18452,7 @@ export default function CREPDashboardPage({
                                 </div>
                                 <div className="flex items-center justify-between mt-0.5">
                                   <span className="text-[8px] text-gray-500 truncate max-w-[100px]">
-                                    {obs.location || `${typeof obs.latitude === 'number' ? obs.latitude.toFixed(2) : 'Ã¢â‚¬â€'}Ã‚Â°, ${typeof obs.longitude === 'number' ? obs.longitude.toFixed(2) : 'Ã¢â‚¬â€'}Ã‚Â°`}
+                                    {obs.location || `${typeof obs.latitude === "number" ? obs.latitude.toFixed(2) : "—"}°, ${typeof obs.longitude === "number" ? obs.longitude.toFixed(2) : "—"}°`}
                                   </span>
                                   <Badge
                                     variant="outline"
@@ -18307,7 +18463,14 @@ export default function CREPDashboardPage({
                                         : "border-yellow-500/50 text-yellow-400"
                                     )}
                                   >
-                                    {isResearchGrade ? "Ã¢Å“â€œ verified" : "needs ID"}
+                                    {isResearchGrade ? (
+                                      <span className="inline-flex items-center gap-0.5">
+                                        <CheckCircle2 className="h-2.5 w-2.5" />
+                                        verified
+                                      </span>
+                                    ) : (
+                                      "needs ID"
+                                    )}
                                   </Badge>
                                 </div>
                                 {obs.observed_on && (
@@ -18323,7 +18486,7 @@ export default function CREPDashboardPage({
                     )}
                     {visibleFungalObservations.length > 90 && (
                       <div className="text-center py-2 text-[9px] text-gray-500">
-                        Showing 90 of {visibleFungalObservations.length} visible Ã¢â‚¬Â¢ Zoom in for more
+                        Showing 90 of {visibleFungalObservations.length} visible • Zoom in for more
                       </div>
                     )}
                   </div>
@@ -18736,6 +18899,17 @@ export default function CREPDashboardPage({
                       </details>
                     ))}
                   </div>
+                </details>
+
+                <details className="group border-t border-cyan-500/20 bg-black/20">
+                  <summary className="flex cursor-pointer select-none list-none items-center justify-between gap-2 p-2 [&::-webkit-details-marker]:hidden">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <ChevronDown className="h-3 w-3 shrink-0 text-cyan-300 transition-transform group-open:rotate-180" />
+                      <Activity className="h-3.5 w-3.5 shrink-0 text-cyan-300" />
+                      <span className="truncate text-[10px] font-semibold text-cyan-100">System Services</span>
+                    </div>
+                  </summary>
+                  <ServicesPanelLive active={leftSecondaryTab === "devices"} />
                 </details>
               </div>
             )}
@@ -23753,17 +23927,31 @@ export default function CREPDashboardPage({
       {/* Bottom Status Bar */}
       {!embedded && <div className="hidden md:flex flex-shrink-0 items-center justify-between px-4 py-1.5 bg-black/80 border-t border-cyan-500/20 z-50">
         <div className="flex items-center gap-4 text-[10px] font-mono">
-          <span className="text-green-400">SYSTEM OPERATIONAL</span>
+          <span className={footerStatusClass(footerServiceHealth.system)} title="Aggregate platform health from /api/health">
+            {footerStatusText(footerServiceHealth.system, {
+              connected: "SYSTEM OPERATIONAL",
+              degraded: "SYSTEM DEGRADED",
+              offline: "SYSTEM OFFLINE",
+            })}
+          </span>
           <span className="text-gray-600">|</span>
-          <span className="text-cyan-400">UPTIME: 99.9%</span>
+          <span className={footerStatusClass(footerServiceHealth.mycobrain)} title="MycoBrain service health">
+            MYCOBRAIN: {footerStatusText(footerServiceHealth.mycobrain, { connected: "CONNECTED", degraded: "DEGRADED", offline: "OFFLINE" })}
+          </span>
           <span className="text-gray-600">|</span>
-          <span className="text-cyan-400">MYCOBRAIN: CONNECTED</span>
+          <span className={footerStatusClass(footerServiceHealth.mindex)} title="MINDEX API health">
+            MINDEX: {footerStatusText(footerServiceHealth.mindex, { connected: "SYNCED", degraded: "DEGRADED", offline: "OFFLINE" })}
+          </span>
           <span className="text-gray-600">|</span>
-          <span className="text-cyan-400">MINDEX: SYNCED</span>
+          <span className={footerStatusClass(footerServiceHealth.myca)} title="MAS / MYCA orchestrator health">
+            MYCA: {footerStatusText(footerServiceHealth.myca, { connected: "ACTIVE", degraded: "DEGRADED", offline: "OFFLINE" })}
+          </span>
           <span className="text-gray-600">|</span>
-          <span className="text-purple-400">MYCA: ACTIVE</span>
+          <span className={footerStatusClass(footerServiceHealth.earth2)} title="Earth-2 GPU inference health">
+            EARTH-2: {footerStatusText(footerServiceHealth.earth2, { connected: "ONLINE", degraded: "DEGRADED", offline: "OFFLINE" })}
+          </span>
           <span className="text-gray-600">|</span>
-          <span ref={fpsOverlayRef} className="tabular-nums text-cyan-300" title="Live Earth Simulator FPS sample">â€” FPS</span>
+          <span ref={fpsOverlayRef} className="tabular-nums text-cyan-300" title="Live Earth Simulator FPS sample">— FPS</span>
           <span className="text-gray-600">|</span>
           <span
             className="tabular-nums text-cyan-300"

--- a/components/crep/panels/services-panel-live.tsx
+++ b/components/crep/panels/services-panel-live.tsx
@@ -48,7 +48,7 @@ const STATUS_CONFIG = {
   offline: { icon: <XCircle className="w-3 h-3" />, color: "text-red-400", bg: "bg-red-500/10", border: "border-red-500/20" },
 };
 
-export default function ServicesPanelLive() {
+export default function ServicesPanelLive({ active = true }: { active?: boolean }) {
   const [services, setServices] = useState<ServiceStatus[]>([]);
   const [summary, setSummary] = useState<ServicesSummary>({ online: 0, degraded: 0, offline: 0, total: 0 });
   const [loading, setLoading] = useState(true);
@@ -56,7 +56,7 @@ export default function ServicesPanelLive() {
 
   const fetchServices = useCallback(async () => {
     try {
-      const res = await fetch("/api/crep/services", { signal: AbortSignal.timeout(10000) });
+      const res = await fetch("/api/crep/services", { signal: AbortSignal.timeout(40_000) });
       if (!res.ok) return;
       const data = await res.json();
       setServices(data.services || []);
@@ -70,10 +70,21 @@ export default function ServicesPanelLive() {
   }, []);
 
   useEffect(() => {
+    if (!active) return;
     fetchServices();
-    const interval = setInterval(fetchServices, 30000);
-    return () => clearInterval(interval);
-  }, [fetchServices]);
+    const interval = setInterval(() => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      fetchServices();
+    }, 30000);
+    const onVisibility = () => {
+      if (!document.hidden && active) fetchServices();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [active, fetchServices]);
 
   return (
     <div className="p-3 space-y-3 text-xs">

--- a/components/mindex/tabs/overview-tab.tsx
+++ b/components/mindex/tabs/overview-tab.tsx
@@ -431,7 +431,7 @@ export function OverviewSection({
 
     async function loadEarthFeed() {
       try {
-        const response = await fetch("/api/crep/unified", {
+        const response = await fetch("/api/crep/unified?countsOnly=true", {
           cache: "no-store",
           signal: controller.signal,
         })

--- a/contexts/myca-context.tsx
+++ b/contexts/myca-context.tsx
@@ -458,7 +458,7 @@ export function MYCAProvider({
           content: isTimeout
             ? "MYCA is taking longer than expected to respond. Please try again in a moment."
             : isNetwork
-            ? "MYCA is temporarily unable to connect. Please try again shortly."
+            ? "MAS orchestrator is unreachable — map commands still work locally; LLM chat resumes when MAS is back online."
             : `MYCA is briefly unavailable. Please try again in a moment.`,
           timestamp: new Date().toISOString(),
           agent: "myca-orchestrator",

--- a/hooks/use-crep-poll-scheduler.ts
+++ b/hooks/use-crep-poll-scheduler.ts
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+export interface CrepPollTask {
+  id: string
+  intervalMs: number
+  enabled?: boolean
+  run: () => void | Promise<void>
+}
+
+interface UseCrepPollSchedulerOptions {
+  masterTickMs?: number
+  shouldPause?: () => boolean
+}
+
+function scheduleIdleWork(fn: () => void) {
+  if (typeof requestIdleCallback === "function") {
+    requestIdleCallback(() => fn(), { timeout: 2_000 })
+    return
+  }
+  window.setTimeout(fn, 0)
+}
+
+export function useCrepPollScheduler(
+  tasks: CrepPollTask[],
+  options?: UseCrepPollSchedulerOptions,
+) {
+  const tasksRef = useRef(tasks)
+  tasksRef.current = tasks
+  const lastRunRef = useRef<Record<string, number>>({})
+  const shouldPauseRef = useRef(options?.shouldPause)
+  shouldPauseRef.current = options?.shouldPause
+
+  useEffect(() => {
+    const masterTickMs = options?.masterTickMs ?? 60_000
+
+    const tick = () => {
+      if (shouldPauseRef.current?.()) return
+      if (typeof document !== "undefined" && document.hidden) return
+
+      const now = Date.now()
+      for (const task of tasksRef.current) {
+        if (task.enabled === false) continue
+        const last = lastRunRef.current[task.id] ?? 0
+        if (now - last < task.intervalMs) continue
+        lastRunRef.current[task.id] = now
+        scheduleIdleWork(() => {
+          void task.run()
+        })
+      }
+    }
+
+    tick()
+    const intervalId = window.setInterval(tick, masterTickMs)
+    const onVisibility = () => {
+      if (!document.hidden) tick()
+    }
+    document.addEventListener("visibilitychange", onVisibility)
+    return () => {
+      window.clearInterval(intervalId)
+      document.removeEventListener("visibilitychange", onVisibility)
+    }
+  }, [options?.masterTickMs])
+}

--- a/lib/crep/crep-data-service.ts
+++ b/lib/crep/crep-data-service.ts
@@ -37,6 +37,17 @@ export interface FetchOptions {
   signal?: AbortSignal
 }
 
+/** Default caps for /api/crep/unified global bundle (Jun 20 2026). */
+export const UNIFIED_DEFAULT_LIMITS = {
+  aircraft: 1500,
+  vessels: 2500,
+  satellites: 1200,
+  fungal: 800,
+  events: 500,
+} as const
+
+export type UnifiedLimits = typeof UNIFIED_DEFAULT_LIMITS
+
 export interface PaginatedResult<T> {
   data: T[]
   total: number
@@ -179,6 +190,70 @@ async function safeFetch<T>(
   }
 }
 
+function slimAircraftRecord(raw: Record<string, unknown>): Aircraft {
+  return {
+    id: String(raw.id ?? raw.icao ?? ""),
+    callsign: String(raw.callsign ?? raw.flight ?? ""),
+    lat: Number(raw.lat ?? 0),
+    lng: Number(raw.lng ?? raw.lon ?? 0),
+    altitude: Number(raw.altitude ?? raw.alt ?? 0),
+    speed: Number(raw.speed ?? raw.velocity ?? 0),
+    heading: Number(raw.heading ?? raw.track ?? 0),
+    type: raw.type ? String(raw.type) : undefined,
+    origin: raw.origin ? String(raw.origin) : undefined,
+    destination: raw.destination ? String(raw.destination) : undefined,
+  }
+}
+
+function slimVesselRecord(raw: Record<string, unknown>): Vessel {
+  return {
+    id: String(raw.id ?? raw.mmsi ?? ""),
+    mmsi: String(raw.mmsi ?? raw.id ?? ""),
+    name: String(raw.name ?? "Vessel"),
+    lat: Number(raw.lat ?? 0),
+    lng: Number(raw.lng ?? raw.lon ?? 0),
+    heading: Number(raw.heading ?? 0),
+    speed: Number(raw.speed ?? 0),
+    type: raw.type ? String(raw.type) : undefined,
+    destination: raw.destination ? String(raw.destination) : undefined,
+  }
+}
+
+function slimFungalRecord(raw: Record<string, unknown>): FungalObservation {
+  return {
+    id: String(raw.id ?? ""),
+    species: String(raw.species ?? raw.name ?? "Species"),
+    lat: Number(raw.lat ?? 0),
+    lng: Number(raw.lng ?? raw.lon ?? 0),
+    observedOn: raw.observedOn ? String(raw.observedOn) : raw.observed_on ? String(raw.observed_on) : undefined,
+    location: raw.location ? String(raw.location) : undefined,
+  }
+}
+
+function slimGlobalEventRecord(raw: Record<string, unknown>): GlobalEvent {
+  return {
+    id: String(raw.id ?? ""),
+    type: String(raw.type ?? "event"),
+    title: String(raw.title ?? raw.name ?? "Event"),
+    lat: Number(raw.lat ?? 0),
+    lng: Number(raw.lng ?? raw.lon ?? 0),
+    severity: raw.severity ? String(raw.severity) : undefined,
+    timestamp: raw.timestamp ? String(raw.timestamp) : undefined,
+  }
+}
+
+function slimDeviceRecord(raw: Record<string, unknown>): Device {
+  return {
+    id: String(raw.id ?? ""),
+    name: String(raw.name ?? "Device"),
+    type: String(raw.type ?? "device"),
+    lat: raw.lat != null ? Number(raw.lat) : undefined,
+    lng: raw.lng != null ? Number(raw.lng) : raw.lon != null ? Number(raw.lon) : undefined,
+    status: String(raw.status ?? "unknown"),
+    lastSeen: raw.lastSeen ? String(raw.lastSeen) : raw.last_seen ? String(raw.last_seen) : undefined,
+  }
+}
+
 // ============================================================================
 // Aircraft Data
 // ============================================================================
@@ -186,18 +261,21 @@ async function safeFetch<T>(
 export async function getAircraft(options?: FetchOptions): Promise<Aircraft[]> {
   if (options?.forceRefresh) invalidateCache("aircraft")
 
-  return getCachedData<Aircraft[]>("aircraft", async () => {
+  const cacheKey = options?.limit ? `aircraft:limit:${options.limit}` : "aircraft"
+
+  return getCachedData<Aircraft[]>(cacheKey, async () => {
     const baseUrl = getBaseUrl()
     const url = new URL(`${baseUrl}/api/oei/flightradar24`)
     if (options?.limit) url.searchParams.set("limit", String(options.limit))
 
-    const data = await safeFetch<{ aircraft?: Aircraft[] }>(
+    const data = await safeFetch<{ aircraft?: Record<string, unknown>[] }>(
       url.toString(),
       { aircraft: [] },
       options?.timeout || 15000,
       options?.signal
     )
-    return data.aircraft || []
+    const aircraft = (data.aircraft || []).map((a) => slimAircraftRecord(a))
+    return options?.limit ? aircraft.slice(0, options.limit) : aircraft
   })
 }
 
@@ -225,15 +303,21 @@ export async function getAircraftPaginated(
 export async function getVessels(options?: FetchOptions): Promise<Vessel[]> {
   if (options?.forceRefresh) invalidateCache("vessels")
 
-  return getCachedData<Vessel[]>("vessels", async () => {
+  const cacheKey = options?.limit ? `vessels:limit:${options.limit}` : "vessels"
+
+  return getCachedData<Vessel[]>(cacheKey, async () => {
     const baseUrl = getBaseUrl()
-    const data = await safeFetch<{ vessels?: Vessel[] }>(
-      `${baseUrl}/api/oei/aisstream`,
+    const url = new URL(`${baseUrl}/api/oei/aisstream`)
+    if (options?.limit) url.searchParams.set("limit", String(options.limit))
+
+    const data = await safeFetch<{ vessels?: Record<string, unknown>[] }>(
+      url.toString(),
       { vessels: [] },
       options?.timeout || 15000,
       options?.signal
     )
-    return data.vessels || []
+    const vessels = (data.vessels || []).map((v) => slimVesselRecord(v))
+    return options?.limit ? vessels.slice(0, options.limit) : vessels
   })
 }
 
@@ -260,17 +344,54 @@ export async function getVesselsPaginated(
 
 const SATELLITE_CATEGORIES = ["weather", "science", "gps-ops", "active"]
 
+function slimSatelliteRecord(raw: Record<string, unknown>): Satellite {
+  return {
+    id: String(raw.id ?? raw.noradId ?? raw.norad_id ?? ""),
+    name: String(raw.name ?? "Unknown"),
+    noradId: String(raw.noradId ?? raw.norad_id ?? raw.id ?? ""),
+    lat: Number(raw.lat ?? 0),
+    lng: Number(raw.lng ?? raw.lon ?? 0),
+    altitude: Number(raw.altitude ?? raw.alt ?? 0),
+    velocity: Number(raw.velocity ?? raw.speed ?? 0),
+    category: raw.category ? String(raw.category) : undefined,
+  }
+}
+
+function dedupeSatellites(satellites: Satellite[]): Satellite[] {
+  const seen = new Set<string>()
+  const out: Satellite[] = []
+  for (const sat of satellites) {
+    const key = sat.noradId || sat.id
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    out.push(sat)
+  }
+  return out
+}
+
 export async function getSatellites(options?: FetchOptions): Promise<Satellite[]> {
   if (options?.forceRefresh) invalidateCache("satellites")
 
-  return getCachedData<Satellite[]>("satellites", async () => {
-    const baseUrl = getBaseUrl()
-    const allSatellites: Satellite[] = []
+  const cacheKey = options?.limit ? `satellites:limit:${options.limit}` : "satellites"
 
-    // Fetch categories in parallel for faster load
+  return getCachedData<Satellite[]>(cacheKey, async () => {
+    const baseUrl = getBaseUrl()
+    const limit = options?.limit
+
+    if (limit) {
+      const data = await safeFetch<{ satellites?: Record<string, unknown>[] }>(
+        `${baseUrl}/api/oei/satellites?category=active&mode=registry&limit=${limit}`,
+        { satellites: [] },
+        options?.timeout || 20000,
+        options?.signal
+      )
+      const raw = data.satellites || []
+      return dedupeSatellites(raw.map((s) => slimSatelliteRecord(s))).slice(0, limit)
+    }
+
     const results = await Promise.allSettled(
       SATELLITE_CATEGORIES.map((category) =>
-        safeFetch<{ satellites?: Satellite[] }>(
+        safeFetch<{ satellites?: Record<string, unknown>[] }>(
           `${baseUrl}/api/oei/satellites?category=${category}`,
           { satellites: [] },
           options?.timeout || 20000,
@@ -279,13 +400,14 @@ export async function getSatellites(options?: FetchOptions): Promise<Satellite[]
       )
     )
 
+    const allSatellites: Satellite[] = []
     for (const result of results) {
       if (result.status === "fulfilled" && result.value.satellites) {
-        allSatellites.push(...result.value.satellites)
+        allSatellites.push(...result.value.satellites.map((s) => slimSatelliteRecord(s)))
       }
     }
 
-    return allSatellites
+    return dedupeSatellites(allSatellites)
   })
 }
 
@@ -314,15 +436,21 @@ export async function getSpaceWeather(options?: FetchOptions): Promise<SpaceWeat
 export async function getGlobalEvents(options?: FetchOptions): Promise<GlobalEvent[]> {
   if (options?.forceRefresh) invalidateCache("globalEvents")
 
-  return getCachedData<GlobalEvent[]>("globalEvents", async () => {
+  const cacheKey = options?.limit ? `globalEvents:limit:${options.limit}` : "globalEvents"
+
+  return getCachedData<GlobalEvent[]>(cacheKey, async () => {
     const baseUrl = getBaseUrl()
-    const data = await safeFetch<{ events?: GlobalEvent[] }>(
-      `${baseUrl}/api/natureos/global-events`,
+    const url = new URL(`${baseUrl}/api/natureos/global-events`)
+    if (options?.limit) url.searchParams.set("limit", String(options.limit))
+
+    const data = await safeFetch<{ events?: Record<string, unknown>[] }>(
+      url.toString(),
       { events: [] },
       options?.timeout || 15000,
       options?.signal
     )
-    return data.events || []
+    const events = (data.events || []).map((e) => slimGlobalEventRecord(e))
+    return options?.limit ? events.slice(0, options.limit) : events
   })
 }
 
@@ -333,18 +461,21 @@ export async function getGlobalEvents(options?: FetchOptions): Promise<GlobalEve
 export async function getFungalObservations(options?: FetchOptions): Promise<FungalObservation[]> {
   if (options?.forceRefresh) invalidateCache("fungalObservations")
 
-  return getCachedData<FungalObservation[]>("fungalObservations", async () => {
+  const cacheKey = options?.limit ? `fungalObservations:limit:${options.limit}` : "fungalObservations"
+
+  return getCachedData<FungalObservation[]>(cacheKey, async () => {
     const baseUrl = getBaseUrl()
     const url = new URL(`${baseUrl}/api/crep/fungal`)
     if (options?.limit) url.searchParams.set("limit", String(options.limit))
 
-    const data = await safeFetch<{ observations?: FungalObservation[] }>(
+    const data = await safeFetch<{ observations?: Record<string, unknown>[] }>(
       url.toString(),
       { observations: [] },
       options?.timeout || 20000,
       options?.signal
     )
-    return data.observations || []
+    const observations = (data.observations || []).map((o) => slimFungalRecord(o))
+    return options?.limit ? observations.slice(0, options.limit) : observations
   })
 }
 
@@ -357,13 +488,13 @@ export async function getDevices(options?: FetchOptions): Promise<Device[]> {
 
   return getCachedData<Device[]>("devices", async () => {
     const baseUrl = getBaseUrl()
-    const data = await safeFetch<{ devices?: Device[] }>(
+    const data = await safeFetch<{ devices?: Record<string, unknown>[] }>(
       `${baseUrl}/api/mycobrain/devices`,
       { devices: [] },
       options?.timeout || 10000,
       options?.signal
     )
-    return data.devices || []
+    return (data.devices || []).map((d) => slimDeviceRecord(d))
   })
 }
 
@@ -371,16 +502,22 @@ export async function getDevices(options?: FetchOptions): Promise<Device[]> {
 // Aggregated Data
 // ============================================================================
 
-export async function getDataSummary(signal?: AbortSignal): Promise<CREPDataSummary> {
-  const opts: FetchOptions = { signal }
+export async function getDataSummary(
+  signal?: AbortSignal,
+  limits: UnifiedLimits = UNIFIED_DEFAULT_LIMITS
+): Promise<CREPDataSummary> {
+  const opts: FetchOptions = {
+    signal,
+    limit: limits.aircraft,
+  }
   const [aircraft, vessels, satellites, fungalObservations, globalEvents, devices] =
     await Promise.all([
-      getAircraft(opts).catch(() => []),
-      getVessels(opts).catch(() => []),
-      getSatellites(opts).catch(() => []),
-      getFungalObservations(opts).catch(() => []),
-      getGlobalEvents(opts).catch(() => []),
-      getDevices(opts).catch(() => []),
+      getAircraft({ ...opts, limit: limits.aircraft }).catch(() => []),
+      getVessels({ signal, limit: limits.vessels }).catch(() => []),
+      getSatellites({ signal, limit: limits.satellites }).catch(() => []),
+      getFungalObservations({ signal, limit: limits.fungal }).catch(() => []),
+      getGlobalEvents({ signal, limit: limits.events }).catch(() => []),
+      getDevices({ signal }).catch(() => []),
     ])
 
   return {
@@ -400,7 +537,8 @@ export async function getDataSummary(signal?: AbortSignal): Promise<CREPDataSumm
  */
 export async function fetchAllData(
   onDataReady?: (type: string, data: unknown[]) => void,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  limits: UnifiedLimits = UNIFIED_DEFAULT_LIMITS
 ): Promise<{
   aircraft: Aircraft[]
   vessels: Vessel[]
@@ -421,23 +559,23 @@ export async function fetchAllData(
 
   const fetchers = [
     async () => {
-      results.aircraft = await getAircraft(opts)
+      results.aircraft = await getAircraft({ ...opts, limit: limits.aircraft })
       onDataReady?.("aircraft", results.aircraft)
     },
     async () => {
-      results.vessels = await getVessels(opts)
+      results.vessels = await getVessels({ ...opts, limit: limits.vessels })
       onDataReady?.("vessels", results.vessels)
     },
     async () => {
-      results.satellites = await getSatellites(opts)
+      results.satellites = await getSatellites({ ...opts, limit: limits.satellites })
       onDataReady?.("satellites", results.satellites)
     },
     async () => {
-      results.fungalObservations = await getFungalObservations(opts)
+      results.fungalObservations = await getFungalObservations({ ...opts, limit: limits.fungal })
       onDataReady?.("fungalObservations", results.fungalObservations)
     },
     async () => {
-      results.globalEvents = await getGlobalEvents(opts)
+      results.globalEvents = await getGlobalEvents({ ...opts, limit: limits.events })
       onDataReady?.("globalEvents", results.globalEvents)
     },
     async () => {
@@ -537,56 +675,131 @@ export async function getEarthDataByBbox(options: EarthBboxOptions): Promise<{
     spaceWeather: [] as SpaceWeatherEvent[],
   }
 
-  // Try MINDEX spatial endpoint first
-  try {
-    const params = new URLSearchParams({
-      north: String(options.north),
-      south: String(options.south),
-      east: String(options.east),
-      west: String(options.west),
-    })
-    if (options.layers?.length) {
-      params.set("layers", options.layers.join(","))
-    }
-    if (options.limit) {
-      params.set("limit", String(options.limit))
-    }
+  // Try MINDEX spatial endpoint — one layer per request (API requires layer=)
+  const perLayerLimit = options.limit
+    ? Math.max(50, Math.ceil(options.limit / 4))
+    : 500
 
-    const mindexUrl = `${API_URLS.MINDEX}/api/earth/map/bbox?${params}`
-    const data = await safeFetch<Record<string, unknown[]>>(
-      mindexUrl,
-      {},
-      options.timeout || 8000,
-      options.signal
+  const layerMap: Array<{ key: keyof typeof emptyResult; layer: string; field: string }> = [
+    { key: "aircraft", layer: "aircraft", field: "aircraft" },
+    { key: "vessels", layer: "vessels", field: "vessels" },
+    { key: "satellites", layer: "satellites", field: "satellites" },
+    { key: "fungalObservations", layer: "species", field: "fungalObservations" },
+    { key: "globalEvents", layer: "earthquakes", field: "globalEvents" },
+    { key: "devices", layer: "facilities", field: "devices" },
+  ]
+
+  try {
+    const baseParams = new URLSearchParams({
+      lat_min: String(options.south),
+      lat_max: String(options.north),
+      lng_min: String(options.west),
+      lng_max: String(options.east),
+      limit: String(perLayerLimit),
+    })
+
+    const layerResults = await Promise.allSettled(
+      layerMap.map(async ({ layer }) => {
+        const params = new URLSearchParams(baseParams)
+        params.set("layer", layer)
+        const mindexUrl = `${API_URLS.MINDEX}/api/earth/map/bbox?${params}`
+        return safeFetch<{ entities?: Record<string, unknown>[] }>(
+          mindexUrl,
+          { entities: [] },
+          options.timeout || 8000,
+          options.signal
+        )
+      })
     )
 
-    if (data && Object.keys(data).length > 0) {
-      return {
-        aircraft: (data.aircraft as Aircraft[]) || [],
-        vessels: (data.vessels as Vessel[]) || [],
-        satellites: (data.satellites as Satellite[]) || [],
-        globalEvents: (data.events as GlobalEvent[]) || (data.globalEvents as GlobalEvent[]) || [],
-        fungalObservations: (data.observations as FungalObservation[]) || (data.fungalObservations as FungalObservation[]) || [],
-        devices: (data.devices as Device[]) || [],
-        weather: (data.weather as WeatherAlert[]) || [],
-        emissions: (data.emissions as EmissionSource[]) || [],
-        infrastructure: (data.infrastructure as InfrastructureItem[]) || [],
-        spaceWeather: (data.space_weather as SpaceWeatherEvent[]) || (data.spaceWeather as SpaceWeatherEvent[]) || [],
+    const merged = { ...emptyResult }
+    let anyData = false
+
+    for (let i = 0; i < layerMap.length; i++) {
+      const result = layerResults[i]
+      const { key } = layerMap[i]
+      if (result.status !== "fulfilled" || !result.value.entities?.length) continue
+      anyData = true
+      const entities = result.value.entities
+      if (key === "aircraft") {
+        merged.aircraft = entities.map((e) => ({
+          id: String(e.id ?? ""),
+          callsign: String((e.properties as Record<string, unknown>)?.callsign ?? e.name ?? ""),
+          lat: Number(e.lat ?? 0),
+          lng: Number(e.lng ?? 0),
+          altitude: Number((e.properties as Record<string, unknown>)?.altitude ?? 0),
+          speed: Number((e.properties as Record<string, unknown>)?.speed ?? 0),
+          heading: Number((e.properties as Record<string, unknown>)?.heading ?? 0),
+        }))
+      } else if (key === "vessels") {
+        merged.vessels = entities.map((e) => ({
+          id: String(e.id ?? ""),
+          mmsi: String((e.properties as Record<string, unknown>)?.mmsi ?? e.id ?? ""),
+          name: String(e.name ?? "Vessel"),
+          lat: Number(e.lat ?? 0),
+          lng: Number(e.lng ?? 0),
+          heading: Number((e.properties as Record<string, unknown>)?.heading ?? 0),
+          speed: Number((e.properties as Record<string, unknown>)?.speed ?? 0),
+        }))
+      } else if (key === "satellites") {
+        merged.satellites = entities.map((e) =>
+          slimSatelliteRecord({
+            id: e.id,
+            name: e.name,
+            lat: e.lat,
+            lng: e.lng,
+            altitude: (e.properties as Record<string, unknown>)?.altitude,
+          })
+        )
+      } else if (key === "fungalObservations") {
+        merged.fungalObservations = entities.map((e) => ({
+          id: String(e.id ?? ""),
+          species: String(e.name ?? "Species"),
+          lat: Number(e.lat ?? 0),
+          lng: Number(e.lng ?? 0),
+          observedOn: String(e.occurred_at ?? ""),
+        }))
+      } else if (key === "globalEvents") {
+        merged.globalEvents = entities.map((e) => ({
+          id: String(e.id ?? ""),
+          type: String(e.entity_type ?? "event"),
+          title: String(e.name ?? "Event"),
+          lat: Number(e.lat ?? 0),
+          lng: Number(e.lng ?? 0),
+          timestamp: String(e.occurred_at ?? ""),
+        }))
+      } else if (key === "devices") {
+        merged.devices = entities.map((e) => ({
+          id: String(e.id ?? ""),
+          name: String(e.name ?? "Device"),
+          type: String(e.entity_type ?? "facility"),
+          lat: Number(e.lat ?? 0),
+          lng: Number(e.lng ?? 0),
+          status: "online",
+        }))
       }
+    }
+
+    if (anyData) {
+      return merged
     }
   } catch {
     console.warn("[CREP Service] MINDEX earth/map/bbox unavailable, falling back to OEI")
   }
 
-  // Fallback: use existing OEI-based fetchers
-  const opts: FetchOptions = { signal: options.signal }
+  // Fallback: use existing OEI-based fetchers with limits
+  const perLimit = options.limit || UNIFIED_DEFAULT_LIMITS.aircraft
+  const opts: FetchOptions = {
+    signal: options.signal,
+    limit: perLimit,
+  }
   const [aircraft, vessels, satellites, fungalObservations, globalEvents, devices] =
     await Promise.all([
-      getAircraft(opts).catch(() => []),
-      getVessels(opts).catch(() => []),
-      getSatellites(opts).catch(() => []),
-      getFungalObservations(opts).catch(() => []),
-      getGlobalEvents(opts).catch(() => []),
+      getAircraft({ ...opts, limit: UNIFIED_DEFAULT_LIMITS.aircraft }).catch(() => []),
+      getVessels({ ...opts, limit: UNIFIED_DEFAULT_LIMITS.vessels }).catch(() => []),
+      getSatellites({ ...opts, limit: UNIFIED_DEFAULT_LIMITS.satellites }).catch(() => []),
+      getFungalObservations({ ...opts, limit: UNIFIED_DEFAULT_LIMITS.fungal }).catch(() => []),
+      getGlobalEvents({ ...opts, limit: UNIFIED_DEFAULT_LIMITS.events }).catch(() => []),
       getDevices(opts).catch(() => []),
     ])
 
@@ -632,7 +845,8 @@ export async function getEarthStats(signal?: AbortSignal): Promise<Record<string
  */
 export async function fetchAllEarthData(
   onDataReady?: (type: string, data: unknown[]) => void,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  limits: UnifiedLimits = UNIFIED_DEFAULT_LIMITS
 ): Promise<{
   aircraft: Aircraft[]
   vessels: Vessel[]
@@ -645,41 +859,7 @@ export async function fetchAllEarthData(
   infrastructure: InfrastructureItem[]
   spaceWeather: SpaceWeatherEvent[]
 }> {
-  // Try MINDEX full earth sync first
-  try {
-    const data = await safeFetch<Record<string, unknown[]>>(
-      `${API_URLS.MINDEX}/api/earth/crep/sync`,
-      {},
-      12000,
-      signal
-    )
-    if (data && Object.keys(data).length > 0) {
-      const result = {
-        aircraft: (data.aircraft as Aircraft[]) || [],
-        vessels: (data.vessels as Vessel[]) || [],
-        satellites: (data.satellites as Satellite[]) || [],
-        fungalObservations: (data.observations as FungalObservation[]) || [],
-        globalEvents: (data.events as GlobalEvent[]) || [],
-        devices: (data.devices as Device[]) || [],
-        weather: (data.weather as WeatherAlert[]) || [],
-        emissions: (data.emissions as EmissionSource[]) || [],
-        infrastructure: (data.infrastructure as InfrastructureItem[]) || [],
-        spaceWeather: (data.space_weather as SpaceWeatherEvent[]) || [],
-      }
-      // Fire progressive callbacks
-      for (const [key, val] of Object.entries(result)) {
-        if (Array.isArray(val) && val.length > 0) {
-          onDataReady?.(key, val)
-        }
-      }
-      return result
-    }
-  } catch {
-    // Fall through to individual fetchers
-  }
-
-  // Fallback: use existing fetchAllData + empty new domains
-  const base = await fetchAllData(onDataReady, signal)
+  const base = await fetchAllData(onDataReady, signal, limits)
   return {
     ...base,
     weather: [],

--- a/lib/crep/static-infra-loader.ts
+++ b/lib/crep/static-infra-loader.ts
@@ -104,19 +104,16 @@ export const INFRA_LAYERS: Record<string, InfraLayerConfig> = {
     // ~1.1 MB of points — load the full set so every data center shows at
     // flyover zoom (the PMTiles decimate; user: "missing data centers ...
     // should be the neon blue icons everywhere").
-    preferGeoJSON: true,
+    preferGeoJSON: false,
     maxGeojsonFallbackBytes: 8 * MB,
     label: "Global data centers (OSM + PeeringDB + MINDEX)",
   },
   powerPlantsGlobal: {
     sourceId: "crep-plants-global",
     pmtilesLayerName: "power_plants",
-    pmtilesUrl: "/data/crep/tiles/power-plants-global.pmtiles",
+    pmtilesUrl: "/api/crep/tiles/power-plants-global.pmtiles",
     geojsonUrl: "/data/crep/power-plants-global.geojson",
-    // ~15.6 MB / 34,936 points. PMTiles base-zoom decimation shows only the
-    // biggest ~50 plants at z3-4; load the full GeoJSON so all plants paint at
-    // every zoom (capacity-sized via circle-radius LOD), like OpenGridWorks.
-    preferGeoJSON: true,
+    preferGeoJSON: false,
     maxGeojsonFallbackBytes: 20 * MB,
     label: "Global power plants (WRI)",
   },
@@ -357,6 +354,11 @@ export async function addInfraSourceWithFallback(
     }
     const res = await fetch(cfg.geojsonUrl, { cache: "force-cache" })
     if (!res.ok) throw new Error(`${cfg.geojsonUrl} → HTTP ${res.status}`)
+    const contentType = res.headers.get("content-type") || ""
+    if (!contentType.includes("json") && !contentType.includes("geo+json")) {
+      const preview = (await res.clone().text()).slice(0, 80)
+      throw new Error(`${cfg.geojsonUrl} returned non-JSON (${contentType || "unknown"}): ${preview}`)
+    }
     const fc = await res.json()
     try {
       map.addSource(cfg.sourceId, { type: "geojson", data: fc })

--- a/lib/crep/streaming/entity-websocket-client.ts
+++ b/lib/crep/streaming/entity-websocket-client.ts
@@ -282,7 +282,7 @@ export class EntityStreamClient {
     if (this.options.types?.length) params.set("types", this.options.types.join(","))
     if (this.options.timeFrom) params.set("time_from", this.options.timeFrom)
     const qs = params.toString()
-    return `/api/stream/entities${qs ? `?${qs}` : ""}`
+    return `/api/stream/crep?mode=entities${qs ? `&${qs}` : ""}`
   }
 
   private openSseBff(): void {

--- a/public/crep-sw.js
+++ b/public/crep-sw.js
@@ -43,7 +43,7 @@
 // May 16, 2026: v5 bypasses video/range requests entirely. A root-scoped
 // cache-first worker must never answer MP4 Range requests; doing so can make
 // homepage/device videos stutter, restart, or play stale cached media.
-const CACHE_VERSION = "crep-v5"
+const CACHE_VERSION = "crep-v6"
 const CACHE_NAME = `mycosoft-${CACHE_VERSION}`
 const API_CACHE_NAME = `${CACHE_NAME}-api`
 

--- a/scripts/audit-earth-simulator-prod.mjs
+++ b/scripts/audit-earth-simulator-prod.mjs
@@ -1,0 +1,350 @@
+/**
+ * Production audit: Earth Simulator at mycosoft.com
+ * One-shot script — writes JSON report to stdout.
+ */
+import { chromium } from "playwright";
+import { writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+
+const URL = process.env.EARTH_SIM_AUDIT_URL || process.env.BASE_URL || "https://mycosoft.com/natureos/earth-simulator";
+const OUT_DIR = join(process.cwd(), "tmp", "earth-simulator-audit");
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  const report = {
+    url: URL,
+    timestamp: new Date().toISOString(),
+    pageLoad: {},
+    uiElements: [],
+    features: { working: [], broken: [], unknown: [] },
+    networkFailures: [],
+    consoleErrors: [],
+    consoleWarnings: [],
+    interactions: [],
+    performance: {},
+    screenshots: [],
+  };
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    userAgent:
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  });
+  const page = await context.newPage();
+
+  const failedRequests = [];
+  page.on("requestfailed", (req) => {
+    failedRequests.push({
+      url: req.url(),
+      method: req.method(),
+      failure: req.failure()?.errorText ?? "unknown",
+    });
+  });
+
+  page.on("response", (res) => {
+    const status = res.status();
+    if (status >= 400) {
+      failedRequests.push({
+        url: res.url(),
+        method: res.request().method(),
+        status,
+      });
+    }
+  });
+
+  page.on("console", (msg) => {
+    const type = msg.type();
+    const text = msg.text();
+    if (type === "error") report.consoleErrors.push(text.slice(0, 500));
+    if (type === "warning") report.consoleWarnings.push(text.slice(0, 300));
+  });
+
+  page.on("pageerror", (err) => {
+    report.consoleErrors.push(`PAGE_ERROR: ${err.message}`.slice(0, 500));
+  });
+
+  const navStart = Date.now();
+  let response = null;
+  try {
+    response = await page.goto(URL, { waitUntil: "domcontentloaded", timeout: 90000 });
+  } catch (e) {
+    report.pageLoad.error = String(e);
+  }
+  const domReadyMs = Date.now() - navStart;
+
+  report.pageLoad.httpStatus = response?.status() ?? null;
+  report.pageLoad.domContentLoadedMs = domReadyMs;
+
+  // Wait for map or loading state to resolve
+  await page.waitForTimeout(8000);
+
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 15000 });
+    report.pageLoad.networkIdleMs = Date.now() - navStart;
+  } catch {
+    report.pageLoad.networkIdleMs = null;
+    report.pageLoad.networkIdleTimeout = true;
+  }
+
+  const totalMs = Date.now() - navStart;
+  report.pageLoad.totalWaitMs = totalMs;
+
+  // Initial screenshot
+  const shot1 = join(OUT_DIR, "01-initial.png");
+  await page.screenshot({ path: shot1, fullPage: false });
+  report.screenshots.push({ file: shot1, label: "Initial after 8s wait" });
+
+  const bodyText = await page.locator("body").innerText().catch(() => "");
+  report.pageLoad.bodyTextSample = bodyText.slice(0, 2000);
+  report.pageLoad.stillInitializing =
+    /INITIALIZING|Loading|loading/i.test(bodyText) &&
+    !/Earth Simulator/i.test(bodyText.slice(0, 500));
+
+  // Collect visible UI via common selectors / aria / text
+  const uiChecks = [
+    { name: "Map canvas (Mapbox/Cesium)", selectors: ["canvas.mapboxgl-canvas", "canvas", ".mapboxgl-map", "#cesiumContainer", "[data-testid*='map']"] },
+    { name: "Layer toggles / controls", selectors: ["[data-testid*='layer']", "button:has-text('Layer')", "[aria-label*='layer' i]", ".layer-control", "[class*='layer']"] },
+    { name: "Environment panel", selectors: ["[data-testid*='environment']", ":text('Environment')", "[aria-label*='environment' i]"] },
+    { name: "Emergency weather", selectors: [":text('Emergency')", ":text('Weather')", "[data-testid*='weather']", "[data-testid*='emergency']"] },
+    { name: "Aircraft", selectors: [":text('Aircraft')", ":text('Aviation')", "[data-testid*='aircraft']", "[data-testid*='aviation']"] },
+    { name: "Vessels", selectors: [":text('Vessel')", ":text('Maritime')", "[data-testid*='vessel']"] },
+    { name: "Satellites", selectors: [":text('Satellite')", "[data-testid*='satellite']"] },
+    { name: "Fungal layer", selectors: [":text('Fungal')", ":text('Fungi')", "[data-testid*='fungal']", "[data-testid*='fungi']"] },
+    { name: "Devices / sensors", selectors: [":text('Device')", ":text('Sensor')", "[data-testid*='device']", "[data-testid*='sensor']"] },
+    { name: "MYCA / AI chat", selectors: [":text('MYCA')", ":text('Ask MYCA')", "[data-testid*='myca']", "[data-testid*='chat']", "[aria-label*='chat' i]"] },
+    { name: "NatureOS navigation", selectors: ["nav", "[role='navigation']", ":text('Earth Simulator')"] },
+    { name: "Side panel / drawer", selectors: ["[role='dialog']", "aside", "[data-testid*='panel']", "[data-testid*='sidebar']"] },
+  ];
+
+  for (const check of uiChecks) {
+    let found = false;
+    let count = 0;
+    for (const sel of check.selectors) {
+      try {
+        const loc = page.locator(sel).first();
+        if ((await loc.count()) > 0 && (await loc.isVisible().catch(() => false))) {
+          found = true;
+          count = await page.locator(sel).count();
+          break;
+        }
+      } catch {
+        /* skip invalid selector */
+      }
+    }
+    report.uiElements.push({ feature: check.name, visible: found, matchCount: count });
+  }
+
+  // Text-based feature scan
+  const featureKeywords = [
+    "Layer", "Environment", "Weather", "Aircraft", "Vessel", "Satellite",
+    "Fungal", "Fungi", "Device", "Sensor", "MYCA", "CREP", "Earth",
+    "Zoom", "Timeline", "Filter", "Search",
+  ];
+  report.visibleKeywords = featureKeywords.filter((k) =>
+    new RegExp(k, "i").test(bodyText)
+  );
+
+  // Map canvas dimensions
+  const canvasInfo = await page.evaluate(() => {
+    const canvases = Array.from(document.querySelectorAll("canvas"));
+    return canvases.map((c) => ({
+      w: c.width,
+      h: c.height,
+      clientW: c.clientWidth,
+      clientH: c.clientHeight,
+      className: c.className?.slice?.(0, 80) ?? "",
+    }));
+  });
+  report.performance.canvasElements = canvasInfo;
+  report.features.working.push(
+    ...(canvasInfo.some((c) => c.clientW > 100 && c.clientH > 100)
+      ? ["Map canvas rendered with non-zero dimensions"]
+      : [])
+  );
+  if (!canvasInfo.some((c) => c.clientW > 100)) {
+    report.features.broken.push("No visible map canvas (>100px)");
+  }
+
+  // FPS sample via rAF over 2s
+  const fpsSample = await page.evaluate(async () => {
+    return new Promise((resolve) => {
+      let frames = 0;
+      const start = performance.now();
+      function tick() {
+        frames++;
+        if (performance.now() - start < 2000) {
+          requestAnimationFrame(tick);
+        } else {
+          resolve({ fps: Math.round((frames / 2) * 10) / 10, frames });
+        }
+      }
+      requestAnimationFrame(tick);
+    });
+  });
+  report.performance.estimatedFps = fpsSample;
+
+  // Interactions
+  async function tryClick(label, selectors) {
+    for (const sel of selectors) {
+      try {
+        const el = page.locator(sel).first();
+        if ((await el.count()) > 0 && (await el.isVisible())) {
+          await el.click({ timeout: 3000 });
+          await page.waitForTimeout(1500);
+          report.interactions.push({ action: label, selector: sel, success: true });
+          return true;
+        }
+      } catch (e) {
+        report.interactions.push({ action: label, selector: sel, success: false, error: String(e).slice(0, 200) });
+      }
+    }
+    return false;
+  }
+
+  // Zoom via mapbox controls or wheel
+  try {
+    const mapCanvas = page.locator("canvas.mapboxgl-canvas, canvas").first();
+    if ((await mapCanvas.count()) > 0) {
+      const box = await mapCanvas.boundingBox();
+      if (box) {
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.wheel(0, -400);
+        await page.waitForTimeout(1000);
+        await page.mouse.wheel(0, 400);
+        report.interactions.push({ action: "Map zoom wheel in/out", success: true });
+      }
+    } else {
+      report.interactions.push({ action: "Map zoom wheel", success: false, error: "no canvas" });
+    }
+  } catch (e) {
+    report.interactions.push({ action: "Map zoom wheel", success: false, error: String(e).slice(0, 200) });
+  }
+
+  await tryClick("Zoom in button", [
+    "button[aria-label*='Zoom in' i]",
+    ".mapboxgl-ctrl-zoom-in",
+    "[title*='Zoom in' i]",
+  ]);
+  await tryClick("Layer toggle", [
+    "button:has-text('Layer')",
+    "[data-testid*='layer']",
+    "label:has-text('Layer')",
+  ]);
+  await tryClick("Environment panel", [
+    "button:has-text('Environment')",
+    "[data-testid*='environment']",
+  ]);
+  await tryClick("Aircraft layer", [
+    "button:has-text('Aircraft')",
+    "label:has-text('Aircraft')",
+    "[data-testid*='aircraft']",
+  ]);
+  await tryClick("Open side panel", [
+    "button[aria-label*='panel' i]",
+    "button[aria-label*='menu' i]",
+    "[data-testid*='sidebar']",
+  ]);
+
+  const readAircraftCounters = async () => {
+    const body = await page.locator("body").innerText().catch(() => "");
+    const zoomMatch = body.match(/Z\s+([\d.]+)/);
+    const planesMatch = body.match(/Planes:\s*(\d+)/);
+    return {
+      zoom: zoomMatch ? Number(zoomMatch[1]) : null,
+      planes: planesMatch ? Number(planesMatch[1]) : null,
+      hasZoomHint: /Zoom in for aircraft/i.test(body),
+    };
+  };
+
+  const aircraftAtDefaultZoom = await readAircraftCounters();
+  report.aircraftLod = { atDefaultZoom: aircraftAtDefaultZoom };
+  if (aircraftAtDefaultZoom.zoom != null && aircraftAtDefaultZoom.zoom < 3.5) {
+    if (aircraftAtDefaultZoom.hasZoomHint) {
+      report.features.working.push("Aircraft zoom hint shown below z3.5");
+    } else {
+      report.features.broken.push("Aircraft zoom hint missing below z3.5");
+    }
+  }
+
+  try {
+    const mapCanvas = page.locator("canvas.mapboxgl-canvas, canvas").first();
+    if ((await mapCanvas.count()) > 0) {
+      const box = await mapCanvas.boundingBox();
+      if (box) {
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        for (let i = 0; i < 8; i += 1) {
+          await page.mouse.wheel(0, -500);
+          await page.waitForTimeout(250);
+        }
+        await page.waitForTimeout(4000);
+        const aircraftZoomedIn = await readAircraftCounters();
+        report.aircraftLod.atZoom4Plus = aircraftZoomedIn;
+        if (aircraftZoomedIn.zoom != null && aircraftZoomedIn.zoom >= 3.5) {
+          if (aircraftZoomedIn.planes != null && aircraftZoomedIn.planes > 0) {
+            report.features.working.push(`Aircraft visible at z${aircraftZoomedIn.zoom} (${aircraftZoomedIn.planes} planes)`);
+          } else {
+            report.features.unknown.push(`Aircraft layer empty at z${aircraftZoomedIn.zoom} (API may be empty)`);
+          }
+        }
+      }
+    }
+  } catch (e) {
+    report.aircraftLod.zoomInError = String(e).slice(0, 200);
+  }
+
+  const shot2 = join(OUT_DIR, "02-after-interactions.png");
+  await page.screenshot({ path: shot2, fullPage: false });
+  report.screenshots.push({ file: shot2, label: "After interactions" });
+
+  // Dedupe network failures
+  const seen = new Set();
+  report.networkFailures = failedRequests.filter((r) => {
+    const key = `${r.url}|${r.status ?? r.failure}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    // Ignore analytics / third-party noise optionally
+    return true;
+  }).slice(0, 80);
+
+  // Classify API failures
+  const apiFailures = report.networkFailures.filter(
+    (r) =>
+      r.url.includes("/api/") ||
+      r.url.includes("192.168") ||
+      r.url.includes("mindex") ||
+      r.url.includes("mas") ||
+      r.url.includes("crep") ||
+      r.url.includes("earth")
+  );
+  report.apiFailures = apiFailures;
+
+  report.consoleErrors = [...new Set(report.consoleErrors)].slice(0, 30);
+  report.consoleWarnings = [...new Set(report.consoleWarnings)].slice(0, 20);
+
+  // Feature working/broken heuristics
+  for (const el of report.uiElements) {
+    if (el.visible) report.features.working.push(el.feature);
+    else report.features.unknown.push(el.feature);
+  }
+  if (/INITIALIZING CREP/i.test(bodyText) && totalMs > 10000) {
+    report.features.broken.push("CREP stuck on INITIALIZING after extended wait");
+  }
+  if (report.consoleErrors.length > 0) {
+    report.features.broken.push(`${report.consoleErrors.length} console error(s)`);
+  }
+  if (apiFailures.length > 0) {
+    report.features.broken.push(`${apiFailures.length} API/network failure(s)`);
+  }
+
+  writeFileSync(join(OUT_DIR, "report.json"), JSON.stringify(report, null, 2));
+  console.log(JSON.stringify(report, null, 2));
+
+  await browser.close();
+}
+
+main().catch((e) => {
+  console.error(JSON.stringify({ fatal: String(e) }));
+  process.exit(1);
+});

--- a/scripts/blue-green-deploy.sh
+++ b/scripts/blue-green-deploy.sh
@@ -70,47 +70,20 @@ load_deploy_env() {
 load_production_env() {
   local env_file="${DEPLOY_DIR:-/opt/mycosoft/website}/.env"
   [[ -f "$env_file" ]] || { err "Missing production env: $env_file"; exit 8; }
-  # In-place sanitize: join KEY= + bare value line (Jun 19 2026 prod regression).
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - "$env_file" <<'PY' || true
-import sys
-from pathlib import Path
-p = Path(sys.argv[1])
-lines = p.read_text().splitlines()
-out, i, changed = [], 0, False
-while i < len(lines):
-    ln, s = lines[i], lines[i].strip()
-    if s and not s.startswith("#") and "=" not in s:
-        if out and out[-1].rstrip().endswith("="):
-            out[-1] = out[-1].rstrip() + s
-        else:
-            out.append("MINDEX_INTERNAL_TOKEN=" + s)
-        changed = True
-        i += 1
-        continue
-    if ln.rstrip().endswith("=") and i + 1 < len(lines):
-        nxt = lines[i + 1].strip()
-        if nxt and "=" not in nxt and not nxt.startswith("#"):
-            out.append(ln.rstrip() + nxt)
-            changed = True
-            i += 2
-            continue
-    out.append(ln)
-    i += 1
-if changed:
-    orig = p.read_text()
-    p.write_text("\n".join(out) + ("\n" if orig.endswith("\n") else ""))
-PY
+  local sanitizer="${DEPLOY_DIR}/scripts/sanitize-production-env.sh"
+  if [[ -x "$sanitizer" ]]; then
+    # shellcheck disable=SC1090
+    source "$sanitizer" "$env_file"
+  elif command -v python3 >/dev/null 2>&1 && [[ -f "${DEPLOY_DIR}/scripts/sanitize-production-env.py" ]]; then
+    python3 "${DEPLOY_DIR}/scripts/sanitize-production-env.py" "$env_file" || true
+    set -a
+    # shellcheck disable=SC1090
+    eval "$(python3 "${DEPLOY_DIR}/scripts/sanitize-production-env.py" --export "$env_file")"
+    set +a
+  else
+    err "Missing sanitize-production-env helper — cannot safely load $env_file"
+    exit 8
   fi
-  set -a
-  # Robust source: only well-formed KEY=VALUE assignment lines. A malformed line — e.g. a
-  # stray secret wrapped onto its own line without a KEY= prefix — would otherwise be run as
-  # a command under `source` and abort the whole deploy (exit 127) BEFORE any health/auth
-  # safety check, blocking every cutover. Filtering keeps all real vars, drops junk lines.
-  # (Jun 19 2026 — prod .env line-167 bare-token regression that blocked a deploy.)
-  # shellcheck disable=SC1090
-  source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$env_file")
-  set +a
   # Never allow dev PC values on production VM
   if [[ "${NEXT_PUBLIC_BASE_URL:-}" == *localhost* ]]; then
     err "NEXT_PUBLIC_BASE_URL must not be localhost on production (got $NEXT_PUBLIC_BASE_URL)"

--- a/scripts/sanitize-production-env.py
+++ b/scripts/sanitize-production-env.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Sanitize production .env and emit safe export statements (no bash source of raw file)."""
+from __future__ import annotations
+
+import re
+import shlex
+import sys
+from pathlib import Path
+
+KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Long alphanumeric lines without = are stray secrets (Jun 19 2026 regression).
+BARE_SECRET_RE = re.compile(r"^[A-Za-z0-9_-]{20,}$")
+
+
+def _normalize_value(val: str) -> str:
+    val = val.strip()
+    # Backticks or $(...) turn the token into a shell command when sourced.
+    if len(val) >= 2 and val[0] == "`" and val[-1] == "`":
+        val = val[1:-1]
+    if val.startswith("$(") and val.endswith(")"):
+        val = val[2:-1]
+    if ";" in val:
+        val = val.split(";", 1)[0].strip()
+    parts = val.split()
+    if len(parts) > 1 and BARE_SECRET_RE.match(parts[-1]):
+        val = parts[0]
+    return val
+
+
+def sanitize_lines(lines: list[str]) -> tuple[list[str], bool]:
+    out: list[str] = []
+    changed = False
+    i = 0
+    while i < len(lines):
+        raw = lines[i]
+        s = raw.strip().strip("\r")
+
+        if not s or s.startswith("#"):
+            out.append(raw.rstrip("\r"))
+            i += 1
+            continue
+
+        if "=" not in s:
+            if BARE_SECRET_RE.match(s) or (
+                len(s) > 30 and re.fullmatch(r"[A-Za-z0-9_-]+", s)
+            ):
+                if out and out[-1].rstrip().endswith("="):
+                    out[-1] = out[-1].rstrip() + s
+                else:
+                    out.append("MINDEX_INTERNAL_TOKEN=" + s)
+                changed = True
+                i += 1
+                continue
+            out.append(raw.rstrip("\r"))
+            i += 1
+            continue
+
+        key, _, val = s.partition("=")
+        key = key.strip()
+        val = val.strip()
+
+        if KEY_RE.match(key) and val == "" and i + 1 < len(lines):
+            nxt = lines[i + 1].strip().strip("\r")
+            if nxt and "=" not in nxt and not nxt.startswith("#"):
+                merged = f"{key}={nxt}"
+                if merged != s:
+                    changed = True
+                out.append(merged)
+                i += 2
+                continue
+
+        if KEY_RE.match(key):
+            new_val = _normalize_value(val)
+            merged = f"{key}={new_val}"
+            if merged != s:
+                changed = True
+            out.append(merged)
+            i += 1
+            continue
+
+        out.append(raw.rstrip("\r"))
+        i += 1
+
+    # Drop duplicate bare-secret lines that slipped through as KEY= duplicates.
+    seen_mindex = False
+    deduped: list[str] = []
+    for ln in out:
+        s = ln.strip()
+        if s.startswith("MINDEX_INTERNAL_TOKEN="):
+            if seen_mindex:
+                changed = True
+                continue
+            seen_mindex = True
+        deduped.append(ln)
+
+    return deduped, changed
+
+
+def sanitize_file(path: Path) -> bool:
+    text = path.read_text()
+    lines = text.splitlines()
+    cleaned, changed = sanitize_lines(lines)
+    if changed:
+        path.write_text("\n".join(cleaned) + ("\n" if text.endswith("\n") else ""))
+        print(f"Sanitized {path}")
+    else:
+        print(f"No changes needed for {path}")
+    return changed
+
+
+def export_statements(path: Path) -> str:
+    lines = path.read_text().splitlines()
+    exports: list[str] = []
+    for raw in lines:
+        s = raw.strip().strip("\r")
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        key, _, val = s.partition("=")
+        key = key.strip()
+        if not KEY_RE.match(key):
+            continue
+        val = _normalize_value(val)
+        exports.append(f"export {key}={shlex.quote(val)}")
+    return "\n".join(exports)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: sanitize-production-env.py <path> | --export <path>", file=sys.stderr)
+        return 2
+
+    if sys.argv[1] == "--export":
+        path = Path(sys.argv[2])
+        if not path.is_file():
+            print(f"Missing {path}", file=sys.stderr)
+            return 1
+        print(export_statements(path))
+        return 0
+
+    path = Path(sys.argv[1])
+    if not path.is_file():
+        print(f"Missing {path}", file=sys.stderr)
+        return 1
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    backup = path.with_suffix(path.suffix + ".bak.sanitize")
+    backup.write_text(path.read_text())
+    sanitize_file(path)
+    # Verify exports parse without shell execution of secret tokens.
+    try:
+        export_statements(path)
+    except Exception as exc:
+        print(f"ENV_VERIFY_FAILED: {exc}", file=sys.stderr)
+        return 1
+    print("ENV_VERIFY_OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sanitize-production-env.sh
+++ b/scripts/sanitize-production-env.sh
@@ -1,44 +1,19 @@
 #!/usr/bin/env bash
-# Fix malformed production .env lines (bare secret on its own line without KEY=).
-# Jun 19 2026 — blocked blue/green cutover with exit 127.
+# Sanitize production .env and load vars safely (no raw bash source of .env).
 set -euo pipefail
+
 ENV_FILE="${1:-/opt/mycosoft/website/.env}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="${SCRIPT_DIR}/sanitize-production-env.py"
+
 [[ -f "$ENV_FILE" ]] || { echo "Missing $ENV_FILE" >&2; exit 1; }
-cp "$ENV_FILE" "${ENV_FILE}.bak.sanitize"
-python3 - "$ENV_FILE" <<'PY'
-import sys
-from pathlib import Path
-p = Path(sys.argv[1])
-lines = p.read_text().splitlines()
-out, i, changed = [], 0, False
-while i < len(lines):
-    ln, s = lines[i], lines[i].strip()
-    if s and not s.startswith("#") and "=" not in s:
-        if out and out[-1].rstrip().endswith("="):
-            out[-1] = out[-1].rstrip() + s
-        else:
-            out.append("MINDEX_INTERNAL_TOKEN=" + s)
-        changed = True
-        i += 1
-        continue
-    if ln.rstrip().endswith("=") and i + 1 < len(lines):
-        nxt = lines[i + 1].strip()
-        if nxt and "=" not in nxt and not nxt.startswith("#"):
-            out.append(ln.rstrip() + nxt)
-            changed = True
-            i += 2
-            continue
-    out.append(ln)
-    i += 1
-if changed:
-    orig = p.read_text()
-    p.write_text("\n".join(out) + ("\n" if orig.endswith("\n") else ""))
-    print(f"Sanitized {p}")
-else:
-    print(f"No changes needed for {p}")
-PY
+[[ -f "$PY" ]] || { echo "Missing $PY" >&2; exit 1; }
+
+python3 "$PY" "$ENV_FILE"
+
 set -a
 # shellcheck disable=SC1090
-source <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE")
+eval "$(python3 "$PY" --export "$ENV_FILE")"
 set +a
+
 echo "ENV_SOURCE_OK"


### PR DESCRIPTION
## Summary
- Add /api/stream/entities SSE BFF for MAS entity stream
- Cap and slim /api/crep/unified payloads (~520KB vs 3MB)
- PMTiles-first infra loading, live status bar, MYCA full LLM, poll scheduler

## Test plan
- [x] localhost:3010 earth-simulator loads
- [x] unified API capped (~533KB)
- [x] Playwright audit: aircraft LOD, UTF-8 verified text
- [ ] Production deploy after merge (MAS 188 currently unreachable)

## Summary by Sourcery

Cap and slim CREP unified Earth data responses while adding MAS entity SSE streaming and live health/status UX improvements for the Earth Simulator.

New Features:
- Expose a unified SSE entities stream API that proxies MAS WebSocket streams for browser clients.
- Add a poll scheduler hook to drive periodic CREP background health checks and warming.
- Introduce a production Playwright-based Earth Simulator audit script and env-sanitizer helper for safer deploys.

Bug Fixes:
- Prevent malformed or unsafe production .env content from breaking blue/green deploys by sanitizing and exporting variables robustly.
- Avoid blocking or noisy external health checks by tightening timeouts and simplifying CelesTrak probing.
- Ensure Earth-2-dependent visual layers auto-disable when the service is unavailable to avoid broken UX.

Enhancements:
- Slim aircraft, vessel, satellite, fungal, event, and device records and enforce per-domain limits to reduce unified CREP payload sizes.
- Add bbox-aware, cached unified Earth data endpoint with counts-only mode to support lighter overviews and faster reloads.
- Prefer PMTiles for heavy infrastructure layers while hardening GeoJSON fallbacks with content-type validation.
- Upgrade Earth Simulator UI with richer footer health status, MYCA messaging, and zoom-based aircraft LOD hints.
- Make live services panel and health polling respect tab visibility and pause conditions to reduce unnecessary load.

Build:
- Add a headless audit script using Playwright to verify Earth Simulator rendering, LOD behavior, and network/API health in production.

CI:
- Wire the new audit and sanitize helpers into CI/CD deploy steps and simplify env handling on production hosts.

Deployment:
- Standardize production env sanitization across blue/green deploy scripts using shared bash/Python helpers and sync them from main during deploys.