### PR TITLE
fix(devices): AutoplayVideo crash on iPad/touch

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -25,6 +25,7 @@
 # Jun 20, 2026 (r8): tablet Earth Sim pan freeze + poster-first home video —
 # CREPDashboardClient + home-command-page changes must invalidate npm run build.
 # Jun 20, 2026 (r9): iPad Earth Sim — SGP4 satellites + terrain3d boot + tablet terrain thresholds.
+# Jun 21, 2026 (r10): fix AutoplayVideo pointerClass TDZ crash on touch (device pages blank on iPad).
 
 FROM node:20-bookworm-slim AS base
 # SECURITY: no default — NEXTAUTH_SECRET must be supplied at build/runtime (docker-compose

--- a/components/ui/autoplay-video.tsx
+++ b/components/ui/autoplay-video.tsx
@@ -530,6 +530,7 @@ export function AutoplayVideo({
   }, [activeSrc, stallTimeoutMs, hideUntilPlaying, shouldLoad, youtubeFallbackId, usingYoutubeFallback, fallbackAfterFreezeMs, pauseWhenOutsideViewport, smoothLoop, disableProgressWatch, effectiveSmoothLoop])
 
   if (!activeSrc) return null
+  const pointerClass = pointerEventsNone ? "pointer-events-none" : ""
   const touchPosterOnly =
     typeof navigator !== "undefined" && (navigator.maxTouchPoints ?? 0) > 1
   const derivedPoster = sidecarPosterForVideo(activeSrc)
@@ -578,7 +579,6 @@ export function AutoplayVideo({
       : hideUntilPlaying
         ? "opacity-100 transition-opacity duration-500"
         : ""
-  const pointerClass = pointerEventsNone ? "pointer-events-none" : ""
   const showYoutubeFallback = Boolean(youtubeFallbackId && usingYoutubeFallback)
   const hidePrimaryForYoutube = showYoutubeFallback && youtubeFallbackReady
   const videoStyle = hidePrimaryForYoutube ? { ...style, opacity: 0 } : style


### PR DESCRIPTION
## Root cause
PR #225 touchPosterOnly early-return used \pointerClass\ before it was defined → ReferenceError on any touch device when a video poster exists.

Device pages (and home) use AutoplayVideo heavily → blank/crash on iPad.

## Fix
Define \pointerClass\ before the touchPosterOnly branch.

## Test
- iPad /devices and /devices/mushroom-1 load
- Desktop unchanged

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Resolve ReferenceError on touch devices when rendering videos with posters in AutoplayVideo.