### PR TITLE
fix: hero videos on phone and tablet (remove touchPosterOnly)

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -26,6 +26,7 @@
 # CREPDashboardClient + home-command-page changes must invalidate npm run build.
 # Jun 20, 2026 (r9): iPad Earth Sim — SGP4 satellites + terrain3d boot + tablet terrain thresholds.
 # Jun 21, 2026 (r10): fix AutoplayVideo pointerClass TDZ crash on touch (device pages blank on iPad).
+# Jun 21, 2026 (r11): remove touchPosterOnly — hero/tile videos must play on phone and tablet.
 
 FROM node:20-bookworm-slim AS base
 # SECURITY: no default — NEXTAUTH_SECRET must be supplied at build/runtime (docker-compose

--- a/components/ui/autoplay-video.tsx
+++ b/components/ui/autoplay-video.tsx
@@ -531,8 +531,6 @@ export function AutoplayVideo({
 
   if (!activeSrc) return null
   const pointerClass = pointerEventsNone ? "pointer-events-none" : ""
-  const touchPosterOnly =
-    typeof navigator !== "undefined" && (navigator.maxTouchPoints ?? 0) > 1
   const derivedPoster = sidecarPosterForVideo(activeSrc)
   const rawPoster = typeof poster === "string" && poster ? poster : derivedPoster
   const posterAttr =
@@ -541,21 +539,6 @@ export function AutoplayVideo({
         ? encodeAssetUrl(rawPoster)
         : rawPoster
       : undefined
-
-  if (touchPosterOnly && posterAttr) {
-    return (
-      <div
-        aria-hidden="true"
-        className={[className, pointerClass].filter(Boolean).join(" ")}
-        style={{
-          ...style,
-          backgroundImage: `url("${posterAttr}")`,
-          backgroundSize: style?.backgroundSize || "cover",
-          backgroundPosition: style?.backgroundPosition || "center",
-        }}
-      />
-    )
-  }
 
   if (hideUntilPlaying && allFailed) {
     if (!posterAttr) return null

--- a/lib/client-motion.ts
+++ b/lib/client-motion.ts
@@ -30,9 +30,9 @@ export function shouldUseLightweightVisuals() {
   return prefersReducedVisualMotion() || isCoarsePointerDevice()
 }
 
-/** Poster-only video on tablet/iPad — avoids multiple simultaneous decoders. */
+/** Poster-only when user prefers reduced motion — never tablet/phone-only. */
 export function shouldUsePosterOnlyVideo() {
-  return shouldUseLightweightVisuals() && isTabletLikeDevice()
+  return prefersReducedVisualMotion()
 }
 
 export function useTabletLikeDevice() {
@@ -43,11 +43,11 @@ export function useTabletLikeDevice() {
   return tabletLike
 }
 
-/** Poster/static until desktop confirmed — avoids iPad hydration flash loading 10+ decoders. */
+/** Allow hero/tile video on all devices; only block when user prefers reduced motion. */
 export function useAllowRichHomeMedia() {
-  const [allow, setAllow] = useState(false)
+  const [allow, setAllow] = useState(true)
   useEffect(() => {
-    setAllow(!prefersReducedVisualMotion() && !isTabletLikeDevice())
+    setAllow(!prefersReducedVisualMotion())
   }, [])
   return allow
 }


### PR DESCRIPTION
## Summary
- Remove touchPosterOnly from AutoplayVideo so device page heroes render live video on touch devices.
- useAllowRichHomeMedia now allows video on all devices except prefers-reduced-motion.
- Home tile squares use AutoplayVideo on tablet/phone again.

## Test plan
- [ ] /devices/mushroom-1 hero plays on iPhone/iPad
- [ ] Home tile squares show live video on tablet
- [ ] Desktop unchanged

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Allow hero and tile videos to autoplay on touch devices while honoring reduced-motion preferences.

Bug Fixes:
- Restore live hero and tile video playback on phones and tablets where it was previously limited to posters only.

Enhancements:
- Simplify autoplay video behavior by removing touch-only poster rendering and basing poster-only mode solely on reduced-motion settings.