### PR TITLE
fix(tablet): iPad home + Earth Simulator perf

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -83,7 +83,7 @@ ENV NEXT_PRIVATE_DISABLE_WORKER_THREADS=1
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # Cache-bust token MUST change when routes must register on prod (BuildKit GHA cache).
-RUN echo "DEPLOY_CACHE_BUST=earth-sim-entities-via-crep-jun20-r7 commit=${SOURCE_COMMIT}" && npm run build
+RUN echo "DEPLOY_CACHE_BUST=ipad-tablet-perf-jun20-r8 commit=${SOURCE_COMMIT}" && npm run build
 
 # Production image
 FROM base AS runner

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -2447,11 +2447,11 @@ function getEventDomMarkerCapForZoom(zoom: number, earthSimulator = false) {
     }
     if (perfClass === "tablet") {
       const tabletCap =
-        zoom >= 9 ? 180 :
-        zoom >= 7 ? 160 :
-        zoom >= 5 ? 140 :
-        zoom >= 3 ? 120 :
-        100;
+        zoom >= 9 ? 100 :
+        zoom >= 7 ? 90 :
+        zoom >= 5 ? 75 :
+        zoom >= 3 ? 65 :
+        55;
       return Math.min(baseCap, tabletCap);
     }
     return baseCap;
@@ -2489,13 +2489,13 @@ function getNatureDomMarkerCapForZoom(
     }
     if (perfClass === "tablet") {
       const tabletCap =
-        zoom >= 11 ? 760 :
-        zoom >= 9 ? 660 :
-        zoom >= 7 ? 560 :
-        zoom >= 5 ? 460 :
-        zoom >= 3 ? 320 :
-        220;
-      return Math.min(EARTH_SIM_DOM_MARKER_CAP, Math.max(120, Math.floor(tabletCap * kingdomScale)));
+        zoom >= 11 ? 380 :
+        zoom >= 9 ? 330 :
+        zoom >= 7 ? 280 :
+        zoom >= 5 ? 220 :
+        zoom >= 3 ? 160 :
+        120;
+      return Math.min(EARTH_SIM_DOM_MARKER_CAP, Math.max(80, Math.floor(tabletCap * kingdomScale)));
     }
     const tierCap =
       zoom >= 11 ? 900 :
@@ -7896,10 +7896,18 @@ export default function CREPDashboardPage({
     };
   }, []);
   const [leftPanelOpen, setLeftPanelOpen] = useState(
-    () => !embedded && !(isEarthSimulatorPath() && getEarthSimViewportPerfClass() === "phone"),
+    () => {
+      if (embedded) return false
+      if (!isEarthSimulatorPath()) return true
+      return getEarthSimViewportPerfClass() !== "phone"
+    },
   );
   const [rightPanelOpen, setRightPanelOpen] = useState(
-    () => !embedded && !(isEarthSimulatorPath() && getEarthSimViewportPerfClass() === "phone"),
+    () => {
+      if (embedded) return false
+      if (!isEarthSimulatorPath()) return true
+      return getEarthSimViewportPerfClass() === "desktop"
+    },
   );
   const [rightPanelTab, setRightPanelTab] = useState("myca");
   const [leftPanelTab, setLeftPanelTab] = useState<"fungal" | "myca" | "infra">("fungal"); // DEFAULT TO FUNGAL
@@ -7934,24 +7942,25 @@ export default function CREPDashboardPage({
     const phoneMq = window.matchMedia("(max-width: 767px)");
     const earthTabletMq = window.matchMedia("(max-width: 1180px), (pointer: coarse)");
     const applyResponsivePanelDefaults = () => {
-      const earthSimulator = isEarthSimulatorPath();
-      // Only genuine phones (perf-class) auto-collapse the Earth Sim panels.
-      // earthTabletMq = "(max-width:1180px),(pointer:coarse)" matched EVERY iPad
-      // (coarse pointer) and re-closed the panels the init opened — defeating the
-      // "iPad starts like desktop" requirement. Now iPads ("tablet") fall into the
-      // panels-open branch. (Jun 13, 2026 — iPad QA.)
-      const earthTablet = isEarthSimulatorPath() && getEarthSimViewportPerfClass() === "phone";
-      if (phoneMq.matches || earthTablet) {
-        setLeftPanelOpen(false);
-        setRightPanelOpen(false);
+      const earthSimulator = isEarthSimulatorPath()
+      const perfClass = earthSimulator ? getEarthSimViewportPerfClass() : "desktop"
+      // Only genuine phones auto-collapse both panels. iPad/tablet keeps left open only
+      // so the map has GPU headroom (Jun 20, 2026 — iPad freeze fix).
+      const earthPhone = perfClass === "phone"
+      if (phoneMq.matches || earthPhone) {
+        setLeftPanelOpen(false)
+        setRightPanelOpen(false)
+      } else if (earthSimulator && perfClass === "tablet") {
+        setLeftPanelOpen(true)
+        setRightPanelOpen(false)
       } else if (earthSimulator) {
-        setLeftPanelOpen(true);
-        setRightPanelOpen(true);
+        setLeftPanelOpen(true)
+        setRightPanelOpen(true)
       } else {
-        setLeftPanelOpen(true);
-        setRightPanelOpen(true);
+        setLeftPanelOpen(true)
+        setRightPanelOpen(true)
       }
-    };
+    }
     applyResponsivePanelDefaults();
     phoneMq.addEventListener("change", applyResponsivePanelDefaults);
     earthTabletMq.addEventListener("change", applyResponsivePanelDefaults);
@@ -8020,9 +8029,9 @@ export default function CREPDashboardPage({
     // the heavier layers hydrate (the 1.75s/2.5s values removed that safety valve
     // and compounded the iPad freeze). Not the old 35-55s — a survivable middle.
     const delayMs =
-      earthSimViewportPerfClass === "phone" ? 8_000 :
-      earthSimViewportPerfClass === "tablet" ? 5_000 :
-      750;
+      earthSimViewportPerfClass === "phone" ? 10_000 :
+      earthSimViewportPerfClass === "tablet" ? 18_000 :
+      750
     const timer = window.setTimeout(() => setEarthSimDeferredDataReady(true), delayMs);
     return () => window.clearTimeout(timer);
   }, [
@@ -8669,7 +8678,8 @@ export default function CREPDashboardPage({
       }
     };
     installHoverBridge();
-    const repairTimer = window.setInterval(installHoverBridge, 2_000);
+    const repairMs = getEarthSimViewportPerfClass() === "desktop" ? 2_000 : 30_000;
+    const repairTimer = window.setInterval(installHoverBridge, repairMs);
     const onHover = (event: Event) => {
       const detail = (event as CustomEvent<MapAssetHoverPayload | null>).detail ?? null;
       handleMapAssetHover(detail);
@@ -9322,6 +9332,7 @@ export default function CREPDashboardPage({
 
   useEffect(() => {
     if (!earthStrictPerfMode || !mapRef) return;
+    if (getEarthSimViewportPerfClass() !== "desktop") return;
     const perfClass = getEarthSimViewportPerfClass();
     const sampleWindowMs = perfClass === "desktop" ? 1_000 : 250;
     const sampleIntervalMs = perfClass === "desktop" ? 2_000 : 8_000;
@@ -15895,11 +15906,14 @@ export default function CREPDashboardPage({
     let rafId: number | null = null;
     let intervalId: any = null;
     let lastTickAt = 0;
+    const moverPerfClass = earthStrictPerfMode ? getEarthSimViewportPerfClass() : "desktop";
+    const useIntervalOnly = earthStrictPerfMode && moverPerfClass !== "desktop";
     const getTickMs = () => {
-      // Jun 16 — tighter cadence so planes glide smoothly instead of stepping
-      // every ~0.5–1s. The setData coalescer caps GPU uploads at one per frame,
-      // so the only added cost is the (viewport-LOD'd) feature rebuild.
-      if (earthStrictPerfMode) return 1000;
+      if (earthStrictPerfMode) {
+        if (moverPerfClass === "tablet") return 2000;
+        if (moverPerfClass === "phone") return 2500;
+        return 1000;
+      }
       const zoom = mapZoomRef.current;
       if (!Number.isFinite(zoom) || zoom < 3) return 400;
       if (zoom < 5) return 350;
@@ -16010,6 +16024,14 @@ export default function CREPDashboardPage({
       }
     };
 
+    // Tablet/phone: interval-only pump — perpetual rAF starves iPad Safari main thread.
+    if (useIntervalOnly) {
+      const intervalMs = moverPerfClass === "tablet" ? 2000 : 2500;
+      intervalId = setInterval(() => {
+        lastTickAt = performance.now();
+        pumpOnce();
+      }, intervalMs);
+    } else {
     // rAF tick: runs at ~60 Hz when tab is visible; browser pauses when hidden.
     const rafTick = (ts: number) => {
       const nowPerf = performance.now();
@@ -16032,6 +16054,7 @@ export default function CREPDashboardPage({
       lastTickAt = performance.now();
       pumpOnce();
     }, 500);
+    }
 
     return () => {
       if (rafId != null) cancelAnimationFrame(rafId);

--- a/components/home/hero-search.tsx
+++ b/components/home/hero-search.tsx
@@ -25,6 +25,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import { useTheme } from "next-themes"
 import Image from "next/image"
 import { cn } from "@/lib/utils"
+import { useTabletLikeDevice } from "@/lib/client-motion"
 import { usePersonaPlexContext } from "@/components/voice/PersonaPlexProvider"
 import { useTypingPlaceholder } from "@/hooks/use-typing-placeholder"
 import { useDebounce } from "@/hooks/use-debounce"
@@ -153,6 +154,7 @@ export function HeroSearch({
   onOpenMYCADemo,
 }: HeroSearchProps) {
   const router = useRouter()
+  const tabletLike = useTabletLikeDevice()
   const { resolvedTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
   /** Defer mounting hero <video> until after first paint + idle — avoids decode/network fighting hydration (OOM / tab crash). */
@@ -489,16 +491,22 @@ export function HeroSearch({
             "relative",
             embedded
               ? "myco-hero-search-card overflow-visible"
-              : "overflow-hidden rounded-3xl backdrop-blur-xl bg-background/20 dark:bg-background/30",
+              : tabletLike
+                ? "overflow-hidden rounded-3xl bg-background/85 dark:bg-background/90 border border-border/40"
+                : "overflow-hidden rounded-3xl backdrop-blur-xl bg-background/20 dark:bg-background/30",
             !embedded && isFocused && "ring-2 ring-primary/50"
           )}
         >
           {/* Animated Gradient Border */}
           {!embedded ? (
+            tabletLike ? (
+              <div className="absolute inset-[1px] rounded-[22px] bg-background/90 dark:bg-background/95" />
+            ) : (
             <>
               <div className="absolute inset-0 rounded-3xl p-[2px] bg-gradient-to-r from-primary/40 via-purple-500/40 to-cyan-500/40 animate-gradient-x" />
               <div className="absolute inset-[2px] rounded-[22px] bg-background/10 dark:bg-background/20" />
             </>
+            )
           ) : null}
 
           {/* Content */}
@@ -570,7 +578,9 @@ export function HeroSearch({
                 "relative flex items-center gap-2 sm:gap-3 px-3 sm:px-5 py-3 sm:py-4 md:py-5 rounded-xl sm:rounded-2xl",
                 embedded
                   ? "myco-hero-input-glass border border-white/20"
-                  : "bg-background/60 dark:bg-white/10 backdrop-blur-md border border-border dark:border-white/20 shadow-2xl shadow-black/10 dark:shadow-black/20",
+                  : tabletLike
+                    ? "bg-background/95 dark:bg-neutral-900/90 border border-border dark:border-white/15 shadow-lg"
+                    : "bg-background/60 dark:bg-white/10 backdrop-blur-md border border-border dark:border-white/20 shadow-2xl shadow-black/10 dark:shadow-black/20",
                 "transition-all duration-300",
                 isFocused && (embedded
                   ? "border-white/25"

--- a/components/home/home-command-page.tsx
+++ b/components/home/home-command-page.tsx
@@ -11,6 +11,8 @@ import { AutoplayVideo } from "@/components/ui/autoplay-video"
 import { homeHeroVideoSources, primaryHomeHeroPosterPath } from "@/lib/asset-video-sources"
 import { homeHeroYoutubeId } from "@/lib/hero-youtube"
 import { cn } from "@/lib/utils"
+import { useTabletLikeDevice } from "@/lib/client-motion"
+import Image from "next/image"
 
 const HOME_HERO_SOURCES = homeHeroVideoSources()
 const HOME_HERO_POSTER = primaryHomeHeroPosterPath()
@@ -132,13 +134,23 @@ const TILES: HomeTile[] = [
   },
 ]
 
-function TileMedia({ tile }: { tile: HomeTile }) {
+function TileMedia({ tile, posterOnly }: { tile: HomeTile; posterOnly?: boolean }) {
+  const posterSrc = tile.poster
   return (
     <div className="absolute inset-0 overflow-hidden bg-neutral-950">
-      {tile.video || tile.sources?.length ? (
+      {posterOnly && posterSrc ? (
+        <Image
+          src={posterSrc}
+          alt=""
+          fill
+          sizes="(max-width: 768px) 100vw, 50vw"
+          className="object-cover opacity-80 transition-transform duration-700 group-hover:scale-105"
+        />
+      ) : tile.video || tile.sources?.length ? (
         <AutoplayVideo
           src={tile.video}
           sources={tile.sources}
+          poster={posterSrc}
           preload="none"
           lazyRootMargin="0px 0px"
           pauseWhenOutsideViewport
@@ -155,6 +167,7 @@ function TileMedia({ tile }: { tile: HomeTile }) {
 }
 
 export function HomeCommandPage() {
+  const tabletLike = useTabletLikeDevice()
   const [showMYCADemo, setShowMYCADemo] = useState(false)
   const [hasMountedMYCADemo, setHasMountedMYCADemo] = useState(false)
   const showMYCADemoRef = useRef(false)
@@ -213,11 +226,12 @@ export function HomeCommandPage() {
               src={HOME_HERO_SOURCES[0]}
               sources={HOME_HERO_SOURCES}
               poster={HOME_HERO_POSTER}
-              preload="auto"
-              stallTimeoutMs={6000}
-              fallbackAfterFreezeMs={5000}
+              preload={tabletLike ? "metadata" : "auto"}
+              stallTimeoutMs={tabletLike ? 9000 : 6000}
+              fallbackAfterFreezeMs={tabletLike ? 12000 : 5000}
               youtubeFallbackId={HOME_HERO_YOUTUBE_ID}
-              smoothLoop
+              smoothLoop={!tabletLike}
+              disableProgressWatch={tabletLike}
               className="absolute inset-0 h-full w-full object-cover"
               encodeSrc
             />
@@ -315,7 +329,7 @@ export function HomeCommandPage() {
                   tile.span === 2 && "sm:col-span-2 sm:aspect-[2/1]"
                 )}
               >
-                <TileMedia tile={tile} />
+                <TileMedia tile={tile} posterOnly={tabletLike} />
                 <div className="relative z-10 flex h-full flex-col justify-between p-5 sm:p-6">
                   <div className="flex items-center justify-between">
                     <span className="inline-flex items-center gap-2 border border-white/15 bg-black/35 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 backdrop-blur">

--- a/components/ui/autoplay-video.tsx
+++ b/components/ui/autoplay-video.tsx
@@ -142,6 +142,8 @@ interface AutoplayVideoProps {
   unloadWhenOutsideViewport?: boolean
   /** Prewarm a second copy near the loop seam so long-running hero videos do not visibly hitch at reset. */
   smoothLoop?: boolean
+  /** Skip the 1.25s progressWatch interval (saves CPU on iPad with multiple videos). */
+  disableProgressWatch?: boolean
   /**
    * When true (default), the video does not receive pointer events so full-bleed heroes
    * do not sit above the footer/header stack and eat the first tap/click.
@@ -167,6 +169,7 @@ export function AutoplayVideo({
   pauseWhenOutsideViewport = false,
   unloadWhenOutsideViewport = false,
   smoothLoop = false,
+  disableProgressWatch = false,
 }: AutoplayVideoProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const loopCoverRef = useRef<HTMLVideoElement>(null)
@@ -185,6 +188,10 @@ export function AutoplayVideo({
   const [youtubeFallbackReady, setYoutubeFallbackReady] = useState(false)
   const [loopCoverVisible, setLoopCoverVisible] = useState(false)
   const activeSrc = list[index] ?? ""
+  const effectiveSmoothLoop =
+    smoothLoop &&
+    !disableProgressWatch &&
+    (typeof navigator === "undefined" || (navigator.maxTouchPoints ?? 0) <= 1)
   const listRef = useRef(list)
   const recoveryCountRef = useRef(0)
   const qualityIssueCountRef = useRef(0)
@@ -429,7 +436,7 @@ export function AutoplayVideo({
       }
     }
     const armLoopCover = () => {
-      if (!smoothLoop || loopCoverActiveRef.current || !shouldMaintainPlayback()) return
+      if (!effectiveSmoothLoop || loopCoverActiveRef.current || !shouldMaintainPlayback()) return
       if (!Number.isFinite(v.duration) || v.duration < 8) return
       if (v.duration - v.currentTime > 1.4) return
       const cover = loopCoverRef.current
@@ -449,7 +456,10 @@ export function AutoplayVideo({
       lastProgressAt = performance.now()
       armLoopCover()
     }
-    const progressWatch = window.setInterval(() => {
+    const progressWatch =
+      disableProgressWatch || (typeof navigator !== "undefined" && (navigator.maxTouchPoints ?? 0) > 1)
+        ? null
+        : window.setInterval(() => {
       if (document.hidden) return
       if (!shouldMaintainPlayback()) return
       if (v.paused && !v.ended) {
@@ -502,7 +512,7 @@ export function AutoplayVideo({
     return () => {
       clearStall()
       clearLoopCover()
-      window.clearInterval(progressWatch)
+      if (progressWatch != null) window.clearInterval(progressWatch)
       document.removeEventListener("touchstart", onUserGesture)
       document.removeEventListener("pointerdown", onUserGesture)
       document.removeEventListener("visibilitychange", onVisibility)
@@ -517,7 +527,7 @@ export function AutoplayVideo({
       v.removeEventListener("loadedmetadata", onLoadedMetadata)
       v.removeEventListener("timeupdate", onTimeUpdate)
     }
-  }, [activeSrc, stallTimeoutMs, hideUntilPlaying, shouldLoad, youtubeFallbackId, usingYoutubeFallback, fallbackAfterFreezeMs, pauseWhenOutsideViewport, smoothLoop])
+  }, [activeSrc, stallTimeoutMs, hideUntilPlaying, shouldLoad, youtubeFallbackId, usingYoutubeFallback, fallbackAfterFreezeMs, pauseWhenOutsideViewport, smoothLoop, disableProgressWatch, effectiveSmoothLoop])
 
   if (!activeSrc) return null
   const derivedPoster = sidecarPosterForVideo(activeSrc)
@@ -590,7 +600,7 @@ export function AutoplayVideo({
       >
         <source src={activeSrc} type={mediaTypeForVideo(activeSrc)} />
       </video>
-      {smoothLoop ? (
+      {effectiveSmoothLoop ? (
         <video
           key={`${activeSrc}-loop-cover`}
           ref={loopCoverRef}

--- a/lib/client-motion.ts
+++ b/lib/client-motion.ts
@@ -1,18 +1,45 @@
 "use client"
 
+import { useEffect, useState } from "react"
+
 export function prefersReducedVisualMotion() {
   if (typeof window === "undefined") return true
 
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches
 }
 
+/** iPad / tablet — matches Earth Simulator perf-class (maxTouchPoints is reliable on iPadOS). */
+export function isTabletLikeDevice() {
+  if (typeof window === "undefined") return false
+  const width = window.innerWidth || 1440
+  const height = window.innerHeight || width
+  const touch = (navigator.maxTouchPoints ?? 0) > 1
+  const shortEdge = Math.min(width, height)
+  if (shortEdge <= 540) return false
+  const coarse = window.matchMedia("(pointer: coarse)").matches
+  return touch || coarse || width <= 1180
+}
+
 export function isCoarsePointerDevice() {
   if (typeof window === "undefined") return true
 
-  return window.matchMedia("(pointer: coarse)").matches || window.innerWidth < 1024
+  return window.matchMedia("(pointer: coarse)").matches || isTabletLikeDevice()
 }
 
 export function shouldUseLightweightVisuals() {
   return prefersReducedVisualMotion() || isCoarsePointerDevice()
+}
+
+/** Poster-only video on tablet/iPad — avoids multiple simultaneous decoders. */
+export function shouldUsePosterOnlyVideo() {
+  return shouldUseLightweightVisuals() && isTabletLikeDevice()
+}
+
+export function useTabletLikeDevice() {
+  const [tabletLike, setTabletLike] = useState(false)
+  useEffect(() => {
+    setTabletLike(isTabletLikeDevice())
+  }, [])
+  return tabletLike
 }
 


### PR DESCRIPTION
Poster-only tile videos on tablet, disable hero smoothLoop/progressWatch, lighter hero glass, Earth Sim: one panel, lower DOM caps, interval-only mover pump, 18s deferred hydrate.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Improve iPad/tablet performance and stability on the Earth Simulator and home hero.

New Features:
- Introduce tablet detection helpers and hooks to drive tablet-specific UI and media behaviour.
- Add poster-only tile video mode on tablet devices to reduce simultaneous video decoding load.

Bug Fixes:
- Reduce DOM marker caps and adjust mover scheduling on tablet/phone in Earth Simulator to prevent iPad freezes and main-thread starvation.
- Adjust Earth Simulator panel defaults so tablet keeps only the left panel open, preserving GPU headroom while maintaining usability.
- Increase deferred hydration delay for tablet/phone Earth Simulator views to avoid contention with heavy layers.
- Throttle Earth Simulator hover-bridge repair polling on non-desktop devices to reduce background work.
- Ensure strict Earth performance sampling only runs on desktop-class devices to avoid overhead on tablets.

Enhancements:
- Tune home hero video preload, loop, and stall handling on tablet, disabling smoothLoop/progressWatch and lightening glass effects to reduce CPU/GPU load.
- Expand autoplay video component with optional progress-watch disabling and safer smooth-loop behaviour on touch devices.
- Refine coarse-pointer detection and lightweight visuals heuristics to better classify tablet-like devices and drive motion/video fallbacks.