### PR TITLE
fix(ci): Instant Deploy job setup

### DIFF
--- a/.github/workflows/instant-deploy.yml
+++ b/.github/workflows/instant-deploy.yml
@@ -123,19 +123,6 @@ jobs:
         id: sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      # no_cache full Next.js builds exceed default runner disk (~14GB free).
-      - name: Free disk space on runner
-        if: inputs.no_cache == 'true'
-        uses: jlumbroso/free-disk-space-action@v1.3.1
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
Remove jlumbroso/free-disk-space-action (repo not found). Shell cleanup step remains for no_cache builds.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

CI:
- Remove the jlumbroso/free-disk-space-action step from the Instant Deploy workflow while retaining other job steps.