### PR TITLE
fix(earth-sim): restore live MINDEX fungal observations (X-Internal-Token + guild filter)

### DIFF
--- a/app/api/crep/fungal-atlas/samples/route.ts
+++ b/app/api/crep/fungal-atlas/samples/route.ts
@@ -30,14 +30,33 @@ function parseBounds(params: URLSearchParams): FungalAtlasBounds | undefined {
   return undefined
 }
 
-async function fetchMindexOverlaySamples(bounds: FungalAtlasBounds | undefined, limit: number) {
+async function fetchMindexOverlaySamples(
+  bounds: FungalAtlasBounds | undefined,
+  limit: number,
+  guild?: string,
+) {
+  // MINDEX fungal-overlays require X-Internal-Token (not the customer X-API-Key).
+  // Mirrors the cells route; without this the MINDEX-first path 401s and silently
+  // falls back to the legacy local atlas, so live observations never load.
+  const internalTokenRaw =
+    process.env.MINDEX_INTERNAL_TOKEN ||
+    process.env.MINDEX_INTERNAL_TOKENS ||
+    ""
+  const internalToken = internalTokenRaw.includes(",")
+    ? internalTokenRaw.split(",")[0]?.trim()
+    : internalTokenRaw.trim()
   const params = new URLSearchParams({ limit: String(limit) })
   if (bounds) {
     params.set("bbox", `${bounds.west},${bounds.south},${bounds.east},${bounds.north}`)
   }
+  // Real functional_guild filter (migration 029) — no client-side name-string hacks.
+  if (guild) {
+    params.set("guild", guild)
+  }
   const response = await fetch(`${MINDEX_API}/api/mindex/fungal-overlays/samples?${params.toString()}`, {
     headers: {
       Accept: "application/json",
+      ...(internalToken ? { "X-Internal-Token": internalToken } : {}),
       "X-API-Key": process.env.MINDEX_API_KEY || "",
     },
     signal: AbortSignal.timeout(5000),
@@ -73,6 +92,13 @@ export async function GET(request: NextRequest) {
     .map((s) => s.trim() as FungalSampleGroup)
     .filter((g) => VALID_GROUPS.has(g))
 
+  // Optional ECM/AM/etc. guild filter — forwarded to MINDEX functional_guild.
+  // Only known guilds are forwarded; absent/unknown → all samples (current behavior).
+  const guildRaw = (params.get("guild") || "").trim().toLowerCase()
+  const guild = ["ecm", "am", "saprotroph", "pathogen", "lichen"].includes(guildRaw)
+    ? guildRaw
+    : undefined
+
   if (groupsParam && groups.length === 0) {
     return NextResponse.json({
       type: "FeatureCollection",
@@ -82,7 +108,7 @@ export async function GET(request: NextRequest) {
     })
   }
 
-  const mindexSamplesRaw = await fetchMindexOverlaySamples(bounds, limit || 4000).catch(() => null)
+  const mindexSamplesRaw = await fetchMindexOverlaySamples(bounds, limit || 4000, guild).catch(() => null)
   const mindexSamples = mindexSamplesRaw
     ? groups.length
       ? mindexSamplesRaw.filter((sample) => groups.includes(sample.group as FungalSampleGroup))


### PR DESCRIPTION
## What

The website's fungal **samples** route (`app/api/crep/fungal-atlas/samples/route.ts`) was sending the customer `X-API-Key` to MINDEX. MINDEX's `fungal-overlays` endpoints now require `X-Internal-Token`, so every MINDEX-first request 401'd and the route silently fell back to the **stale local atlas** — Earth Simulator was rendering snapshot data instead of live iNaturalist observations.

## Fix (additive, single file)

- Send `X-Internal-Token` (mirrors the already-correct `cells` route) so live observations load
- Thread the real `?guild=ecm|am` filter through to MINDEX `functional_guild` (migration 029) — no client-side name-string guild hacks

## Verified — dev (clean) → build → browser

- **Dev:** `samples` → `sourceDir: mindex`, `source: inat` (live obs restored, was stale atlas); `guild=ecm` → honest empty set (0 rows) until guild ETL backfills; broken MINDEX `cells` 500 still degrades gracefully to legacy (site unharmed)
- **Build:** `next build` → *Compiled successfully in 3.8min*, route present in production route table
- **Browser:** Earth Sim page mounts clean (no 4xx/5xx), page-context fetch returns live MINDEX data

## Not included (backend — handed to Cursor)

Wildfire / guild / air-quality layers remain blocked on MINDEX-189 **serving** fixes: `cells`/`deployment` 500, missing internal-token wildfire route (1530 FIRMS rows unreachable), `/weather` column mismatch, and the guild + air ETL. This PR is the website half and degrades gracefully until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore live MINDEX-backed fungal samples and support functional guild filtering in the fungal atlas samples API route.

New Features:
- Add support for forwarding a validated fungal guild filter from the samples API route to MINDEX fungal-overlays.

Bug Fixes:
- Send the correct X-Internal-Token header to MINDEX fungal-overlays so fungal samples requests use live observations instead of falling back to the legacy local atlas.

Enhancements:
- Normalize handling of MINDEX internal tokens to support comma-separated configurations while preserving existing behavior.