### PR TITLE
fix(tablet): Earth Sim satellites + 3D terrain on iPad

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -24,6 +24,7 @@
 # npm run build output despite r5/r6 bust strings; full rebuild required.
 # Jun 20, 2026 (r8): tablet Earth Sim pan freeze + poster-first home video —
 # CREPDashboardClient + home-command-page changes must invalidate npm run build.
+# Jun 20, 2026 (r9): iPad Earth Sim — SGP4 satellites + terrain3d boot + tablet terrain thresholds.
 
 FROM node:20-bookworm-slim AS base
 # SECURITY: no default — NEXTAUTH_SECRET must be supplied at build/runtime (docker-compose

--- a/app/dashboard/crep/CREPDashboardClient.tsx
+++ b/app/dashboard/crep/CREPDashboardClient.tsx
@@ -884,11 +884,9 @@ const EARTH_SIM_SAFE_RESOURCE_LIMITS = {
 function getEarthSimMoverRenderCap(kind: "aircraft" | "vessel" | "satellite", zoom: number): number {
   const z = Number.isFinite(zoom) ? zoom : 0;
   // Desktop carries far more than tablet/phone. Aircraft/vessels are native GPU
-  // symbols bbox-culled to ~2x the viewport at z>=tier (so high-zoom caps only
-  // ever paint in-view targets), and satellites are worker-propagated GPU symbols
-  // with the SGP4 loop OFF on tablet/phone — so high desktop caps just blanket the
-  // globe or the viewport without straining smaller devices. (Jun 14, 2026 —
-  // "almost no satellites/planes/vessels, thousands missing, gate by lod + viewport".)
+  // symbols bbox-culled to ~2x the viewport at z>=tier. Satellites use the SGP4
+  // worker on all devices after stagger; orbit rings are desktop-only.
+  // (Jun 14, 2026 — gate by lod + viewport, not device class.)
   const desktop = getEarthSimViewportPerfClass() === "desktop";
   if (kind === "satellite") {
     if (!desktop) { if (z < 5) return 350; if (z < 10) return 500; return 650; }
@@ -8027,12 +8025,17 @@ export default function CREPDashboardPage({
   const earthMoverLimits = earthStrictPerfMode ? EARTH_SIM_SAFE_RESOURCE_LIMITS : RESOURCE_LIMITS.normal;
   const [isMapAnimationActive, setIsMapAnimationActive] = useState(false);
   const [earthSimDeferredDataReady, setEarthSimDeferredDataReady] = useState(() => !isEarthSimulatorPath());
+  // SGP4 + elevated satellites use a shorter stagger than heavy DOM/GeoJSON overlays
+  // so iPad sees live sats within a few seconds, not after the full 18s defer.
+  const [earthSimSatellitePropReady, setEarthSimSatellitePropReady] = useState(() => !isEarthSimulatorPath());
   useEffect(() => {
     if (!isEarthSimulatorRoute) {
       setEarthSimDeferredDataReady(true);
+      setEarthSimSatellitePropReady(true);
       return;
     }
     setEarthSimDeferredDataReady(false);
+    setEarthSimSatellitePropReady(false);
     if (auditAllOffMode || assetIsolationMode) return;
     // Stage heavy overlays in for weaker GPUs. Desktop paints fast (750ms); tablet
     // and phone get real breathing room so the base map + light data settle before
@@ -8042,8 +8045,16 @@ export default function CREPDashboardPage({
       earthSimViewportPerfClass === "phone" ? 10_000 :
       earthSimViewportPerfClass === "tablet" ? 18_000 :
       750
-    const timer = window.setTimeout(() => setEarthSimDeferredDataReady(true), delayMs);
-    return () => window.clearTimeout(timer);
+    const satDelayMs =
+      earthSimViewportPerfClass === "phone" ? 6_000 :
+      earthSimViewportPerfClass === "tablet" ? 4_000 :
+      750
+    const heavyTimer = window.setTimeout(() => setEarthSimDeferredDataReady(true), delayMs);
+    const satTimer = window.setTimeout(() => setEarthSimSatellitePropReady(true), satDelayMs);
+    return () => {
+      window.clearTimeout(heavyTimer);
+      window.clearTimeout(satTimer);
+    };
   }, [
     isEarthSimulatorRoute,
     earthSimViewportPerfClass,
@@ -10007,9 +10018,8 @@ export default function CREPDashboardPage({
 
   const [satelliteFilter, setSatelliteFilter] = useState<SatelliteFilter>(() => {
     // Satellites start ON at boot on Earth Sim — EXCEPT debris (Morgan: all sat
-    // filters on at reload except debris). Categories classify by name; SGP4
-    // render is desktop-only so tablet/phone carry no satellite cost.
-    // (Jun 14, 2026 — movers on at reload.)
+    // filters on at reload except debris). SGP4 + elevated mover-altitude run on
+    // all devices after the first-paint stagger; orbit rings are desktop-only.
     const moversOffAtBoot = getInitialFiltersOffMode();
     return {
       showStations: !moversOffAtBoot,
@@ -16850,14 +16860,12 @@ export default function CREPDashboardPage({
       return;
     }
 
-    // Earth Simulator: the SGP4 rAF loop is held off on tablet/phone for idle
-    // perf (DOM/GPU budget), but desktop has the headroom. Run it on desktop —
-    // gated behind the first-paint stagger (earthSimDeferredDataReady) so it
-    // never competes with the initial globe paint — so that enabling the
-    // satellites layer actually shows live, moving satellites (previously the
-    // source stayed empty on Earth Sim and nothing rendered). Tablet/phone keep
-    // the static-markers-only behavior.
-    if (earthStrictPerfMode && (earthSimViewportPerfClass !== "desktop" || !earthSimDeferredDataReady)) {
+    // Earth Simulator: SGP4 runs on desktop + tablet/phone after the first-paint
+    // stagger so live satellites + the BlueSite mover-altitude layer get data.
+    // Orbit-path rings stay desktop-only (main-thread cost). Pan-freeze is handled
+    // separately — SGP4 uses a Web Worker and __crep_satPropagateWhileMoving for
+    // the elevated layer.
+    if (earthStrictPerfMode && !earthSimSatellitePropReady) {
       stopSatelliteAnimation();
       return;
     }
@@ -16890,8 +16898,8 @@ export default function CREPDashboardPage({
     }));
 
     if (!isSatelliteAnimationRunning()) {
-      // First start â€” launch the animation loop. Orbit rings (computeOrbitPaths)
-      // only on desktop, where the elevated-satellite deck overlay renders them.
+      // Orbit rings (computeOrbitPaths) are desktop-only; tablet/phone still get
+      // live SGP4 positions for native + mover-altitude layers.
       startSatelliteAnimation(map, satInputs, {
         computeOrbitPaths: earthSimViewportPerfClass === "desktop",
       });
@@ -16899,7 +16907,7 @@ export default function CREPDashboardPage({
       // Already running â€” just update the satellite set (adds new ones)
       updateSatelliteAnimation(satInputs);
     }
-  }, [filteredSatellites, earthStrictPerfMode, earthSimViewportPerfClass, earthSimDeferredDataReady]);
+  }, [filteredSatellites, earthStrictPerfMode, earthSimViewportPerfClass, earthSimSatellitePropReady]);
 
   // Cleanup: stop satellite animation on unmount
   useEffect(() => {

--- a/components/crep/layers/proposal-overlays.tsx
+++ b/components/crep/layers/proposal-overlays.tsx
@@ -27,6 +27,7 @@
 
 import { useEffect, useRef, useState } from "react"
 import type { Map as MapLibreMap } from "maplibre-gl"
+import { isTabletLikeDevice } from "@/lib/client-motion"
 import {
   INFRA_LAYERS,
   addInfraSourceWithFallback,
@@ -1592,12 +1593,14 @@ export default function ProposalOverlays({ map, enabled, bbox, searchContextMode
       try { if (map.getTerrain?.()) map.setTerrain(null) } catch { /* ignore */ }
       return
     }
-    const TERRAIN_MIN_ZOOM = 5
+    const touchTablet = typeof navigator !== "undefined" && (navigator.maxTouchPoints ?? 0) > 1
+    const tabletLike = touchTablet || isTabletLikeDevice()
+    const TERRAIN_MIN_ZOOM = tabletLike ? 4 : 5
     // Only drape terrain when the camera is TILTED to an angle — looking straight down,
     // elevation relief is imperceptible and just burns FPS. Flat / top-down view stays the
     // fast flat globe and never pops relief on zoom. Tunable via window.__es_v2.
     const TERRAIN_MIN_PITCH = (() => {
-      try { const v = (window as any).__es_v2?.terrainMinPitch; return Number.isFinite(v) ? Number(v) : 12 } catch { return 12 }
+      try { const v = (window as any).__es_v2?.terrainMinPitch; return Number.isFinite(v) ? Number(v) : (tabletLike ? 8 : 12) } catch { return tabletLike ? 8 : 12 }
     })()
     const exaggeration = (() => {
       try { const v = (window as any).__es_v2?.terrainExaggeration; return Number.isFinite(v) ? Number(v) : 1.5 } catch { return 1.5 }
@@ -1623,7 +1626,13 @@ export default function ProposalOverlays({ map, enabled, bbox, searchContextMode
     // keep it off until FPS recovers comfortably (hysteresis). Enforces the perf contract.
     let fpsBlocked = false
     let healthyTicks = 0
-    const TERR_FPS_FLOOR = (() => { try { const v = (window as any).__es_v2?.terrainFpsFloor; return Number.isFinite(v) ? Number(v) : 36 } catch { return 36 } })()
+    const TERR_FPS_FLOOR = (() => {
+      try {
+        const v = (window as any).__es_v2?.terrainFpsFloor
+        if (Number.isFinite(v)) return Number(v)
+      } catch { /* ignore */ }
+      return tabletLike ? 24 : 36
+    })()
     const apply = () => {
       try {
         if (!isMapStyleReady(map)) return
@@ -1643,7 +1652,7 @@ export default function ProposalOverlays({ map, enabled, bbox, searchContextMode
         if (fps < TERR_FPS_FLOOR) {
           healthyTicks = 0
           if (!fpsBlocked) { fpsBlocked = true; if (map.getTerrain?.()) map.setTerrain(null) }
-        } else if (fps >= TERR_FPS_FLOOR + 12) {           // recover only well above the floor
+        } else if (fps >= TERR_FPS_FLOOR + (tabletLike ? 8 : 12)) {           // recover only well above the floor
           if (fpsBlocked && ++healthyTicks >= 3) { fpsBlocked = false; healthyTicks = 0; apply() }
         }
       } catch { /* ignore */ }

--- a/lib/crep/earth-simulator-boot.ts
+++ b/lib/crep/earth-simulator-boot.ts
@@ -33,6 +33,7 @@ export const EARTH_SIM_BASE_LAYER_IDS = [
   "satImagery",
   "bathymetry",
   "topography",
+  "terrain3d",
   "fungalAtlasECM",
 ] as const
 


### PR DESCRIPTION
## Summary
- Run SGP4 satellite propagation on tablet/phone (was desktop-only)
- Enable terrain3d in Earth Sim boot profile
- Shorter satellite stagger on tablet (4s vs 18s for heavy overlays)
- Lower tablet terrain pitch/zoom thresholds + relaxed FPS floor

## Test plan
- [ ] Desktop Earth Sim: satellites + terrain unchanged
- [ ] iPad: wait ~5s after load, tilt globe — satellites + relief visible
- [ ] iPad pan still smooth (no freeze regression)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Enable live satellite propagation and 3D terrain in Earth Simulator on tablet and phone while tuning performance safeguards for mobile devices.

New Features:
- Run SGP4-based satellite propagation on tablet and phone with a shorter post-load stagger so live satellites appear quickly.
- Enable the terrain3d base layer in the Earth Simulator boot profile to show elevation relief by default.

Enhancements:
- Adjust satellite render caps and boot-time satellite filters to account for SGP4 running on all device classes while keeping orbit rings desktop-only.
- Introduce a separate readiness gate for satellite propagation distinct from heavy overlay loading to better control startup sequencing.
- Relax terrain activation thresholds, pitch requirements, and FPS recovery margins on tablet-like devices to make 3D terrain easier to access without compromising smoothness.