### PR TITLE
fix(tablet): Earth Sim globe pan freeze + poster-first home video

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -22,6 +22,8 @@
 # Force clean `npm run build` layer so manual-SHA image registers new routes.
 # Jun 20, 2026 (r7): instant-deploy no_cache=true — GHA cache still served stale
 # npm run build output despite r5/r6 bust strings; full rebuild required.
+# Jun 20, 2026 (r8): tablet Earth Sim pan freeze + poster-first home video —
+# CREPDashboardClient + home-command-page changes must invalidate npm run build.
 
 FROM node:20-bookworm-slim AS base
 # SECURITY: no default — NEXTAUTH_SECRET must be supplied at build/runtime (docker-compose

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -2406,6 +2406,16 @@ function getEarthSimViewportPerfClass(): "desktop" | "tablet" | "phone" {
   return "desktop";
 }
 
+/** Tablet/phone: always freeze DOM lists during pan. Desktop: live bounds only when not streaming. */
+function shouldHoldDomMarkerListsDuringGlobePan(
+  isMapAnimationActive: boolean,
+  liveMarkerBounds: { north: number; south: number; east: number; west: number } | null,
+): boolean {
+  if (!isMapAnimationActive) return false;
+  if (getEarthSimViewportPerfClass() !== "desktop") return true;
+  return !liveMarkerBounds;
+}
+
 function getEarthSimGlobalEventApiLimit(): number {
   const perfClass = getEarthSimViewportPerfClass();
   if (perfClass === "phone") return 220;
@@ -2447,11 +2457,11 @@ function getEventDomMarkerCapForZoom(zoom: number, earthSimulator = false) {
     }
     if (perfClass === "tablet") {
       const tabletCap =
-        zoom >= 9 ? 100 :
-        zoom >= 7 ? 90 :
-        zoom >= 5 ? 75 :
-        zoom >= 3 ? 65 :
-        55;
+        zoom >= 9 ? 70 :
+        zoom >= 7 ? 60 :
+        zoom >= 5 ? 50 :
+        zoom >= 3 ? 40 :
+        35;
       return Math.min(baseCap, tabletCap);
     }
     return baseCap;
@@ -2489,13 +2499,13 @@ function getNatureDomMarkerCapForZoom(
     }
     if (perfClass === "tablet") {
       const tabletCap =
-        zoom >= 11 ? 380 :
-        zoom >= 9 ? 330 :
-        zoom >= 7 ? 280 :
-        zoom >= 5 ? 220 :
-        zoom >= 3 ? 160 :
-        120;
-      return Math.min(EARTH_SIM_DOM_MARKER_CAP, Math.max(80, Math.floor(tabletCap * kingdomScale)));
+        zoom >= 11 ? 220 :
+        zoom >= 9 ? 180 :
+        zoom >= 7 ? 140 :
+        zoom >= 5 ? 110 :
+        zoom >= 3 ? 80 :
+        60;
+      return Math.min(EARTH_SIM_DOM_MARKER_CAP, Math.max(40, Math.floor(tabletCap * kingdomScale)));
     }
     const tierCap =
       zoom >= 11 ? 900 :
@@ -13731,7 +13741,7 @@ export default function CREPDashboardPage({
     groundFilter.showMarineLife
   ), [natureSpeciesFilterKey]);
   const visibleFungalObservations = useMemo(() => {
-    const holdMarkerLists = isMapAnimationActive && !liveMarkerBounds;
+    const holdMarkerLists = shouldHoldDomMarkerListsDuringGlobePan(isMapAnimationActive, liveMarkerBounds);
     // Recompute from cached store + live bounds during globe pan (occlusion hides back-side).
     if (holdMarkerLists) {
       const frozen = visibleFungalObservationsStableRef.current.list;
@@ -14069,7 +14079,7 @@ export default function CREPDashboardPage({
   }, [fungalObservations, mapZoom, markerBounds, natureObservationFilter, fungalSpeciesFilter, natureFiltersEnabled, natureSpeciesFilterKey, auditAllOffMode, isMapAnimationActive, isEarthSimulatorRoute, liveMarkerBounds]);
 
   const renderedFungalObservationsForMap = useMemo(() => {
-    const holdMarkerLists = isMapAnimationActive && !liveMarkerBounds;
+    const holdMarkerLists = shouldHoldDomMarkerListsDuringGlobePan(isMapAnimationActive, liveMarkerBounds);
     if (holdMarkerLists) {
       const frozen = renderedNatureStableRef.current.list;
       if (frozen.length > 0) return frozen;
@@ -14434,7 +14444,7 @@ export default function CREPDashboardPage({
     [typeFilteredEvents],
   );
   const visibleEvents = useMemo(() => {
-    const holdMarkerLists = isMapAnimationActive && !liveMarkerBounds;
+    const holdMarkerLists = shouldHoldDomMarkerListsDuringGlobePan(isMapAnimationActive, liveMarkerBounds);
     if (holdMarkerLists) {
       const frozen = visibleEventsStableRef.current.events;
       if (frozen.length > 0) return frozen;
@@ -14888,7 +14898,7 @@ export default function CREPDashboardPage({
     : null;
   const mycaAnalysisContext = sustainedHoverContext ?? mycaHoverContext ?? mycaSelectedContext;
   const renderedEventsForMap = useMemo(() => {
-    const holdMarkerLists = isMapAnimationActive && !liveMarkerBounds;
+    const holdMarkerLists = shouldHoldDomMarkerListsDuringGlobePan(isMapAnimationActive, liveMarkerBounds);
     if (holdMarkerLists) {
       const frozen = renderedEventsStableRef.current.events;
       if (frozen.length > 0) return frozen;
@@ -15848,6 +15858,11 @@ export default function CREPDashboardPage({
     if (auditAllOffMode) return true;
     if (assetIsolationMode) return true;
     if (isEmbeddedEarthquakeSearch) return true;
+    if (mapInteractionActiveRef.current && getEarthSimViewportPerfClass() !== "desktop") return true;
+    const map = mapNativeRef.current;
+    if (map && getEarthSimViewportPerfClass() !== "desktop") {
+      if (map.isMoving?.() || map.isZooming?.() || map.isRotating?.()) return true;
+    }
     return typeof document !== "undefined" && document.hidden;
   }, [assetIsolationMode, auditAllOffMode, isEmbeddedEarthquakeSearch]);
   const selectStableLiveMoverFeatures = useCallback((
@@ -16084,6 +16099,7 @@ export default function CREPDashboardPage({
   useEffect(() => {
     const map = mapNativeRef.current
     if (!map || typeof map.getSource !== "function") return
+    if (mapInteractionActiveRef.current && getEarthSimViewportPerfClass() !== "desktop") return
     if (isEmbeddedEarthquakeSearch || assetIsolationMode) {
       const emptyFC = { type: "FeatureCollection", features: [] }
       try {
@@ -22217,7 +22233,13 @@ export default function CREPDashboardPage({
                   mapZoomRef.current = newZoom;
                   mapBoundsRef.current = nextBounds;
                   publishViewportState("live", newZoom, nextBounds);
-                  if (isGlobeRoute) {
+                  const perfClass = earthStrictPerfMode ? getEarthSimViewportPerfClass() : "desktop";
+                  const skipLiveReactBounds =
+                    perfClass !== "desktop" ||
+                    mapInteractionActiveRef.current ||
+                    (typeof map.isMoving === "function" && map.isMoving()) ||
+                    (typeof map.isZooming === "function" && map.isZooming());
+                  if (isGlobeRoute && !skipLiveReactBounds) {
                     setLiveMarkerBounds((prev) => (boundsNearlyEqual(prev, nextBounds, 0.001) ? prev : nextBounds));
                   }
                 });

--- a/components/home/hero-search.tsx
+++ b/components/home/hero-search.tsx
@@ -25,7 +25,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import { useTheme } from "next-themes"
 import Image from "next/image"
 import { cn } from "@/lib/utils"
-import { useTabletLikeDevice } from "@/lib/client-motion"
+import { useAllowRichHomeMedia, useTabletLikeDevice } from "@/lib/client-motion"
 import { usePersonaPlexContext } from "@/components/voice/PersonaPlexProvider"
 import { useTypingPlaceholder } from "@/hooks/use-typing-placeholder"
 import { useDebounce } from "@/hooks/use-debounce"
@@ -155,6 +155,7 @@ export function HeroSearch({
 }: HeroSearchProps) {
   const router = useRouter()
   const tabletLike = useTabletLikeDevice()
+  const allowHomeVideo = useAllowRichHomeMedia()
   const { resolvedTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
   /** Defer mounting hero <video> until after first paint + idle — avoids decode/network fighting hydration (OOM / tab crash). */
@@ -203,6 +204,7 @@ export function HeroSearch({
   }, [])
 
   useEffect(() => {
+    if (!allowHomeVideo) return
     if (typeof window === "undefined") return
     let idleId: number
     let usedIdleCallback = false
@@ -221,7 +223,7 @@ export function HeroSearch({
         window.clearTimeout(idleId)
       }
     }
-  }, [])
+  }, [allowHomeVideo])
 
   const homeNasHeroSources = homeHeroVideoSources()
 
@@ -451,7 +453,7 @@ export function HeroSearch({
           style={{ contain: "paint", willChange: "transform" }}
         >
           {/* Locked NAS MP4 hero background after idle. */}
-          {idleHeroVideoReady && homeNasHeroSources[0] ? (
+          {allowHomeVideo && idleHeroVideoReady && homeNasHeroSources[0] ? (
             <AutoplayVideo
               src={homeNasHeroSources[0]}
               sources={homeNasHeroSources}

--- a/components/home/home-command-page.tsx
+++ b/components/home/home-command-page.tsx
@@ -11,7 +11,7 @@ import { AutoplayVideo } from "@/components/ui/autoplay-video"
 import { homeHeroVideoSources, primaryHomeHeroPosterPath } from "@/lib/asset-video-sources"
 import { homeHeroYoutubeId } from "@/lib/hero-youtube"
 import { cn } from "@/lib/utils"
-import { useTabletLikeDevice } from "@/lib/client-motion"
+import { useAllowRichHomeMedia } from "@/lib/client-motion"
 import Image from "next/image"
 
 const HOME_HERO_SOURCES = homeHeroVideoSources()
@@ -135,10 +135,10 @@ const TILES: HomeTile[] = [
 ]
 
 function TileMedia({ tile, posterOnly }: { tile: HomeTile; posterOnly?: boolean }) {
-  const posterSrc = tile.poster
+  const posterSrc = tile.poster ?? HOME_HERO_POSTER
   return (
     <div className="absolute inset-0 overflow-hidden bg-neutral-950">
-      {posterOnly && posterSrc ? (
+      {posterOnly ? (
         <Image
           src={posterSrc}
           alt=""
@@ -167,7 +167,7 @@ function TileMedia({ tile, posterOnly }: { tile: HomeTile; posterOnly?: boolean 
 }
 
 export function HomeCommandPage() {
-  const tabletLike = useTabletLikeDevice()
+  const allowHomeVideo = useAllowRichHomeMedia()
   const [showMYCADemo, setShowMYCADemo] = useState(false)
   const [hasMountedMYCADemo, setHasMountedMYCADemo] = useState(false)
   const showMYCADemoRef = useRef(false)
@@ -221,21 +221,29 @@ export function HomeCommandPage() {
         className="home-hero-glass-field relative min-h-[calc(100dvh-3rem)] overflow-hidden border-b border-white/10"
       >
         <div className="absolute inset-0">
-          {HOME_HERO_SOURCES[0] ? (
+          {allowHomeVideo && HOME_HERO_SOURCES[0] ? (
             <AutoplayVideo
               src={HOME_HERO_SOURCES[0]}
               sources={HOME_HERO_SOURCES}
               poster={HOME_HERO_POSTER}
-              preload={tabletLike ? "metadata" : "auto"}
-              stallTimeoutMs={tabletLike ? 9000 : 6000}
-              fallbackAfterFreezeMs={tabletLike ? 12000 : 5000}
+              preload="auto"
+              stallTimeoutMs={6000}
+              fallbackAfterFreezeMs={5000}
               youtubeFallbackId={HOME_HERO_YOUTUBE_ID}
-              smoothLoop={!tabletLike}
-              disableProgressWatch={tabletLike}
+              smoothLoop
               className="absolute inset-0 h-full w-full object-cover"
               encodeSrc
             />
-          ) : null}
+          ) : (
+            <Image
+              src={HOME_HERO_POSTER}
+              alt=""
+              fill
+              priority
+              sizes="100vw"
+              className="absolute inset-0 h-full w-full object-cover"
+            />
+          )}
           <div className="absolute inset-0 bg-gradient-to-b from-black/35 via-black/12 to-black/70" />
         </div>
 
@@ -329,7 +337,7 @@ export function HomeCommandPage() {
                   tile.span === 2 && "sm:col-span-2 sm:aspect-[2/1]"
                 )}
               >
-                <TileMedia tile={tile} posterOnly={tabletLike} />
+                <TileMedia tile={tile} posterOnly={!allowHomeVideo} />
                 <div className="relative z-10 flex h-full flex-col justify-between p-5 sm:p-6">
                   <div className="flex items-center justify-between">
                     <span className="inline-flex items-center gap-2 border border-white/15 bg-black/35 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 backdrop-blur">

--- a/components/ui/autoplay-video.tsx
+++ b/components/ui/autoplay-video.tsx
@@ -530,6 +530,8 @@ export function AutoplayVideo({
   }, [activeSrc, stallTimeoutMs, hideUntilPlaying, shouldLoad, youtubeFallbackId, usingYoutubeFallback, fallbackAfterFreezeMs, pauseWhenOutsideViewport, smoothLoop, disableProgressWatch, effectiveSmoothLoop])
 
   if (!activeSrc) return null
+  const touchPosterOnly =
+    typeof navigator !== "undefined" && (navigator.maxTouchPoints ?? 0) > 1
   const derivedPoster = sidecarPosterForVideo(activeSrc)
   const rawPoster = typeof poster === "string" && poster ? poster : derivedPoster
   const posterAttr =
@@ -538,6 +540,21 @@ export function AutoplayVideo({
         ? encodeAssetUrl(rawPoster)
         : rawPoster
       : undefined
+
+  if (touchPosterOnly && posterAttr) {
+    return (
+      <div
+        aria-hidden="true"
+        className={[className, pointerClass].filter(Boolean).join(" ")}
+        style={{
+          ...style,
+          backgroundImage: `url("${posterAttr}")`,
+          backgroundSize: style?.backgroundSize || "cover",
+          backgroundPosition: style?.backgroundPosition || "center",
+        }}
+      />
+    )
+  }
 
   if (hideUntilPlaying && allFailed) {
     if (!posterAttr) return null

--- a/lib/client-motion.ts
+++ b/lib/client-motion.ts
@@ -43,3 +43,12 @@ export function useTabletLikeDevice() {
   return tabletLike
 }
 
+/** Poster/static until desktop confirmed — avoids iPad hydration flash loading 10+ decoders. */
+export function useAllowRichHomeMedia() {
+  const [allow, setAllow] = useState(false)
+  useEffect(() => {
+    setAllow(!prefersReducedVisualMotion() && !isTabletLikeDevice())
+  }, [])
+  return allow
+}
+


### PR DESCRIPTION
## Summary
- Freeze DOM marker lists during globe pan/zoom on tablet and skip liveMarkerBounds updates while the map is moving
- Pause mover animation pumps during map interaction on tablet
- Poster-first home hero/tiles and touch-only AutoplayVideo to stop iPad decoder flash

## Test plan
- [ ] iPad Safari: pan/zoom Earth Simulator globe without freeze
- [ ] iPad Safari: scroll home page without video decoder lockup
- [ ] Desktop: home videos and Earth Sim markers still behave normally

## Summary by Sourcery

Reduce tablet globe marker load and freeze DOM marker lists during map interactions while deferring live bounds updates on non-desktop, and switch home hero and tiles to poster-first media with touch-only AutoplayVideo to avoid iPad video decoder issues.

Bug Fixes:
- Prevent Earth Simulator globe panning and zooming from freezing on tablets by holding DOM marker lists and pausing mover animations during active map interactions.
- Avoid iPad Safari video decoder lockups and hydration flashes by using poster-first media on the home hero and tiles and disabling autoplay video on touch devices.

Enhancements:
- Tighten tablet DOM marker caps for events and nature observations to lower render load on constrained devices.
- Gate rich home media behind a new motion-aware hook so desktop-like devices still receive full autoplay video experiences while tablets default to static posters.